### PR TITLE
Collapse TaskRunner into a deep run() module

### DIFF
--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -17,7 +17,7 @@ from caliper.reporter import (
     save_results,
     update_progress,
 )
-from caliper.runner import TaskRunner
+from caliper.runner import run, AttemptEvent
 from caliper.schema.spec import load_spec, spec_name
 
 console = Console()
@@ -59,12 +59,12 @@ def run_cmd(
     attempt_counts: dict[str, int] = {t.name: 0 for t in spec.tasks}
     pass_counts: dict[str, int] = {t.name: 0 for t in spec.tasks}
 
-    def on_attempt_done(task_id: str, attempt: int, passed: bool, cheated: bool) -> None:
-        task = next((t for t in spec.tasks if t.id == task_id), None)
+    def on_attempt_done(event: AttemptEvent) -> None:
+        task = next((t for t in spec.tasks if t.id == event.task_id), None)
         if task is None:
             return
         attempt_counts[task.name] += 1
-        if passed:
+        if event.passed:
             pass_counts[task.name] += 1
         update_progress(
             progress,
@@ -73,25 +73,22 @@ def run_cmd(
             k,
             attempt_counts[task.name],
             pass_counts[task.name],
-            cheated=cheated,
+            cheated=event.cheated,
         )
-
-    runner = TaskRunner(
-        harness=harness,
-        judge=judge,
-        spec=spec,
-        spec_path=spec_file,
-        k=k,
-        workers=workers,
-        timeout=timeout,
-        baseline=baseline,
-        judge_strategy=judge_strategy,
-        on_attempt_done=on_attempt_done,
-    )
 
     with progress:
         try:
-            results = runner.run()
+            results = run(
+                spec=spec,
+                spec_path=spec_file,
+                harness=harness,
+                judge=judge,
+                k=k,
+                workers=workers,
+                timeout=timeout,
+                baseline=baseline,
+                on_attempt_done=on_attempt_done,
+            )
         except HarnessConfigurationError as exc:
             console.print(
                 Panel(

--- a/caliper/judge/autorater.py
+++ b/caliper/judge/autorater.py
@@ -46,6 +46,8 @@ def _format_transcript(turns: list[ConversationTurn]) -> str:
 
 
 class AutoraterJudge(Judge):
+    strategy = "autorater"
+
     def __init__(self, config: JudgeConfig) -> None:
         self._config = config
         self._client = anthropic.Anthropic()

--- a/caliper/judge/base.py
+++ b/caliper/judge/base.py
@@ -18,6 +18,8 @@ class JudgeResult:
 
 
 class Judge(ABC):
+    strategy: str = "autorater"
+
     @abstractmethod
     def evaluate(
         self,

--- a/caliper/judge/claude_code_judge.py
+++ b/caliper/judge/claude_code_judge.py
@@ -13,6 +13,8 @@ from caliper.schema.spec import JudgeConfig, TaskSpec
 class ClaudeCodeJudge(Judge):
     """Judge that uses the `claude` CLI instead of the Anthropic SDK directly."""
 
+    strategy = "claude-code"
+
     def __init__(self, config: JudgeConfig) -> None:
         self._config = config
 

--- a/caliper/judge/codex_judge.py
+++ b/caliper/judge/codex_judge.py
@@ -18,6 +18,8 @@ CODEX_APP_CLI = Path("/Applications/Codex.app/Contents/Resources/codex")
 class CodexJudge(Judge):
     """Judge that uses `codex exec` instead of a provider SDK directly."""
 
+    strategy = "autorater"
+
     def __init__(self, config: JudgeConfig) -> None:
         self._config = config
 

--- a/caliper/judge/openai_api_judge.py
+++ b/caliper/judge/openai_api_judge.py
@@ -11,6 +11,8 @@ from caliper.schema.spec import JudgeConfig, TaskSpec
 class OpenAIAPIJudge(Judge):
     """Judge that uses the OpenAI API explicitly."""
 
+    strategy = "autorater"
+
     def __init__(self, config: JudgeConfig) -> None:
         self._config = config
 

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -97,6 +97,8 @@ class ScriptAssertJudge(Judge):
     write a Python assertion script.
     """
 
+    strategy = "script"
+
     def __init__(self, config: JudgeConfig) -> None:
         self._config = config
         self._client = None

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
@@ -26,7 +27,227 @@ from caliper.schema.spec import EvalSpec, TaskSpec, spec_name
 from caliper.scoring import aggregate_scores, compute_delta, pass_at_k
 
 
-class CheatDetector:
+@dataclass
+class AttemptEvent:
+    task_id: str
+    attempt: int
+    passed: bool
+    cheated: bool
+
+
+def run(
+    spec: EvalSpec,
+    spec_path: Path,
+    harness: HarnessBackend,
+    judge: Judge,
+    k: int = 3,
+    workers: int = 4,
+    timeout: int = 120,
+    baseline: bool = False,
+    on_attempt_done: Callable[[AttemptEvent], None] | None = None,
+) -> RunResults:
+    skill_snapshot = _SkillSnapshotter().snapshot(_resolve_skill_path(spec, spec_path))
+
+    auto_forbidden = [
+        re.escape(str(spec_path.resolve())),
+        re.escape(str((spec_path.parent / ".caliper").resolve())),
+    ]
+    cheat = _CheatDetector(list(spec.sandbox.forbidden_files) + auto_forbidden)
+
+    task_results_with: list[TaskResult] = []
+    task_results_without: list[TaskResult] = []
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures_with = {
+            pool.submit(
+                _run_task, task, harness, judge, cheat, spec, spec_path,
+                k, timeout, True, on_attempt_done,
+            ): task
+            for task in spec.tasks
+        }
+        futures_without = (
+            {
+                pool.submit(
+                    _run_task, task, harness, judge, cheat, spec, spec_path,
+                    k, timeout, False, on_attempt_done,
+                ): task
+                for task in spec.tasks
+            }
+            if baseline
+            else {}
+        )
+
+        for fut in as_completed(list(futures_with) + list(futures_without)):
+            result = fut.result()
+            if fut in futures_with:
+                task_results_with.append(result)
+            else:
+                task_results_without.append(result)
+
+    task_results_with.sort(key=lambda r: r.task_id)
+    task_results_without.sort(key=lambda r: r.task_id)
+
+    pass_counts_with = {
+        r.task_id: (r.task_name, r.successes, k) for r in task_results_with
+    }
+    agg_with = aggregate_scores(pass_counts_with)
+
+    agg_without: AggregateScore | None = None
+    delta: DeltaReport | None = None
+    if baseline and task_results_without:
+        pass_counts_without = {
+            r.task_id: (r.task_name, r.successes, k) for r in task_results_without
+        }
+        agg_without = aggregate_scores(pass_counts_without)
+        delta = compute_delta(agg_with, agg_without)
+
+    return RunResults(
+        run=RunMeta(
+            spec=spec_name(spec_path),
+            timestamp=datetime.now(tz=timezone.utc),
+            k=k,
+            judge_strategy=judge.strategy,
+            backend=spec.skill.backend,
+            model=spec.skill.model,
+        ),
+        skill_snapshot=skill_snapshot,
+        task_results=task_results_with,
+        aggregate=agg_with,
+        baseline=agg_without,
+        delta=delta,
+    )
+
+
+def _run_task(
+    task: TaskSpec,
+    harness: HarnessBackend,
+    judge: Judge,
+    cheat: _CheatDetector,
+    spec: EvalSpec,
+    spec_path: Path,
+    k: int,
+    timeout: int,
+    with_skill: bool,
+    on_attempt_done: Callable[[AttemptEvent], None] | None,
+) -> TaskResult:
+    attempts: list[AttemptRecord] = []
+    for attempt_num in range(1, k + 1):
+        record = _run_attempt(
+            task, attempt_num, harness, judge, cheat,
+            spec, spec_path, timeout, with_skill, on_attempt_done,
+        )
+        attempts.append(record)
+
+    successes = sum(1 for a in attempts if a.passed)
+    return TaskResult(
+        task_id=task.id,
+        task_name=task.name,
+        attempts=attempts,
+        successes=successes,
+        pass_at_k=pass_at_k(successes, k),
+    )
+
+
+def _run_attempt(
+    task: TaskSpec,
+    attempt: int,
+    harness: HarnessBackend,
+    judge: Judge,
+    cheat: _CheatDetector,
+    spec: EvalSpec,
+    spec_path: Path,
+    timeout: int,
+    with_skill: bool,
+    on_attempt_done: Callable[[AttemptEvent], None] | None,
+) -> AttemptRecord:
+    tmp_dir = tempfile.mkdtemp(prefix="caliper-")
+    try:
+        _run_shell(task.setup)
+        resolved_extra_path = [
+            str((spec_path.parent / p).resolve())
+            for p in spec.sandbox.extra_path
+        ]
+        skill_path = _resolve_skill_path(spec, spec_path) if with_skill else None
+        attempt_result = harness.run(
+            task_id=task.id,
+            attempt=attempt,
+            prompt=task.prompt,
+            skill_path=skill_path,
+            model=spec.skill.model,
+            timeout=timeout,
+            isolated_home=tmp_dir,
+            extra_path=resolved_extra_path,
+        )
+
+        if attempt_result.exit_code != 0:
+            error = attempt_result.error or f"harness exited {attempt_result.exit_code}"
+            if on_attempt_done:
+                on_attempt_done(AttemptEvent(task_id=task.id, attempt=attempt, passed=False, cheated=False))
+            return AttemptRecord(
+                attempt=attempt,
+                output=attempt_result.final_output,
+                duration_seconds=attempt_result.duration_seconds,
+                passed=False,
+                cheated=False,
+                assert_passed=False,
+                assert_evidence=error,
+            )
+
+        cheat_violations = cheat.check(attempt_result.transcript)
+        if cheat_violations:
+            if on_attempt_done:
+                on_attempt_done(AttemptEvent(task_id=task.id, attempt=attempt, passed=False, cheated=True))
+            return AttemptRecord(
+                attempt=attempt,
+                output=attempt_result.final_output,
+                duration_seconds=attempt_result.duration_seconds,
+                passed=False,
+                cheated=True,
+                cheat_evidence=cheat_violations,
+            )
+
+        judge_result = judge.evaluate(
+            task=task,
+            transcript=attempt_result.transcript,
+            final_output=attempt_result.final_output,
+            spec_dir=str(spec_path.parent),
+        )
+
+        passed = judge_result.passed
+        if on_attempt_done:
+            on_attempt_done(AttemptEvent(task_id=task.id, attempt=attempt, passed=passed, cheated=False))
+
+        return AttemptRecord(
+            attempt=attempt,
+            output=attempt_result.final_output,
+            duration_seconds=attempt_result.duration_seconds,
+            passed=passed,
+            cheated=False,
+            assert_passed=judge_result.assert_passed,
+            assert_evidence=judge_result.assert_evidence,
+            autorater_passed=judge_result.autorater_passed,
+            autorater_reasoning=judge_result.autorater_reasoning,
+        )
+    finally:
+        _run_shell(task.cleanup)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _run_shell(cmd: str | None) -> None:
+    if cmd:
+        subprocess.run(cmd, shell=True, check=False)
+
+
+def _resolve_skill_path(spec: EvalSpec, spec_path: Path) -> str | None:
+    if not spec.skill.path:
+        return None
+    path = Path(spec.skill.path).expanduser()
+    if not path.is_absolute():
+        path = spec_path.parent / path
+    return str(path.resolve())
+
+
+class _CheatDetector:
     def __init__(self, patterns: list[str]) -> None:
         self._compiled = [re.compile(p) for p in patterns]
 
@@ -57,7 +278,7 @@ class CheatDetector:
         return []
 
 
-class SkillSnapshotter:
+class _SkillSnapshotter:
     _REF_PATTERN = re.compile(r'[./~][^\s"\'<>]+\.(sh|py|md|js|ts)')
 
     def snapshot(self, skill_path: str | None) -> SkillSnapshot:
@@ -113,196 +334,3 @@ class SkillSnapshotter:
             return repo, sha
         except (subprocess.CalledProcessError, FileNotFoundError):
             return None, None
-
-
-class TaskRunner:
-    def __init__(
-        self,
-        harness: HarnessBackend,
-        judge: Judge,
-        spec: EvalSpec,
-        spec_path: Path,
-        k: int = 3,
-        workers: int = 4,
-        timeout: int = 120,
-        baseline: bool = False,
-        judge_strategy: str = "autorater",
-        on_attempt_done: Callable[[str, int, bool, bool], None] | None = None,
-    ) -> None:
-        self._harness = harness
-        self._judge = judge
-        self._spec = spec
-        self._spec_path = spec_path
-        self._k = k
-        self._workers = workers
-        self._timeout = timeout
-        self._baseline = baseline
-        self._judge_strategy = judge_strategy
-        self._on_attempt_done = on_attempt_done
-
-        auto_forbidden = [
-            re.escape(str(spec_path.resolve())),
-            re.escape(str((spec_path.parent / ".caliper").resolve())),
-        ]
-        all_patterns = list(spec.sandbox.forbidden_files) + auto_forbidden
-        self._cheat = CheatDetector(all_patterns)
-        self._snapshotter = SkillSnapshotter()
-
-    def run(self) -> RunResults:
-        spec = self._spec
-        skill_snapshot = self._snapshotter.snapshot(self._resolve_skill_path())
-
-        task_results_with: list[TaskResult] = []
-        task_results_without: list[TaskResult] = []
-
-        with ThreadPoolExecutor(max_workers=self._workers) as pool:
-            futures_with = {
-                pool.submit(self._run_task, task, with_skill=True): task
-                for task in spec.tasks
-            }
-            futures_without = {}
-            if self._baseline:
-                futures_without = {
-                    pool.submit(self._run_task, task, with_skill=False): task
-                    for task in spec.tasks
-                }
-
-            for fut in as_completed(list(futures_with) + list(futures_without)):
-                result = fut.result()
-                if fut in futures_with:
-                    task_results_with.append(result)
-                else:
-                    task_results_without.append(result)
-
-        task_results_with.sort(key=lambda r: r.task_id)
-        task_results_without.sort(key=lambda r: r.task_id)
-
-        pass_counts_with = {
-            r.task_id: (r.task_name, r.successes, self._k) for r in task_results_with
-        }
-        agg_with = aggregate_scores(pass_counts_with)
-
-        agg_without: AggregateScore | None = None
-        delta: DeltaReport | None = None
-        if self._baseline and task_results_without:
-            pass_counts_without = {
-                r.task_id: (r.task_name, r.successes, self._k) for r in task_results_without
-            }
-            agg_without = aggregate_scores(pass_counts_without)
-            delta = compute_delta(agg_with, agg_without)
-
-        return RunResults(
-            run=RunMeta(
-                spec=spec_name(self._spec_path),
-                timestamp=datetime.now(tz=timezone.utc),
-                k=self._k,
-                judge_strategy=self._judge_strategy,
-                backend=spec.skill.backend,
-                model=spec.skill.model,
-            ),
-            skill_snapshot=skill_snapshot,
-            task_results=task_results_with,
-            aggregate=agg_with,
-            baseline=agg_without,
-            delta=delta,
-        )
-
-    def _run_task(self, task: TaskSpec, *, with_skill: bool) -> TaskResult:
-        attempts: list[AttemptRecord] = []
-        for attempt_num in range(1, self._k + 1):
-            record = self._run_attempt(task, attempt_num, with_skill=with_skill)
-            attempts.append(record)
-
-        successes = sum(1 for a in attempts if a.passed)
-        return TaskResult(
-            task_id=task.id,
-            task_name=task.name,
-            attempts=attempts,
-            successes=successes,
-            pass_at_k=pass_at_k(successes, self._k),
-        )
-
-    def _run_attempt(self, task: TaskSpec, attempt: int, *, with_skill: bool) -> AttemptRecord:
-        tmp_dir = tempfile.mkdtemp(prefix="caliper-")
-        try:
-            self._run_shell(task.setup)
-            resolved_extra_path = [
-                str((self._spec_path.parent / p).resolve())
-                for p in self._spec.sandbox.extra_path
-            ]
-            skill_path = self._resolve_skill_path() if with_skill else None
-            attempt_result = self._harness.run(
-                task_id=task.id,
-                attempt=attempt,
-                prompt=task.prompt,
-                skill_path=skill_path,
-                model=self._spec.skill.model,
-                timeout=self._timeout,
-                isolated_home=tmp_dir,
-                extra_path=resolved_extra_path,
-            )
-
-            if attempt_result.exit_code != 0:
-                error = attempt_result.error or f"harness exited {attempt_result.exit_code}"
-                if self._on_attempt_done:
-                    self._on_attempt_done(task.id, attempt, False, False)
-                return AttemptRecord(
-                    attempt=attempt,
-                    output=attempt_result.final_output,
-                    duration_seconds=attempt_result.duration_seconds,
-                    passed=False,
-                    cheated=False,
-                    assert_passed=False,
-                    assert_evidence=error,
-                )
-
-            cheat_violations = self._cheat.check(attempt_result.transcript)
-            if cheat_violations:
-                if self._on_attempt_done:
-                    self._on_attempt_done(task.id, attempt, False, True)
-                return AttemptRecord(
-                    attempt=attempt,
-                    output=attempt_result.final_output,
-                    duration_seconds=attempt_result.duration_seconds,
-                    passed=False,
-                    cheated=True,
-                    cheat_evidence=cheat_violations,
-                )
-
-            judge_result = self._judge.evaluate(
-                task=task,
-                transcript=attempt_result.transcript,
-                final_output=attempt_result.final_output,
-                spec_dir=str(self._spec_path.parent),
-            )
-
-            passed = judge_result.passed
-            if self._on_attempt_done:
-                self._on_attempt_done(task.id, attempt, passed, False)
-
-            return AttemptRecord(
-                attempt=attempt,
-                output=attempt_result.final_output,
-                duration_seconds=attempt_result.duration_seconds,
-                passed=passed,
-                cheated=False,
-                assert_passed=judge_result.assert_passed,
-                assert_evidence=judge_result.assert_evidence,
-                autorater_passed=judge_result.autorater_passed,
-                autorater_reasoning=judge_result.autorater_reasoning,
-            )
-        finally:
-            self._run_shell(task.cleanup)
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-
-    def _run_shell(self, cmd: str | None) -> None:
-        if cmd:
-            subprocess.run(cmd, shell=True, check=False)
-
-    def _resolve_skill_path(self) -> str | None:
-        if not self._spec.skill.path:
-            return None
-        path = Path(self._spec.skill.path).expanduser()
-        if not path.is_absolute():
-            path = self._spec_path.parent / path
-        return str(path.resolve())

--- a/evals/smoke/claude-code-smoke.eval.yaml
+++ b/evals/smoke/claude-code-smoke.eval.yaml
@@ -1,0 +1,18 @@
+skill:
+  backend: claude-code
+  model: claude-haiku-4-5-20251001
+
+judge:
+  backend: claude-api
+  model: claude-haiku-4-5-20251001
+
+tasks:
+  - name: Write hello to a file
+    setup: rm -f /tmp/caliper-e2e-smoke.txt
+    cleanup: rm -f /tmp/caliper-e2e-smoke.txt
+    prompt: Write the text "hello" to /tmp/caliper-e2e-smoke.txt using the Bash tool.
+    assert: |
+      from pathlib import Path
+      p = Path("/tmp/caliper-e2e-smoke.txt")
+      assert p.exists(), "file was not created"
+      assert "hello" in p.read_text(), "file does not contain hello"

--- a/evals/smoke/codex-smoke.eval.yaml
+++ b/evals/smoke/codex-smoke.eval.yaml
@@ -1,0 +1,17 @@
+skill:
+  backend: codex
+
+judge:
+  backend: claude-api
+  model: claude-haiku-4-5-20251001
+
+tasks:
+  - name: Write hello to a file
+    setup: rm -f /tmp/caliper-e2e-smoke-codex.txt
+    cleanup: rm -f /tmp/caliper-e2e-smoke-codex.txt
+    prompt: Write the text "hello" to /tmp/caliper-e2e-smoke-codex.txt using a shell command.
+    assert: |
+      from pathlib import Path
+      p = Path("/tmp/caliper-e2e-smoke-codex.txt")
+      assert p.exists(), "file was not created"
+      assert "hello" in p.read_text(), "file does not contain hello"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from caliper.harness.base import AttemptResult, HarnessBackend
 from caliper.judge.base import Judge, JudgeResult
-from caliper.runner import TaskRunner
+from caliper.runner import run
 from caliper.schema.spec import EvalSpec, SkillConfig, TaskSpec
 
 
@@ -59,15 +59,15 @@ def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
         ],
     )
 
-    results = TaskRunner(
-        harness=FailingHarness(),
-        judge=judge,
+    results = run(
         spec=spec,
         spec_path=spec_path,
+        harness=FailingHarness(),
+        judge=judge,
         k=1,
         workers=1,
         timeout=30,
-    ).run()
+    )
 
     attempt = results.task_results[0].attempts[0]
     assert attempt.passed is False


### PR DESCRIPTION
## Summary

- **`TaskRunner` deleted** — replaced by a module-level `run(spec, spec_path, harness, judge, k, workers, timeout, baseline, on_attempt_done) → RunResults` function. `CheatDetector` and `SkillSnapshotter` are now private implementation details; callers see one clean interface.
- **`AttemptEvent` dataclass** — replaces the opaque `Callable[[str, int, bool, bool], None]` progress callback with a named struct (`task_id`, `attempt`, `passed`, `cheated`). Future fields (e.g. `duration`) can be added without breaking callers.
- **`Judge.strategy` class attribute** — each judge implementation declares its own strategy name so `RunMeta.judge_strategy` is derived from the injected judge rather than passed as a redundant parameter to the runner.
- **`evals/smoke/`** — two new E2E smoke evals (`claude-code-smoke.eval.yaml`, `codex-smoke.eval.yaml`) verified locally at 100% pass@1; run with `caliper run evals/smoke/claude-code-smoke.eval.yaml --k 1`.

## Test plan

- [ ] `pytest tests/` — all 32 tests pass
- [ ] `caliper run evals/smoke/claude-code-smoke.eval.yaml --k 1` — passes
- [ ] `caliper run evals/smoke/codex-smoke.eval.yaml --k 1` — passes (uses Codex default model; omit `model:` for ChatGPT accounts)