### PR TITLE
Add --model and --judge-model CLI flags with backend:model syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,32 @@ When both `expect` and `assert` are present, both must pass.
 | `--judge MODE` | `autorater` | `autorater` or `script` |
 | `--workers INT` | `4` | Parallel task workers |
 | `--timeout INT` | `120` | Seconds per attempt |
-| `--model MODEL` | — | Override `skill.model` |
+| `--model TARGET` | — | Override skill backend and/or model (see below) |
+| `--judge-model TARGET` | — | Override judge backend and/or model (see below) |
 | `--verbose` | off | Show per-attempt judge reasoning |
 | `--output PATH` | — | Also save results JSON to a specific path |
+
+#### `--model` and `--judge-model` syntax
+
+Both flags accept a `backend:model` compound value, a bare backend name, or a bare model name:
+
+```bash
+# Override backend and model together
+caliper run my-skill.eval.yaml --model claude-api:claude-sonnet-4-6
+
+# Override backend only (model stays unset / from spec)
+caliper run my-skill.eval.yaml --model codex
+
+# Override model only (backend stays from spec)
+caliper run my-skill.eval.yaml --model claude-sonnet-4-6
+
+# Override judge independently
+caliper run my-skill.eval.yaml --model claude-api:claude-sonnet-4-6 --judge-model claude-api:claude-haiku-4-5-20251001
+```
+
+Accepted backends: `claude-code`, `codex`, `claude-api`, `openai-api` (aliases: `claude`, `anthropic`, `openai`).
+
+The spec file is never modified — overrides apply only to the current run.
 
 ---
 

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -18,7 +18,7 @@ from caliper.reporter import (
     update_progress,
 )
 from caliper.runner import run, AttemptEvent
-from caliper.schema.spec import load_spec, spec_name
+from caliper.schema.spec import load_spec, parse_target, spec_name
 
 console = Console()
 
