### PR TITLE
Unify judge: make EvalJudge the single judge, remove --judge flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Caliper — agent instructions
+
+## Updating docs after API changes
+
+When any of the following change, update all three locations before marking the task done:
+
+- A `caliper run` CLI flag is added, removed, or renamed
+- The `.eval.yaml` spec format changes (new fields, removed fields, renamed keys)
+- The judge behavior changes (how `expect:` or `assert:` are evaluated)
+- The results JSON schema changes (`RunMeta`, `AttemptRecord`, etc.)
+
+**Locations to update:**
+
+1. `README.md` — CLI reference table and any relevant prose sections
+2. `skills/evaluate-skill/REFERENCE.md` — the source skill reference
+3. `caliper/resources/evaluate_skill/REFERENCE.md` — the packaged copy (must match #2)
+
+After editing both REFERENCE.md files, run `python -m pytest tests/test_install_skill.py -q` to verify the packaged SKILL.md is still in sync with `skills/evaluate-skill/SKILL.md`. If it fails, copy the source over the packaged copy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# Caliper — agent instructions
+
+## Updating docs after API changes
+
+When any of the following change, update all three locations before marking the task done:
+
+- A `caliper run` CLI flag is added, removed, or renamed
+- The `.eval.yaml` spec format changes (new fields, removed fields, renamed keys)
+- The judge behavior changes (how `expect:` or `assert:` are evaluated)
+- The results JSON schema changes (`RunMeta`, `AttemptRecord`, etc.)
+
+**Locations to update:**
+
+1. `README.md` — CLI reference table and any relevant prose sections
+2. `skills/evaluate-skill/REFERENCE.md` — the source skill reference
+3. `caliper/resources/evaluate_skill/REFERENCE.md` — the packaged copy (must match #2)
+
+After editing both REFERENCE.md files, run `python -m pytest tests/test_install_skill.py -q` to verify the packaged SKILL.md is still in sync with `skills/evaluate-skill/SKILL.md`. If it fails, copy the source over the packaged copy.

--- a/README.md
+++ b/README.md
@@ -265,13 +265,6 @@ tasks:
 
 When both `expect` and `assert` are present, both must pass.
 
-### `--judge` flag
-
-| Flag | Behavior |
-|---|---|
-| `--judge autorater` (default) | LLM judge evaluates `expect` |
-| `--judge script` | Runs `assert:` always; also runs LLM judge if `expect` is present |
-
 ---
 
 ## CLI reference
@@ -292,7 +285,6 @@ When both `expect` and `assert` are present, both must pass.
 |---|---|---|
 | `--k INT` | `3` | Attempts per task |
 | `--baseline` | off | Also run each task without the skill |
-| `--judge MODE` | `autorater` | `autorater` or `script` |
 | `--workers INT` | `4` | Parallel task workers |
 | `--timeout INT` | `120` | Seconds per attempt |
 | `--model TARGET` | — | Override skill backend and/or model (see below) |

--- a/caliper/commands/list_cmd.py
+++ b/caliper/commands/list_cmd.py
@@ -74,7 +74,6 @@ def _list_runs(spec_dir: Path, spec_name: str) -> None:
     table.add_column("k", justify="right")
     table.add_column("Tasks", justify="right")
     table.add_column("pass@k", justify="right")
-    table.add_column("Judge")
     table.add_column("File", style="dim")
 
     for f in files:
@@ -84,11 +83,10 @@ def _list_runs(spec_dir: Path, spec_name: str) -> None:
             score = f"{results.aggregate.avg_pass_at_k * 100:.1f}%"
             k = str(results.run.k)
             n_tasks = str(len(results.task_results))
-            judge = results.run.judge_strategy
         except Exception:
             ts = f.stem
-            score = k = n_tasks = judge = "?"
+            score = k = n_tasks = "?"
 
-        table.add_row(ts, k, n_tasks, score, judge, f.name)
+        table.add_row(ts, k, n_tasks, score, f.name)
 
     console.print(table)

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -9,7 +9,7 @@ from rich.panel import Panel
 
 from caliper.harness.base import HarnessConfigurationError
 from caliper.harness import get_harness
-from caliper.judge import get_judge
+from caliper.judge import EvalJudge
 from caliper.reporter import (
     make_progress,
     print_banner,
@@ -29,7 +29,6 @@ def run_cmd(
     workers: int = typer.Option(4, "--workers", help="Parallel task workers"),
     timeout: int = typer.Option(120, "--timeout", help="Seconds per attempt"),
     baseline: bool = typer.Option(False, "--baseline", help="Also run without skill for delta"),
-    judge_strategy: str = typer.Option("autorater", "--judge", help="Judge strategy: autorater | script"),
     output: Optional[Path] = typer.Option(None, "--output", help="Save results JSON to path"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show per-attempt reasoning"),
     model: Optional[str] = typer.Option(None, "--model", "-m", help="Override skill backend/model (e.g. claude-api:claude-sonnet-4-6 or claude-sonnet-4-6)"),
@@ -63,7 +62,7 @@ def run_cmd(
     print_banner(name, k, spec.skill.backend, spec.skill.model)
 
     harness = get_harness(spec.skill.backend, spec.skill.model)
-    judge = get_judge(judge_strategy, spec.judge)
+    judge = EvalJudge(spec.judge)
 
     task_names = [t.name for t in spec.tasks]
     progress, task_ids = make_progress(task_names, k)

--- a/caliper/judge/__init__.py
+++ b/caliper/judge/__init__.py
@@ -1,42 +1,8 @@
-from caliper.judge.autorater import AutoraterJudge
 from caliper.judge.base import Judge, JudgeResult
-from caliper.judge.claude_code_judge import ClaudeCodeJudge
-from caliper.judge.codex_judge import CodexJudge
-from caliper.judge.openai_api_judge import OpenAIAPIJudge
-from caliper.schema.spec import normalize_backend
-
-
-def get_judge(strategy: str, config) -> Judge:
-    match strategy:
-        case "autorater" | "claude-code":
-            match normalize_backend(config.backend):
-                case "codex":
-                    return CodexJudge(config)
-                case "claude-code":
-                    return ClaudeCodeJudge(config)
-                case "claude-api":
-                    return AutoraterJudge(config)
-                case "openai-api":
-                    return OpenAIAPIJudge(config)
-                case _:
-                    raise ValueError(f"Unknown judge backend: {config.backend!r}")
-        case "autorater-sdk":
-            # Explicit opt-in to the SDK-based judge (requires ANTHROPIC_API_KEY).
-            return AutoraterJudge(config)
-        case "script":
-            from caliper.judge.script_assert import ScriptAssertJudge
-
-            return ScriptAssertJudge(config)
-        case _:
-            raise ValueError(f"Unknown judge strategy: {strategy!r}")
-
+from caliper.judge.script_assert import EvalJudge
 
 __all__ = [
     "Judge",
     "JudgeResult",
-    "AutoraterJudge",
-    "ClaudeCodeJudge",
-    "CodexJudge",
-    "OpenAIAPIJudge",
-    "get_judge",
+    "EvalJudge",
 ]

--- a/caliper/judge/autorater.py
+++ b/caliper/judge/autorater.py
@@ -1,99 +1,12 @@
 from __future__ import annotations
 
-import json
-
-import anthropic
-
 from caliper.harness.base import ConversationTurn
-from caliper.judge.base import Judge, JudgeResult
-from caliper.schema.spec import JudgeConfig, TaskSpec
-
-_SYSTEM = """\
-You are an evaluation judge for an AI assistant. You will be shown a conversation \
-transcript (including all tool calls and their results) produced by the AI, along with \
-an expectation that describes what a successful run looks like.
-
-Your job: decide whether the transcript satisfies the expectation.
-Respond with valid JSON only — no markdown fences, no extra text.
-Format: {"passed": true|false, "reasoning": "<one or two sentences>"}
-"""
-
-_USER_TMPL = """\
-<expectation>
-{expect}
-</expectation>
-
-<transcript>
-{transcript}
-</transcript>
-
-Does the transcript satisfy the expectation? Respond with JSON.
-"""
-
-
-def _format_transcript(turns: list[ConversationTurn]) -> str:
-    lines: list[str] = []
-    for t in turns:
-        if t.role == "assistant":
-            lines.append(f"[assistant] {t.content}")
-        elif t.role == "tool_use":
-            inp = json.dumps(t.tool_input, ensure_ascii=False) if t.tool_input else ""
-            lines.append(f"[tool_use: {t.tool_name}] {inp}")
-        elif t.role == "tool_result":
-            out = (t.tool_output or "")[:2000]
-            lines.append(f"[tool_result] {out}")
-    return "\n".join(lines) or "(empty transcript)"
-
-
-class AutoraterJudge(Judge):
-    strategy = "autorater"
-
-    def __init__(self, config: JudgeConfig) -> None:
-        self._config = config
-        self._client = anthropic.Anthropic()
-
-    def evaluate(
-        self,
-        task: TaskSpec,
-        transcript: list[ConversationTurn],
-        final_output: str,
-        spec_dir: str,
-    ) -> JudgeResult:
-        if not task.expect:
-            return JudgeResult(
-                passed=True,
-                reasoning="No expect defined; autorater skipped.",
-                autorater_passed=None,
-            )
-
-        user_msg = _USER_TMPL.format(
-            expect=task.expect,
-            transcript=_format_transcript(transcript),
-        )
-
-        model = self._config.model or "claude-haiku-4-5-20251001"
-        response = self._client.messages.create(
-            model=model,
-            max_tokens=512,
-            system=_SYSTEM,
-            messages=[{"role": "user", "content": user_msg}],
-        )
-
-        raw = response.content[0].text.strip()
-        try:
-            verdict = json.loads(raw)
-            passed = bool(verdict.get("passed", False))
-            reasoning = str(verdict.get("reasoning", ""))
-        except (json.JSONDecodeError, KeyError):
-            passed = False
-            reasoning = f"Judge returned unparseable response: {raw[:200]}"
-
-        return JudgeResult(
-            passed=passed,
-            reasoning=reasoning,
-            autorater_passed=passed,
-            autorater_reasoning=reasoning,
-        )
+from caliper.judge.script_assert import (
+    _SYSTEM,
+    _USER_TMPL,
+    _format_transcript,
+    _parse_rich_response,
+)
 
 
 def evaluate_with_claude_api(
@@ -101,8 +14,11 @@ def evaluate_with_claude_api(
     expect: str,
     transcript: list[ConversationTurn],
     model: str | None,
+    spec_dir: str,
     timeout: int = 60,
 ) -> tuple[bool, str]:
+    import anthropic
+
     user_msg = _USER_TMPL.format(
         expect=expect,
         transcript=_format_transcript(transcript),
@@ -112,7 +28,7 @@ def evaluate_with_claude_api(
         client = anthropic.Anthropic(timeout=timeout)
         response = client.messages.create(
             model=model or "claude-haiku-4-5-20251001",
-            max_tokens=512,
+            max_tokens=1024,
             system=_SYSTEM,
             messages=[{"role": "user", "content": user_msg}],
         )
@@ -120,12 +36,4 @@ def evaluate_with_claude_api(
     except Exception as exc:
         return False, f"claude-api judge failed: {exc}"
 
-    try:
-        verdict = json.loads(raw)
-        passed = bool(verdict.get("passed", False))
-        reasoning = str(verdict.get("reasoning", ""))
-    except (json.JSONDecodeError, KeyError):
-        passed = False
-        reasoning = f"Judge returned unparseable response: {raw[:200]}"
-
-    return passed, reasoning
+    return _parse_rich_response(raw, spec_dir)

--- a/caliper/judge/claude_code_judge.py
+++ b/caliper/judge/claude_code_judge.py
@@ -6,47 +6,12 @@ import subprocess
 
 from caliper.harness.base import ConversationTurn
 from caliper.harness.claude_code import preferred_nvm_node_bin
-from caliper.judge.base import Judge, JudgeResult
-from caliper.judge.autorater import _format_transcript, _SYSTEM, _USER_TMPL
-from caliper.schema.spec import JudgeConfig, TaskSpec
-
-
-class ClaudeCodeJudge(Judge):
-    """Judge that uses the `claude` CLI instead of the Anthropic SDK directly."""
-
-    strategy = "claude-code"
-
-    def __init__(self, config: JudgeConfig) -> None:
-        self._config = config
-
-    def evaluate(
-        self,
-        task: TaskSpec,
-        transcript: list[ConversationTurn],
-        final_output: str,
-        spec_dir: str,
-    ) -> JudgeResult:
-        if not task.expect:
-            return JudgeResult(
-                passed=True,
-                reasoning="No expect defined; autorater skipped.",
-                autorater_passed=None,
-            )
-
-        user_msg = _USER_TMPL.format(
-            expect=task.expect,
-            transcript=_format_transcript(transcript),
-        )
-        prompt = f"{_SYSTEM}\n\n{user_msg}"
-
-        passed, reasoning = evaluate_prompt_with_claude_code(prompt, self._config.model)
-
-        return JudgeResult(
-            passed=passed,
-            reasoning=reasoning,
-            autorater_passed=passed,
-            autorater_reasoning=reasoning,
-        )
+from caliper.judge.script_assert import (
+    _SYSTEM,
+    _USER_TMPL,
+    _format_transcript,
+    _parse_rich_response,
+)
 
 
 def evaluate_with_claude_code(
@@ -54,13 +19,17 @@ def evaluate_with_claude_code(
     expect: str,
     transcript: list[ConversationTurn],
     model: str | None,
+    spec_dir: str,
 ) -> tuple[bool, str]:
     user_msg = _USER_TMPL.format(
         expect=expect,
         transcript=_format_transcript(transcript),
     )
     prompt = f"{_SYSTEM}\n\n{user_msg}"
-    return evaluate_prompt_with_claude_code(prompt, model)
+    raw, error = _run_claude_code(prompt, model)
+    if error:
+        return False, error
+    return _parse_rich_response(raw, spec_dir)
 
 
 def _judge_env() -> dict[str, str]:
@@ -71,7 +40,7 @@ def _judge_env() -> dict[str, str]:
     return env
 
 
-def evaluate_prompt_with_claude_code(prompt: str, model: str | None) -> tuple[bool, str]:
+def _run_claude_code(prompt: str, model: str | None) -> tuple[str, str | None]:
     cmd = ["claude", "-p", prompt, "--output-format", "text"]
     if model:
         cmd += ["--model", model]
@@ -86,18 +55,10 @@ def evaluate_prompt_with_claude_code(prompt: str, model: str | None) -> tuple[bo
         )
         raw = proc.stdout.strip()
     except subprocess.TimeoutExpired:
-        return False, "Judge timed out."
+        return "", "Judge timed out."
 
     if raw.startswith("```"):
         lines = raw.splitlines()
         raw = "\n".join(line for line in lines if not line.startswith("```")).strip()
 
-    try:
-        verdict = json.loads(raw)
-        passed = bool(verdict.get("passed", False))
-        reasoning = str(verdict.get("reasoning", ""))
-    except (json.JSONDecodeError, KeyError):
-        passed = False
-        reasoning = f"Judge returned unparseable response: {raw[:200]}"
-
-    return passed, reasoning
+    return raw, None

--- a/caliper/judge/codex_judge.py
+++ b/caliper/judge/codex_judge.py
@@ -8,48 +8,14 @@ import tempfile
 from pathlib import Path
 
 from caliper.harness.base import ConversationTurn
-from caliper.judge.autorater import _format_transcript, _SYSTEM, _USER_TMPL
-from caliper.judge.base import Judge, JudgeResult
-from caliper.schema.spec import JudgeConfig, TaskSpec
+from caliper.judge.script_assert import (
+    _SYSTEM,
+    _USER_TMPL,
+    _format_transcript,
+    _parse_rich_response,
+)
 
 CODEX_APP_CLI = Path("/Applications/Codex.app/Contents/Resources/codex")
-
-
-class CodexJudge(Judge):
-    """Judge that uses `codex exec` instead of a provider SDK directly."""
-
-    strategy = "autorater"
-
-    def __init__(self, config: JudgeConfig) -> None:
-        self._config = config
-
-    def evaluate(
-        self,
-        task: TaskSpec,
-        transcript: list[ConversationTurn],
-        final_output: str,
-        spec_dir: str,
-    ) -> JudgeResult:
-        if not task.expect:
-            return JudgeResult(
-                passed=True,
-                reasoning="No expect defined; autorater skipped.",
-                autorater_passed=None,
-            )
-
-        passed, reasoning = evaluate_with_codex(
-            expect=task.expect,
-            transcript=transcript,
-            model=self._config.model,
-            cwd=spec_dir,
-        )
-
-        return JudgeResult(
-            passed=passed,
-            reasoning=reasoning,
-            autorater_passed=passed,
-            autorater_reasoning=reasoning,
-        )
 
 
 def evaluate_with_codex(
@@ -69,15 +35,7 @@ def evaluate_with_codex(
     if error:
         return False, error
 
-    try:
-        verdict = json.loads(_strip_markdown_fence(raw))
-        passed = bool(verdict.get("passed", False))
-        reasoning = str(verdict.get("reasoning", ""))
-    except (json.JSONDecodeError, KeyError):
-        passed = False
-        reasoning = f"Judge returned unparseable response: {raw[:200]}"
-
-    return passed, reasoning
+    return _parse_rich_response(_strip_markdown_fence(raw), cwd)
 
 
 def _run_codex(

--- a/caliper/judge/openai_api_judge.py
+++ b/caliper/judge/openai_api_judge.py
@@ -1,46 +1,12 @@
 from __future__ import annotations
 
-import json
-
 from caliper.harness.base import ConversationTurn
-from caliper.judge.autorater import _format_transcript, _SYSTEM, _USER_TMPL
-from caliper.judge.base import Judge, JudgeResult
-from caliper.schema.spec import JudgeConfig, TaskSpec
-
-
-class OpenAIAPIJudge(Judge):
-    """Judge that uses the OpenAI API explicitly."""
-
-    strategy = "autorater"
-
-    def __init__(self, config: JudgeConfig) -> None:
-        self._config = config
-
-    def evaluate(
-        self,
-        task: TaskSpec,
-        transcript: list[ConversationTurn],
-        final_output: str,
-        spec_dir: str,
-    ) -> JudgeResult:
-        if not task.expect:
-            return JudgeResult(
-                passed=True,
-                reasoning="No expect defined; autorater skipped.",
-                autorater_passed=None,
-            )
-
-        passed, reasoning = evaluate_with_openai_api(
-            expect=task.expect,
-            transcript=transcript,
-            model=self._config.model,
-        )
-        return JudgeResult(
-            passed=passed,
-            reasoning=reasoning,
-            autorater_passed=passed,
-            autorater_reasoning=reasoning,
-        )
+from caliper.judge.script_assert import (
+    _SYSTEM,
+    _USER_TMPL,
+    _format_transcript,
+    _parse_rich_response,
+)
 
 
 def evaluate_with_openai_api(
@@ -48,6 +14,7 @@ def evaluate_with_openai_api(
     expect: str,
     transcript: list[ConversationTurn],
     model: str | None,
+    spec_dir: str,
     timeout: int = 60,
 ) -> tuple[bool, str]:
     try:
@@ -73,15 +40,7 @@ def evaluate_with_openai_api(
     except Exception as exc:
         return False, f"openai-api judge failed: {exc}"
 
-    try:
-        verdict = json.loads(_strip_markdown_fence(raw.strip()))
-        passed = bool(verdict.get("passed", False))
-        reasoning = str(verdict.get("reasoning", ""))
-    except (json.JSONDecodeError, KeyError):
-        passed = False
-        reasoning = f"Judge returned unparseable response: {raw[:200]}"
-
-    return passed, reasoning
+    return _parse_rich_response(_strip_markdown_fence(raw.strip()), spec_dir)
 
 
 def _strip_markdown_fence(raw: str) -> str:

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -7,11 +7,7 @@ import tempfile
 from pathlib import Path
 
 from caliper.harness.base import ConversationTurn
-from caliper.judge.autorater import _format_transcript
-from caliper.judge.claude_code_judge import evaluate_with_claude_code
 from caliper.judge.base import Judge, JudgeResult
-from caliper.judge.codex_judge import evaluate_with_codex
-from caliper.judge.openai_api_judge import evaluate_with_openai_api
 from caliper.schema.spec import normalize_backend
 from caliper.schema.spec import JudgeConfig, TaskSpec
 
@@ -48,6 +44,21 @@ _USER_TMPL = """\
 Evaluate the transcript. Respond with JSON.
 """
 
+
+def _format_transcript(turns: list[ConversationTurn]) -> str:
+    lines: list[str] = []
+    for t in turns:
+        if t.role == "assistant":
+            lines.append(f"[assistant] {t.content}")
+        elif t.role == "tool_use":
+            inp = json.dumps(t.tool_input, ensure_ascii=False) if t.tool_input else ""
+            lines.append(f"[tool_use: {t.tool_name}] {inp}")
+        elif t.role == "tool_result":
+            out = (t.tool_output or "")[:2000]
+            lines.append(f"[tool_result] {out}")
+    return "\n".join(lines) or "(empty transcript)"
+
+
 def _run_inline_script(code: str, spec_dir: str) -> tuple[bool, str]:
     with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
         f.write(code)
@@ -70,13 +81,32 @@ def _run_inline_script(code: str, spec_dir: str) -> tuple[bool, str]:
         Path(tmp_path).unlink(missing_ok=True)
 
 
+def _parse_rich_response(raw: str, spec_dir: str) -> tuple[bool, str]:
+    try:
+        verdict = json.loads(raw)
+    except json.JSONDecodeError:
+        return False, f"Judge returned unparseable response: {raw[:200]}"
+
+    mode = verdict.get("mode", "verdict")
+    reasoning = str(verdict.get("reasoning", ""))
+
+    if mode == "script":
+        code = verdict.get("code", "")
+        if not code:
+            return False, "Judge returned empty script"
+        passed, evidence = _run_inline_script(code, spec_dir)
+        detail = f"{reasoning} | script: {'ok' if passed else evidence}"
+        return passed, detail
+
+    return bool(verdict.get("passed", False)), reasoning
+
+
 def _run_assert_from_task(task: TaskSpec, spec_dir: str) -> tuple[bool, str] | None:
     """Run the static assert field from the task spec, if present."""
     if not task.assert_script:
         return None
 
     raw = task.assert_script.strip()
-    # File path: single line ending in .py, no newlines
     if "\n" not in raw and raw.endswith(".py"):
         script_path = Path(raw)
         if not script_path.is_absolute():
@@ -90,12 +120,8 @@ def _run_assert_from_task(task: TaskSpec, spec_dir: str) -> tuple[bool, str] | N
     return _run_inline_script(code, spec_dir)
 
 
-class ScriptAssertJudge(Judge):
-    """
-    Handles both the static task.assert field and LLM-generated assertion scripts.
-    When task.expect is present, asks the LLM to either give a direct verdict or
-    write a Python assertion script.
-    """
+class EvalJudge(Judge):
+    """Universal judge: runs the static assert script and/or calls an LLM to evaluate."""
 
     strategy = "script"
 
@@ -115,18 +141,15 @@ class ScriptAssertJudge(Judge):
         autorater_passed: bool | None = None
         autorater_reasoning: str | None = None
 
-        # 1. Run the static assert from the spec (if any)
         static_result = _run_assert_from_task(task, spec_dir)
         if static_result is not None:
             assert_passed, assert_evidence = static_result
 
-        # 2. Run the LLM judge (direct verdict or generated script)
         if task.expect:
             llm_passed, llm_reasoning = self._llm_evaluate(task, transcript, spec_dir)
             autorater_passed = llm_passed
             autorater_reasoning = llm_reasoning
 
-        # Overall: both checks must pass (whichever are defined)
         checks = []
         if assert_passed is not None:
             checks.append(assert_passed)
@@ -153,12 +176,10 @@ class ScriptAssertJudge(Judge):
     def _llm_evaluate(
         self, task: TaskSpec, transcript: list[ConversationTurn], spec_dir: str
     ) -> tuple[bool, str]:
-        user_msg = _USER_TMPL.format(
-            expect=task.expect,
-            transcript=_format_transcript(transcript),
-        )
         match normalize_backend(self._config.backend):
             case "codex":
+                from caliper.judge.codex_judge import evaluate_with_codex
+
                 return evaluate_with_codex(
                     expect=task.expect,
                     transcript=transcript,
@@ -166,16 +187,22 @@ class ScriptAssertJudge(Judge):
                     cwd=spec_dir,
                 )
             case "claude-code":
+                from caliper.judge.claude_code_judge import evaluate_with_claude_code
+
                 return evaluate_with_claude_code(
                     expect=task.expect,
                     transcript=transcript,
                     model=self._config.model,
+                    spec_dir=spec_dir,
                 )
             case "openai-api":
+                from caliper.judge.openai_api_judge import evaluate_with_openai_api
+
                 return evaluate_with_openai_api(
                     expect=task.expect,
                     transcript=transcript,
                     model=self._config.model,
+                    spec_dir=spec_dir,
                 )
             case "claude-api":
                 model = self._config.model or "claude-haiku-4-5-20251001"
@@ -183,30 +210,20 @@ class ScriptAssertJudge(Judge):
                     import anthropic
 
                     self._client = anthropic.Anthropic()
-                response = self._client.messages.create(
-                    model=model,
-                    max_tokens=1024,
-                    system=_SYSTEM,
-                    messages=[{"role": "user", "content": user_msg}],
+                user_msg = _USER_TMPL.format(
+                    expect=task.expect,
+                    transcript=_format_transcript(transcript),
                 )
-                raw = response.content[0].text.strip()
+                try:
+                    response = self._client.messages.create(
+                        model=model,
+                        max_tokens=1024,
+                        system=_SYSTEM,
+                        messages=[{"role": "user", "content": user_msg}],
+                    )
+                    raw = response.content[0].text.strip()
+                except Exception as exc:
+                    return False, f"claude-api judge failed: {exc}"
+                return _parse_rich_response(raw, spec_dir)
             case _:
                 return False, f"Unknown judge backend: {self._config.backend!r}"
-
-        try:
-            verdict = json.loads(raw)
-        except json.JSONDecodeError:
-            return False, f"Judge returned unparseable response: {raw[:200]}"
-
-        mode = verdict.get("mode", "verdict")
-        reasoning = str(verdict.get("reasoning", ""))
-
-        if mode == "script":
-            code = verdict.get("code", "")
-            if not code:
-                return False, "Judge returned empty script"
-            passed, evidence = _run_inline_script(code, spec_dir)
-            detail = f"{reasoning} | script: {'ok' if passed else evidence}"
-            return passed, detail
-
-        return bool(verdict.get("passed", False)), reasoning

--- a/caliper/resources/evaluate_skill/REFERENCE.md
+++ b/caliper/resources/evaluate_skill/REFERENCE.md
@@ -6,7 +6,6 @@
 ```bash
 caliper run path/to/spec.eval.yaml --k 3
 caliper run path/to/spec.eval.yaml --k 3 --baseline      # include no-skill delta
-caliper run path/to/spec.eval.yaml --judge script        # LLM writes assertion scripts
 caliper run path/to/spec.eval.yaml --verbose             # show per-attempt reasoning
 ```
 
@@ -98,8 +97,7 @@ judge:
 
 - **pass@k** — probability that at least 1 of k attempts passes (default k=3)
 - **baseline** — runs each task without the skill to compute a delta score
-- **autorater** — LLM reads the full tool-call transcript + expectation → pass/fail
-- **script judge** — LLM can write Python assertion scripts for verifiable facts
+- **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
 - **isolation** — each attempt runs in a fresh temp HOME with no session history
 

--- a/caliper/resources/evaluate_skill/SKILL.md
+++ b/caliper/resources/evaluate_skill/SKILL.md
@@ -46,6 +46,20 @@ Use `references/simple.eval.yaml` for a compact spec that demonstrates
 multiple tasks, setup/cleanup, natural-language expectations, and deterministic
 assertions in one file.
 
+## Creating evals from scratch
+
+If the user has no `.eval.yaml` yet and wants help designing one interactively,
+suggest the `grill-skill` workflow instead of writing the spec manually:
+
+> "It looks like this skill doesn't have an eval yet. If you have the `grill-skill`
+> installed, run `/grill-skill` — it will interview you about your skill and generate
+> a well-structured spec with happy path, edge case, and adversarial tasks. If you'd
+> rather write it by hand, I can help with that too."
+
+Use `grill-skill` when: the user has a `SKILL.md` and no eval, or wants a guided
+create → run → iterate loop. Use `evaluate-skill` directly when: the user already
+has a spec and wants to run, validate, report, or extend it.
+
 ## Designing good agentic evals
 
 1. Name the target behavior: what should the skill do better than the base agent?

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -106,7 +106,6 @@ def run(
             spec=spec_name(spec_path),
             timestamp=datetime.now(tz=timezone.utc),
             k=k,
-            judge_strategy=judge.strategy,
             backend=spec.skill.backend,
             model=spec.skill.model,
         ),

--- a/caliper/schema/results.py
+++ b/caliper/schema/results.py
@@ -21,7 +21,6 @@ class RunMeta(BaseModel):
     spec: str
     timestamp: datetime
     k: int
-    judge_strategy: str
     backend: str
     model: str | None = None
 

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -6,7 +6,6 @@
 ```bash
 caliper run path/to/spec.eval.yaml --k 3
 caliper run path/to/spec.eval.yaml --k 3 --baseline      # include no-skill delta
-caliper run path/to/spec.eval.yaml --judge script        # LLM writes assertion scripts
 caliper run path/to/spec.eval.yaml --verbose             # show per-attempt reasoning
 
 # Override backend and/or model at run time (no spec edit needed)
@@ -105,8 +104,7 @@ judge:
 
 - **pass@k** — probability that at least 1 of k attempts passes (default k=3)
 - **baseline** — runs each task without the skill to compute a delta score
-- **autorater** — LLM reads the full tool-call transcript + expectation → pass/fail
-- **script judge** — LLM can write Python assertion scripts for verifiable facts
+- **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
 - **isolation** — each attempt runs in a fresh temp HOME with no session history
 - **`--model TARGET`** — override skill backend/model at run time; accepts `backend:model`, bare backend (`codex`), or bare model name

--- a/tests/test_claude_judge.py
+++ b/tests/test_claude_judge.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import subprocess
 
 from caliper.harness.base import ConversationTurn
-from caliper.judge.claude_code_judge import ClaudeCodeJudge
+from caliper.judge.script_assert import EvalJudge
 from caliper.schema.spec import JudgeConfig, TaskSpec
 
 
-def test_claude_code_judge_still_invokes_claude_cli(monkeypatch, tmp_path) -> None:
+def test_eval_judge_claude_code_invokes_claude_cli(monkeypatch, tmp_path) -> None:
     calls = []
 
     def fake_run(cmd, **kwargs):
@@ -15,13 +15,13 @@ def test_claude_code_judge_still_invokes_claude_cli(monkeypatch, tmp_path) -> No
         return subprocess.CompletedProcess(
             cmd,
             0,
-            stdout='{"passed": true, "reasoning": "The transcript says hello."}',
+            stdout='{"mode": "verdict", "passed": true, "reasoning": "The transcript says hello."}',
             stderr="",
         )
 
     monkeypatch.setattr("caliper.judge.claude_code_judge.subprocess.run", fake_run)
 
-    result = ClaudeCodeJudge(JudgeConfig(backend="claude", model="claude-test")).evaluate(
+    result = EvalJudge(JudgeConfig(backend="claude", model="claude-test")).evaluate(
         task=TaskSpec(
             id="task-001",
             name="Claude judge",

--- a/tests/test_codex_judge.py
+++ b/tests/test_codex_judge.py
@@ -4,34 +4,95 @@ import json
 import subprocess
 
 from caliper.harness.base import ConversationTurn
-from caliper.judge import ClaudeCodeJudge, CodexJudge, OpenAIAPIJudge, get_judge
 from caliper.judge.codex_judge import _extract_codex_error, evaluate_with_codex
-from caliper.judge.script_assert import ScriptAssertJudge
+from caliper.judge.script_assert import EvalJudge
 from caliper.schema.spec import JudgeConfig, TaskSpec
 
 
-def test_get_judge_returns_codex_for_codex_autorater_backend() -> None:
-    judge = get_judge("autorater", JudgeConfig(backend="codex"))
-
-    assert isinstance(judge, CodexJudge)
-
-
-def test_get_judge_keeps_claude_code_as_default_autorater_backend() -> None:
-    judge = get_judge("autorater", JudgeConfig(backend="claude-code"))
-
-    assert isinstance(judge, ClaudeCodeJudge)
+def test_eval_judge_always_returns_eval_judge_instance() -> None:
+    for backend in ("codex", "claude-code", "claude-api", "openai-api"):
+        judge = EvalJudge(JudgeConfig(backend=backend))
+        assert isinstance(judge, EvalJudge)
 
 
-def test_get_judge_maps_openai_api_explicitly() -> None:
-    judge = get_judge("autorater", JudgeConfig(backend="openai-api"))
+def test_eval_judge_expect_only_calls_llm(monkeypatch, tmp_path) -> None:
+    calls = []
 
-    assert isinstance(judge, OpenAIAPIJudge)
+    def fake_eval(*, expect, transcript, model, cwd, timeout=60):
+        calls.append((expect, model, cwd))
+        return True, "Codex accepted the transcript."
+
+    monkeypatch.setattr("caliper.judge.script_assert.EvalJudge._llm_evaluate",
+                        lambda self, task, transcript, spec_dir: fake_eval(
+                            expect=task.expect,
+                            transcript=transcript,
+                            model=self._config.model,
+                            cwd=spec_dir,
+                        ))
+
+    judge = EvalJudge(JudgeConfig(backend="codex", model="test-model"))
+    result = judge.evaluate(
+        task=TaskSpec(id="t1", name="t", prompt="p", expect="should say hello"),
+        transcript=[ConversationTurn(role="assistant", content="hello")],
+        final_output="hello",
+        spec_dir=str(tmp_path),
+    )
+
+    assert result.passed is True
+    assert result.assert_passed is None
+    assert result.autorater_passed is True
 
 
-def test_legacy_claude_backend_normalizes_to_claude_code() -> None:
-    config = JudgeConfig(backend="claude")
+def test_eval_judge_assert_only_runs_script_no_llm(tmp_path) -> None:
+    judge = EvalJudge(JudgeConfig(backend="codex"))
+    result = judge.evaluate(
+        task=TaskSpec(id="t2", name="t", prompt="p", assert_script="assert 1 == 1"),
+        transcript=[],
+        final_output="",
+        spec_dir=str(tmp_path),
+    )
 
-    assert config.backend == "claude-code"
+    assert result.passed is True
+    assert result.assert_passed is True
+    assert result.autorater_passed is None
+
+
+def test_eval_judge_assert_failure_makes_overall_fail(tmp_path) -> None:
+    judge = EvalJudge(JudgeConfig(backend="codex"))
+    result = judge.evaluate(
+        task=TaskSpec(id="t3", name="t", prompt="p", assert_script="assert False, 'nope'"),
+        transcript=[],
+        final_output="",
+        spec_dir=str(tmp_path),
+    )
+
+    assert result.passed is False
+    assert result.assert_passed is False
+
+
+def test_eval_judge_both_checks_must_pass(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        "caliper.judge.script_assert.EvalJudge._llm_evaluate",
+        lambda self, task, transcript, spec_dir: (True, "LLM says yes"),
+    )
+
+    judge = EvalJudge(JudgeConfig(backend="codex"))
+    result = judge.evaluate(
+        task=TaskSpec(
+            id="t4",
+            name="t",
+            prompt="p",
+            expect="pass",
+            assert_script="assert False, 'script fails'",
+        ),
+        transcript=[],
+        final_output="",
+        spec_dir=str(tmp_path),
+    )
+
+    assert result.passed is False
+    assert result.autorater_passed is True
+    assert result.assert_passed is False
 
 
 def test_codex_judge_uses_output_last_message(monkeypatch, tmp_path) -> None:
@@ -41,7 +102,7 @@ def test_codex_judge_uses_output_last_message(monkeypatch, tmp_path) -> None:
         calls.append((cmd, kwargs))
         output_path = cmd[cmd.index("--output-last-message") + 1]
         with open(output_path, "w") as f:
-            json.dump({"passed": True, "reasoning": "The transcript matches."}, f)
+            json.dump({"mode": "verdict", "passed": True, "reasoning": "The transcript matches."}, f)
         return subprocess.CompletedProcess(cmd, 0, stdout="noisy session log", stderr="")
 
     monkeypatch.setattr("caliper.judge.codex_judge.shutil.which", lambda _name: "codex.cmd")
@@ -65,16 +126,16 @@ def test_codex_judge_uses_output_last_message(monkeypatch, tmp_path) -> None:
     assert kwargs["cwd"] == str(tmp_path)
 
 
-def test_script_judge_uses_codex_for_expect_when_configured(monkeypatch, tmp_path) -> None:
+def test_eval_judge_uses_codex_for_expect_when_configured(monkeypatch, tmp_path) -> None:
     calls = []
 
     def fake_eval(*, expect, transcript, model, cwd, timeout=60):
         calls.append((expect, transcript, model, cwd, timeout))
         return True, "Codex accepted the transcript."
 
-    monkeypatch.setattr("caliper.judge.script_assert.evaluate_with_codex", fake_eval)
+    monkeypatch.setattr("caliper.judge.codex_judge.evaluate_with_codex", fake_eval)
 
-    judge = ScriptAssertJudge(JudgeConfig(backend="codex", model="test-model"))
+    judge = EvalJudge(JudgeConfig(backend="codex", model="test-model"))
     result = judge.evaluate(
         task=TaskSpec(
             id="task-001",


### PR DESCRIPTION
## Summary

- Removes the `--judge` CLI flag and the four backend-specific judge classes (`AutoraterJudge`, `ClaudeCodeJudge`, `CodexJudge`, `OpenAIAPIJudge`)
- Renames `ScriptAssertJudge` → `EvalJudge`, which is now the universal judge for all backends
- All backends now use the rich system prompt that lets the LLM choose between a direct verdict or a generated Python assertion script
- The spec drives evaluation: `expect:` triggers LLM judgment, `assert:` runs a static Python script, both can be combined (both must pass)
- Removes `judge_strategy` from `RunMeta` and the Judge column from `caliper list`
- `script_assert.py` is now the source of truth for shared prompt/parsing utilities; backend files import from it
- Docs, REFERENCE.md files, and packaged skill resources updated; stale packaged SKILL.md synced

Closes #5

## Test plan

- [ ] All 47 unit tests pass (`python -m pytest tests/ -q`)
- [ ] `caliper run tests/claude-code-smoke.eval.yaml --k 1` passes (assert-only path)
- [ ] `caliper run tests/codex-smoke.eval.yaml --k 1` passes (assert-only path)
- [ ] `--judge` flag is gone from `caliper run --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)