@@ -32,7 +32,8 @@ def run_cmd(
     judge_strategy: str = typer.Option("autorater", "--judge", help="Judge strategy: autorater | script"),
     output: Optional[Path] = typer.Option(None, "--output", help="Save results JSON to path"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show per-attempt reasoning"),
-    model: Optional[str] = typer.Option(None, "--model", "-m", help="Override the skill model (e.g. claude-sonnet-4-6)"),
+    model: Optional[str] = typer.Option(None, "--model", "-m", help="Override skill backend/model (e.g. claude-api:claude-sonnet-4-6 or claude-sonnet-4-6)"),
+    judge_model: Optional[str] = typer.Option(None, "--judge-model", help="Override judge backend/model (e.g. claude-api:claude-haiku-4-5-20251001)"),
 ) -> None:
     if not spec_file.exists():
         console.print(f"[bold red]Error:[/bold red] File not found: {spec_file}")
@@ -45,10 +46,21 @@ def run_cmd(
         raise typer.Exit(1)
 
     if model:
-        spec.skill.model = model
+        backend_override, model_override = parse_target(model)
+        if backend_override:
+            spec.skill.backend = backend_override
+        if model_override:
+            spec.skill.model = model_override
+
+    if judge_model:
+        j_backend, j_model = parse_target(judge_model)
+        if j_backend:
+            spec.judge.backend = j_backend
+        if j_model:
+            spec.judge.model = j_model
 
     name = spec_name(spec_file)
-    print_banner(name, k, spec.skill.backend)
+    print_banner(name, k, spec.skill.backend, spec.skill.model)
 
     harness = get_harness(spec.skill.backend, spec.skill.model)
     judge = get_judge(judge_strategy, spec.judge)

--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -38,10 +38,11 @@ _BAR_FULL = "█" if _UNICODE else "#"
 _BAR_EMPTY = "░" if _UNICODE else "-"
 
 
-def print_banner(spec_name: str, k: int, backend: str) -> None:
+def print_banner(spec_name: str, k: int, backend: str, model: str | None = None) -> None:
+    target = f"[cyan]{backend}[/cyan]" + (f" [dim]{_SEP} {model}[/dim]" if model else "")
     console.print(
         Panel(
-            f"{_BANNER}  {_SEP}  [bold]{spec_name}[/bold]  {_SEP}  k=[cyan]{k}[/cyan]  {_SEP}  [cyan]{backend}[/cyan]",
+            f"{_BANNER}  {_SEP}  [bold]{spec_name}[/bold]  {_SEP}  k=[cyan]{k}[/cyan]  {_SEP}  {target}",
             border_style="cyan",
             padding=(0, 2),
         )

--- a/caliper/schema/spec.py
+++ b/caliper/schema/spec.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 BackendName = Literal["claude-code", "codex", "claude-api", "openai-api"]
 
+_VALID_BACKENDS: frozenset[str] = frozenset({"claude-code", "codex", "claude-api", "openai-api"})
+
 
 def normalize_backend(value: str) -> str:
     aliases = {
@@ -16,6 +18,23 @@ def normalize_backend(value: str) -> str:
         "openai": "openai-api",
     }
     return aliases.get(value, value)
+
+
+def parse_target(value: str) -> tuple[str | None, str | None]:
+    """Parse a --model / --judge-model value into (backend, model).
+
+    Accepts three forms:
+      "claude-api:claude-sonnet-4-6"  -> ("claude-api", "claude-sonnet-4-6")
+      "codex"                         -> ("codex", None)   # known backend name
+      "claude-sonnet-4-6"             -> (None, "claude-sonnet-4-6")
+    """
+    if ":" in value:
+        backend, _, model = value.partition(":")
+        return normalize_backend(backend) or None, model or None
+    normalized = normalize_backend(value)
+    if normalized in _VALID_BACKENDS:
+        return normalized, None
+    return None, value
 
 
 class TaskSpec(BaseModel):

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -8,6 +8,13 @@ caliper run path/to/spec.eval.yaml --k 3
 caliper run path/to/spec.eval.yaml --k 3 --baseline      # include no-skill delta
 caliper run path/to/spec.eval.yaml --judge script        # LLM writes assertion scripts
 caliper run path/to/spec.eval.yaml --verbose             # show per-attempt reasoning
+
+# Override backend and/or model at run time (no spec edit needed)
+caliper run path/to/spec.eval.yaml --model claude-api:claude-sonnet-4-6
+caliper run path/to/spec.eval.yaml --model codex
+caliper run path/to/spec.eval.yaml --model claude-sonnet-4-6   # model only, keep spec backend
+caliper run path/to/spec.eval.yaml --judge-model claude-api:claude-haiku-4-5-20251001
+caliper run path/to/spec.eval.yaml --model claude-api:claude-sonnet-4-6 --judge-model claude-api:claude-haiku-4-5-20251001
 ```
 
 ### Create a new evaluation spec (interactive wizard)
@@ -102,6 +109,8 @@ judge:
 - **script judge** — LLM can write Python assertion scripts for verifiable facts
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
 - **isolation** — each attempt runs in a fresh temp HOME with no session history
+- **`--model TARGET`** — override skill backend/model at run time; accepts `backend:model`, bare backend (`codex`), or bare model name
+- **`--judge-model TARGET`** — same syntax, overrides the judge backend/model independently
 
 ## Results storage
 

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -15,6 +15,11 @@ caliper run path/to/spec.eval.yaml --k 3
 # Baseline run — before committing, proves the skill makes a difference
 caliper run path/to/spec.eval.yaml --k 3 --baseline
 
+# Run against a different backend or model without editing the spec
+caliper run path/to/spec.eval.yaml --model claude-api:claude-sonnet-4-6
+caliper run path/to/spec.eval.yaml --model codex
+caliper run path/to/spec.eval.yaml --judge-model claude-api:claude-haiku-4-5-20251001
+
 # Browse past results
 caliper list
 caliper report path/to/spec.eval.yaml

--- a/tests/test_parse_target.py
+++ b/tests/test_parse_target.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from caliper.schema.spec import parse_target
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # backend:model compound
+        ("claude-api:claude-sonnet-4-6", ("claude-api", "claude-sonnet-4-6")),
+        ("openai-api:gpt-4o", ("openai-api", "gpt-4o")),
+        # aliases normalised on the backend side
+        ("anthropic:claude-sonnet-4-6", ("claude-api", "claude-sonnet-4-6")),
+        ("claude:claude-sonnet-4-6", ("claude-code", "claude-sonnet-4-6")),
+        # backend only (known name, no colon)
+        ("codex", ("codex", None)),
+        ("claude-code", ("claude-code", None)),
+        ("claude-api", ("claude-api", None)),
+        ("openai-api", ("openai-api", None)),
+        # alias as backend-only
+        ("anthropic", ("claude-api", None)),
+        # plain model name (not a known backend)
+        ("claude-sonnet-4-6", (None, "claude-sonnet-4-6")),
+        ("gpt-4o", (None, "gpt-4o")),
+        # colon with no model → backend only
+        ("codex:", ("codex", None)),
+        # colon with no backend → model only
+        (":claude-sonnet-4-6", (None, "claude-sonnet-4-6")),
+        # multiple colons → only first split
+        ("claude-api:some:model", ("claude-api", "some:model")),
+    ],
+)
+def test_parse_target(value: str, expected: tuple[str | None, str | None]) -> None:
+    assert parse_target(value) == expected


### PR DESCRIPTION
## Summary

- Adds `--model` flag (extended from model-only to `backend:model` compound syntax) to override the skill harness backend and/or model at run time
- Adds `--judge-model` flag with the same syntax to independently override the judge backend and/or model
- Introduces `parse_target()` in `spec.py` as the single parsing seam: splits on first `:`, detects bare backend names, falls back to plain model name
- Updates `print_banner` to show the effective model alongside the backend
- Updates README and skill REFERENCE.md files with examples and flag documentation
- 14 new parametrized tests for `parse_target`

Closes #4

## Test plan

- [ ] `pytest tests/test_parse_target.py` — 14 cases covering compound, backend-only, model-only, aliases, edge cases
- [ ] `pytest tests/test_runner.py tests/test_reporter.py tests/test_update_cli.py` — no regressions
- [ ] `caliper run <spec> --model claude-api:claude-sonnet-4-6` overrides both backend and model
- [ ] `caliper run <spec> --model codex` switches backend, leaves model unset
- [ ] `caliper run <spec> --model claude-sonnet-4-6` overrides model only, keeps spec backend
- [ ] `--judge-model` works independently from `--model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)