### PR TITLE
Add pi backend (issue #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ If an `.eval.yaml` already exists next to your skill, `grill-skill` reads the ex
 | Term | What it is |
 |---|---|
 | **Spec** | A `.eval.yaml` file that describes the skill, judge, and tasks to run |
-| **Backend** | The agent that executes the skill (`claude-code`, `codex`, `claude-api`, `openai-api`) |
+| **Backend** | The agent that executes the skill (`claude-code`, `codex`, `pi`, `claude-api`, `openai-api`) |
 | **Judge** | What decides pass/fail — an LLM reading the transcript (`expect:`), Python assertions (`assert:`), or both |
 | **pass@k** | Reliability score: run k times, measure how often the skill succeeds |
 | **Baseline** | Re-run the same tasks without the skill to prove the skill is doing the work |
@@ -223,6 +223,7 @@ If an `.eval.yaml` already exists next to your skill, `grill-skill` reads the ex
 |---|---|---|
 | `claude-code` | Claude Code CLI installed and authenticated | Testing Claude Code slash-command skills |
 | `codex` | Codex CLI installed (`npm install -g @openai/codex`) | Testing Codex skills |
+| `pi` | pi CLI installed (`npm install -g @earendil-works/pi-coding-agent`) and authenticated | Testing pi skills (agentskills.io) |
 | `claude-api` | `ANTHROPIC_API_KEY` env var | API-backed agents, no CLI needed |
 | `openai-api` | `OPENAI_API_KEY` env var | OpenAI API agents |
 
@@ -253,6 +254,15 @@ For `backend: openai-api`:
 export OPENAI_API_KEY=...
 ```
 
+### pi setup
+
+```bash
+npm install -g @earendil-works/pi-coding-agent
+pi   # then authenticate (e.g. /login for a subscription provider, or set the provider API key)
+```
+
+`backend: pi` runs `pi --print --mode json` and loads the skill natively via pi's `--skill` flag (the agentskills.io standard). It reuses your `~/.pi/agent` auth and settings — the spec's `model:` overrides pi's configured default when set. Set `PI_CLI_PATH` to force a specific binary. Note: pi's built-in default provider is `google`, so a spec with no `model:` relies on your pi config to resolve a provider you are authenticated for.
+
 Check installed CLI versions:
 
 ```bash
@@ -281,11 +291,11 @@ caliper update-cli --check
 ```yaml
 skill:
   path: ./SKILL.md              # path to the skill file (optional for baseline-only runs)
-  backend: claude-code          # claude-code | codex | claude-api | openai-api
+  backend: claude-code          # claude-code | codex | pi | claude-api | openai-api
   model: <model-name>           # optional model override
 
 judge:
-  backend: claude-code          # claude-code | codex | claude-api | openai-api
+  backend: claude-code          # claude-code | codex | pi | claude-api | openai-api
   model: <model-name>           # optional model override
 
 sandbox:
@@ -397,7 +407,7 @@ caliper run my-skill.eval.yaml --model claude-sonnet-4-6
 caliper run my-skill.eval.yaml --model claude-api:claude-sonnet-4-6 --judge-model claude-api:claude-haiku-4-5-20251001
 ```
 
-Accepted backends: `claude-code`, `codex`, `claude-api`, `openai-api` (aliases: `claude`, `anthropic`, `openai`).
+Accepted backends: `claude-code`, `codex`, `pi`, `claude-api`, `openai-api` (aliases: `claude`, `anthropic`, `openai`).
 
 The spec file is never modified — overrides apply only to the current run.
 
@@ -468,7 +478,7 @@ npm install -g @openai/codex
 ```
 
 **`claude` command not found**
-Install and authenticate Claude Code, or switch the backend to `codex`, `claude-api`, or `openai-api`.
+Install and authenticate Claude Code, or switch the backend to `codex`, `pi`, `claude-api`, or `openai-api`.
 
 **A task passes only because of `assert:`**
 When a task has only `assert:`, no LLM judge runs. Add `expect:` if you also want an LLM to evaluate the transcript.

--- a/caliper/commands/install_skill.py
+++ b/caliper/commands/install_skill.py
@@ -13,6 +13,7 @@ SKILL_FILENAME = "SKILL.md"
 TARGETS = {
     "codex": Path(".codex") / "skills" / "evaluate-skill" / "SKILL.md",
     "claude-code": Path(".claude") / "commands" / "evaluate-skill.md",
+    "pi": Path(".pi") / "agent" / "skills" / "evaluate-skill" / "SKILL.md",
 }
 
 
@@ -23,7 +24,7 @@ def load_packaged_skill() -> str:
 def install_skill_cmd(
     target: Annotated[
         str,
-        typer.Argument(help="Agent target to install for: codex or claude-code"),
+        typer.Argument(help="Agent target to install for: codex, claude-code, or pi"),
     ],
     force: Annotated[
         bool,

--- a/caliper/commands/new.py
+++ b/caliper/commands/new.py
@@ -10,7 +10,7 @@ from caliper.wizard import run_wizard
 def new_cmd(
     name: Annotated[Optional[str], typer.Argument(help="Eval name (used as default filename)")] = None,
     skill: Annotated[Optional[str], typer.Option("--skill", help="Pre-populate skill path")] = None,
-    backend: Annotated[str, typer.Option("--backend", help="Pre-populate backend")] = "claude-code",
+    backend: Annotated[str, typer.Option("--backend", help="Pre-populate backend (claude-code, codex, claude-api, openai-api, pi)")] = "claude-code",
     output: Annotated[Optional[Path], typer.Option("--out", help="Output path for .eval.yaml")] = None,
 ) -> None:
     run_wizard(name=name, output=output, skill_path=skill, backend=backend)

--- a/caliper/commands/update_cli.py
+++ b/caliper/commands/update_cli.py
@@ -36,6 +36,11 @@ TARGETS = {
         binary="claude",
         npm_package="@anthropic-ai/claude-code",
     ),
+    "pi": CliTarget(
+        name="pi",
+        binary="pi",
+        npm_package="@earendil-works/pi-coding-agent",
+    ),
 }
 
 ALIASES = {
@@ -47,7 +52,7 @@ ALIASES = {
 def update_cli_cmd(
     target: Annotated[
         Optional[str],
-        typer.Argument(help="CLI to update: codex, claude-code, or all"),
+        typer.Argument(help="CLI to update: codex, claude-code, pi, or all"),
     ] = None,
     check: Annotated[
         bool,

--- a/caliper/harness/__init__.py
+++ b/caliper/harness/__init__.py
@@ -16,6 +16,9 @@ def get_harness(backend: str, model: str | None = None) -> HarnessBackend:
             return ClaudeAPIHarness(model=model)
         case "openai-api":
             return OpenAIAPIHarness(model=model)
+        case "pi":
+            from caliper.harness.pi import PiHarness
+            return PiHarness(model=model)
         case _:
             raise ValueError(f"Unknown backend: {backend!r}")
 

--- a/caliper/harness/pi.py
+++ b/caliper/harness/pi.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from caliper.harness.base import (
+    AttemptResult,
+    ConversationTurn,
+    HarnessBackend,
+    HarnessConfigurationError,
+)
+
+
+class PiHarness(HarnessBackend):
+    """CLI-subprocess backend for the `pi` coding agent.
+
+    Drives the locally installed `pi` CLI in non-interactive JSON mode and
+    loads the skill-under-test natively via pi's `--skill` flag (the
+    agentskills.io standard), unlike codex which injects the skill into the
+    prompt.
+    """
+
+    def __init__(self, model: str | None = None) -> None:
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "pi"
+
+    def run(
+        self,
+        task_id: str,
+        attempt: int,
+        prompt: str,
+        *,
+        skill_path: str | None,
+        model: str | None,
+        timeout: int,
+        isolated_home: str,
+        extra_path: list[str] | None = None,
+    ) -> AttemptResult:
+        effective_model = model or self._model
+        start = time.monotonic()
+
+        if not self._cli_available():
+            raise HarnessConfigurationError(
+                "pi CLI is not available for the `pi` backend.\n\n"
+                "Install the pi coding agent (`npm install -g "
+                "@earendil-works/pi-coding-agent`) and authenticate it, or set "
+                "`PI_CLI_PATH` to the pi binary, then rerun caliper."
+            )
+
+        # pi reads auth/settings from its config dir. We copy the real config
+        # verbatim into a per-attempt directory (parallel-safe; never mutates
+        # the user's real ~/.pi) and point pi at it via PI_CODING_AGENT_DIR.
+        # The config's default model/provider is preserved on purpose; the
+        # spec's `--model` overrides it when set. See issue #10 for why this
+        # differs from codex (which strips its config default).
+        agent_dir = self._copy_pi_config(isolated_home)
+
+        output, exit_code, error = self._run_cli(
+            prompt,
+            effective_model,
+            skill_path,
+            timeout,
+            isolated_home,
+            agent_dir,
+            extra_path or [],
+        )
+        diagnostic = self._diagnose_configuration_error(exit_code, output, error)
+        if diagnostic:
+            raise HarnessConfigurationError(diagnostic)
+
+        duration = time.monotonic() - start
+        transcript, final_output = self._parse_json_stream(output)
+        if not transcript and output:
+            transcript = [ConversationTurn(role="assistant", content=output)]
+            final_output = output
+
+        return AttemptResult(
+            task_id=task_id,
+            attempt=attempt,
+            transcript=transcript,
+            final_output=final_output,
+            exit_code=exit_code,
+            duration_seconds=duration,
+            error=error,
+        )
+
+    def _cli_available(self) -> bool:
+        pi = self._pi_command()
+        if pi is None:
+            return False
+        try:
+            result = subprocess.run(
+                [pi, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return result.returncode == 0
+
+    def _run_cli(
+        self,
+        prompt: str,
+        model: str | None,
+        skill_path: str | None,
+        timeout: int,
+        isolated_home: str,
+        agent_dir: Path,
+        extra_path: list[str],
+    ) -> tuple[str, int, str | None]:
+        pi = self._pi_command() or "pi"
+        env = self._build_env(isolated_home, agent_dir, extra_path)
+        cmd = [
+            pi,
+            "--print",
+            "--mode", "json",
+            "--no-session",
+            # Trust the project-local skill file for this run; without it pi
+            # blocks on an interactive trust prompt when a skill is loaded.
+            "--approve",
+        ]
+        if model:
+            cmd += ["--model", model]
+        if skill_path:
+            skill_src = Path(skill_path).expanduser()
+            if skill_src.exists():
+                cmd += ["--skill", str(skill_src)]
+        cmd.append(prompt)
+
+        try:
+            result = subprocess.run(
+                cmd,
+                # Close stdin: in --print mode pi otherwise blocks reading
+                # stdin (e.g. for a trust confirmation) and hangs until timeout.
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                encoding="utf-8",
+                text=True,
+                timeout=timeout,
+                env=env,
+                cwd=isolated_home,
+            )
+            return result.stdout.strip(), result.returncode, result.stderr.strip() or None
+        except subprocess.TimeoutExpired:
+            return "", 124, "timeout"
+        except OSError as exc:
+            return "", 1, f"pi CLI failed: {exc}"
+
+    def _parse_json_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]:
+        transcript: list[ConversationTurn] = []
+        final_output = ""
+
+        for line in stdout.splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+
+            etype = event.get("type")
+
+            if etype == "tool_execution_start":
+                tool_name = event.get("toolName")
+                args = event.get("args")
+                transcript.append(
+                    ConversationTurn(
+                        role="tool_use",
+                        content=f"[tool: {tool_name}]",
+                        tool_name=tool_name,
+                        tool_input=args if isinstance(args, dict) else None,
+                    )
+                )
+                continue
+
+            if etype == "tool_execution_end":
+                output = self._flatten_result(event.get("result"))
+                transcript.append(
+                    ConversationTurn(
+                        role="tool_result",
+                        content=output,
+                        tool_output=output,
+                    )
+                )
+                continue
+
+            if etype == "message_end":
+                message = event.get("message")
+                if not isinstance(message, dict) or message.get("role") != "assistant":
+                    continue
+                text = self._flatten_text(message.get("content"))
+                if text:
+                    transcript.append(ConversationTurn(role="assistant", content=text))
+                    final_output = text
+
+        if not final_output and transcript:
+            for turn in reversed(transcript):
+                if turn.role == "assistant" and turn.content:
+                    final_output = turn.content
+                    break
+
+        return transcript, final_output
+
+    def _flatten_text(self, content: object) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            ]
+            return "".join(parts).strip()
+        return ""
+
+    def _flatten_result(self, result: object) -> str:
+        if isinstance(result, dict):
+            return self._flatten_text(result.get("content"))
+        if isinstance(result, str):
+            return result
+        return ""
+
+    def _build_env(
+        self, isolated_home: str, agent_dir: Path, extra_path: list[str]
+    ) -> dict[str, str]:
+        path = os.environ.get("PATH", "")
+        if extra_path:
+            path = os.pathsep.join(extra_path) + os.pathsep + path
+
+        env = {
+            "HOME": isolated_home,
+            "PATH": path,
+            "PI_CODING_AGENT_DIR": str(agent_dir),
+        }
+        for key in ("LANG", "LC_ALL", "TERM", "TMPDIR"):
+            if key in os.environ:
+                env[key] = os.environ[key]
+        return env
+
+    def _pi_command(self) -> str | None:
+        configured = os.environ.get("PI_CLI_PATH")
+        if configured and Path(configured).exists():
+            return configured
+        return shutil.which("pi")
+
+    def _copy_pi_config(self, isolated_home: str) -> Path:
+        agent_dir = Path(isolated_home) / ".pi" / "agent"
+        real_agent_dir = Path.home() / ".pi" / "agent"
+        for filename in ("auth.json", "settings.json"):
+            src = real_agent_dir / filename
+            if src.exists():
+                agent_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, agent_dir / filename)
+        return agent_dir
+
+    def _diagnose_configuration_error(
+        self,
+        returncode: int,
+        stdout: str,
+        stderr: str | None,
+    ) -> str | None:
+        if returncode == 0:
+            return None
+
+        text = "\n".join(part for part in (stdout, stderr or "") if part).strip()
+        if not text:
+            return None
+        lowered = text.lower()
+
+        provider_markers = (
+            "no api key",
+            "no credentials",
+            "missing api key",
+            "set an api key",
+            "no provider",
+            "unknown provider",
+        )
+        if any(marker in lowered for marker in provider_markers) or (
+            "provider" in lowered and "api key" in lowered
+        ):
+            return (
+                "pi cannot run with the current provider/credential "
+                "configuration.\n\n"
+                "Caliper copies your `~/.pi/agent` auth and settings verbatim "
+                "and passes `--model` only when the spec sets one. The pi CLI "
+                "returned:\n"
+                f"  {text}\n\n"
+                "pi's built-in default provider is `google`, so a spec with no "
+                "`model:` (and no Google credentials) can fail here. Set a "
+                "`model:`/provider you are authenticated for in the spec, or "
+                "configure pi's default provider with `pi` directly, then rerun "
+                "caliper."
+            )
+
+        auth_markers = (
+            "401",
+            "unauthorized",
+            "not logged in",
+            "please login",
+            "please run /login",
+            "authentication",
+            "invalid api key",
+            "subscription",
+        )
+        if any(marker in lowered for marker in auth_markers):
+            return (
+                "pi cannot run with the current authentication "
+                "configuration.\n\n"
+                "Caliper drives the local pi CLI and reuses its `~/.pi/agent` "
+                "credentials. The pi CLI returned:\n"
+                f"  {text}\n\n"
+                "Authenticate pi (e.g. `pi` then `/login`, or set the provider "
+                "API key), verify `pi --print 'Reply OK'` works in your normal "
+                "shell, then rerun caliper."
+            )
+
+        return None

--- a/caliper/resources/evaluate_skill/REFERENCE.md
+++ b/caliper/resources/evaluate_skill/REFERENCE.md
@@ -7,6 +7,13 @@
 caliper run path/to/spec.eval.yaml --k 3
 caliper run path/to/spec.eval.yaml --k 3 --baseline      # include no-skill delta
 caliper run path/to/spec.eval.yaml --verbose             # show per-attempt reasoning
+
+# Override backend and/or model at run time (no spec edit needed)
+caliper run path/to/spec.eval.yaml --model claude-api:claude-sonnet-4-6
+caliper run path/to/spec.eval.yaml --model codex
+caliper run path/to/spec.eval.yaml --model claude-sonnet-4-6   # model only, keep spec backend
+caliper run path/to/spec.eval.yaml --judge-model claude-api:claude-haiku-4-5-20251001
+caliper run path/to/spec.eval.yaml --model claude-api:claude-sonnet-4-6 --judge-model claude-api:claude-haiku-4-5-20251001
 ```
 
 ### Create a new evaluation spec (interactive wizard)
@@ -26,22 +33,17 @@ caliper validate path/to/spec.eval.yaml
 ```bash
 caliper list                        # all specs with latest scores
 caliper list my-skill-eval          # all runs for one spec
-caliper report my-skill-eval        # latest run — failed tasks shown with detail
-caliper report my-skill-eval --verbose  # all tasks with full output
+caliper report my-skill-eval        # latest run (table view)
 caliper report my-skill-eval --run 2026-05-12T14-23-01Z  # specific run
 caliper report results.json --format json
 ```
-
-After any `caliper run`, failed tasks are automatically shown with their agent
-output (last 500 chars) and `assert_evidence`. Use `--verbose` when you need
-full output for all tasks including passing ones.
 
 ## Spec format (.eval.yaml)
 
 ```yaml
 skill:
   path: ./SKILL.md
-  backend: claude-code     # claude-code | codex | claude-api | openai-api
+  backend: claude-code     # claude-code | codex | pi | claude-api | openai-api
   model: claude-sonnet-4-6 # optional
 
 judge:
@@ -85,6 +87,18 @@ judge:
   backend: codex
 ```
 
+For a pi-backed eval (loads the skill natively via pi's `--skill` flag):
+
+```yaml
+skill:
+  path: ./SKILL.md
+  backend: pi
+  model: claude-sonnet-4-6  # optional; overrides pi's configured default
+
+judge:
+  backend: pi
+```
+
 For an API-backed eval, opt in explicitly:
 
 ```yaml
@@ -105,6 +119,8 @@ judge:
 - **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
 - **isolation** — each attempt runs in a fresh temp HOME with no session history
+- **`--model TARGET`** — override skill backend/model at run time; accepts `backend:model`, bare backend (`codex`), or bare model name
+- **`--judge-model TARGET`** — same syntax, overrides the judge backend/model independently
 
 ## Results storage
 

--- a/caliper/resources/evaluate_skill/SKILL.md
+++ b/caliper/resources/evaluate_skill/SKILL.md
@@ -25,6 +25,9 @@ Supported backends:
 - `codex` — runs Codex skills by prepending the skill body to the prompt passed
   to `codex exec`; this uses the Codex CLI subscription/auth and never falls
   back to the OpenAI API.
+- `pi` — runs pi skills via the pi CLI (`pi --print --mode json`), loading the
+  skill natively with pi's `--skill` flag (agentskills.io standard). Uses the pi
+  CLI's `~/.pi/agent` subscription/auth.
 - `claude-api` — runs through the Anthropic API explicitly.
 - `openai-api` — runs through the OpenAI API explicitly.
 

--- a/caliper/schema/spec.py
+++ b/caliper/schema/spec.py
@@ -6,9 +6,11 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
-BackendName = Literal["claude-code", "codex", "claude-api", "openai-api"]
+BackendName = Literal["claude-code", "codex", "claude-api", "openai-api", "pi"]
 
-_VALID_BACKENDS: frozenset[str] = frozenset({"claude-code", "codex", "claude-api", "openai-api"})
+_VALID_BACKENDS: frozenset[str] = frozenset(
+    {"claude-code", "codex", "claude-api", "openai-api", "pi"}
+)
 
 
 def normalize_backend(value: str) -> str:

--- a/caliper/wizard.py
+++ b/caliper/wizard.py
@@ -34,7 +34,7 @@ def run_wizard(
 
     backend_choice = Prompt.ask(
         "  Backend",
-        choices=["claude-code", "codex", "claude-api", "openai-api"],
+        choices=["claude-code", "codex", "claude-api", "openai-api", "pi"],
         default=normalize_backend(backend),
     )
     model = Prompt.ask("  Model override", default="").strip() or None
@@ -45,7 +45,7 @@ def run_wizard(
     console.print(Rule("[bold]Step 2 — Judge[/bold]", style="cyan"))
     judge_backend = Prompt.ask(
         "  Judge backend",
-        choices=["claude-code", "codex", "claude-api", "openai-api"],
+        choices=["claude-code", "codex", "claude-api", "openai-api", "pi"],
         default="claude-code",
     )
     judge_model = Prompt.ask("  Judge model override", default="").strip() or None

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -43,7 +43,7 @@ caliper report results.json --format json
 ```yaml
 skill:
   path: ./SKILL.md
-  backend: claude-code     # claude-code | codex | claude-api | openai-api
+  backend: claude-code     # claude-code | codex | pi | claude-api | openai-api
   model: claude-sonnet-4-6 # optional
 
 judge:
@@ -85,6 +85,18 @@ skill:
 
 judge:
   backend: codex
+```
+
+For a pi-backed eval (loads the skill natively via pi's `--skill` flag):
+
+```yaml
+skill:
+  path: ./SKILL.md
+  backend: pi
+  model: claude-sonnet-4-6  # optional; overrides pi's configured default
+
+judge:
+  backend: pi
 ```
 
 For an API-backed eval, opt in explicitly:

--- a/skills/evaluate-skill/SKILL.md
+++ b/skills/evaluate-skill/SKILL.md
@@ -25,6 +25,9 @@ Supported backends:
 - `codex` — runs Codex skills by prepending the skill body to the prompt passed
   to `codex exec`; this uses the Codex CLI subscription/auth and never falls
   back to the OpenAI API.
+- `pi` — runs pi skills via the pi CLI (`pi --print --mode json`), loading the
+  skill natively with pi's `--skill` flag (agentskills.io standard). Uses the pi
+  CLI's `~/.pi/agent` subscription/auth.
 - `claude-api` — runs through the Anthropic API explicitly.
 - `openai-api` — runs through the OpenAI API explicitly.
 

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -107,6 +107,7 @@ Add `assert:` when the outcome is a fact that an LLM judge might guess wrong:
 |---|---|---|
 | `claude-code` | Claude Code CLI | Default for most skills |
 | `codex` | Codex CLI | For Codex-targeted skills |
+| `pi` | pi CLI (authenticated) | For pi / agentskills.io skills; native `--skill` loading |
 | `claude-api` | `ANTHROPIC_API_KEY` | No CLI needed |
 | `openai-api` | `OPENAI_API_KEY` | No CLI needed |
 

--- a/tests/pi-smoke.eval.yaml
+++ b/tests/pi-smoke.eval.yaml
@@ -1,0 +1,17 @@
+skill:
+  backend: pi
+
+judge:
+  backend: claude-api
+  model: claude-haiku-4-5-20251001
+
+tasks:
+  - name: Write hello to a file
+    setup: rm -f /tmp/caliper-e2e-smoke-pi.txt
+    cleanup: rm -f /tmp/caliper-e2e-smoke-pi.txt
+    prompt: Write the text "hello" to /tmp/caliper-e2e-smoke-pi.txt using a shell command.
+    assert: |
+      from pathlib import Path
+      p = Path("/tmp/caliper-e2e-smoke-pi.txt")
+      assert p.exists(), "file was not created"
+      assert "hello" in p.read_text(), "file does not contain hello"

--- a/tests/test_pi_harness.py
+++ b/tests/test_pi_harness.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from caliper.harness.base import HarnessConfigurationError
+from caliper.harness.pi import PiHarness
+
+
+def _version(cmd):
+    return subprocess.CompletedProcess(cmd, 0, stdout="0.80.2\n", stderr="")
+
+
+def test_pi_cli_receives_skill_and_model_flags(monkeypatch, tmp_path) -> None:
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("---\ndescription: test\n---\n\nUse caliper carefully.")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.pi.subprocess.run", fake_run)
+
+    PiHarness().run(
+        task_id="task-001",
+        attempt=1,
+        prompt="Validate the spec",
+        skill_path=str(skill),
+        model="claude-sonnet-4-6",
+        timeout=30,
+        isolated_home=str(tmp_path),
+        extra_path=[str(tmp_path / "bin")],
+    )
+
+    run_cmd = calls[1][0]
+    assert run_cmd[0] == "pi"
+    assert "--print" in run_cmd
+    assert run_cmd[run_cmd.index("--mode") + 1] == "json"
+    assert "--no-session" in run_cmd
+    assert "--approve" in run_cmd
+    assert calls[1][1]["stdin"] is subprocess.DEVNULL
+    assert run_cmd[run_cmd.index("--model") + 1] == "claude-sonnet-4-6"
+    assert run_cmd[run_cmd.index("--skill") + 1] == str(skill)
+    # prompt is the final positional arg
+    assert run_cmd[-1] == "Validate the spec"
+    # config is pointed at the per-attempt copy, not the real ~/.pi
+    env = calls[1][1]["env"]
+    assert env["PI_CODING_AGENT_DIR"] == str(tmp_path / ".pi" / "agent")
+    assert env["HOME"] == str(tmp_path)
+
+
+def test_pi_omits_model_and_skill_when_unspecified(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.pi.subprocess.run", fake_run)
+
+    PiHarness().run(
+        task_id="task-001",
+        attempt=1,
+        prompt="Hello",
+        skill_path=None,
+        model=None,
+        timeout=12,
+        isolated_home=str(tmp_path),
+    )
+
+    run_cmd = calls[1][0]
+    assert "--model" not in run_cmd
+    assert "--skill" not in run_cmd
+
+
+def test_pi_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
+    def fake_run(cmd, **kwargs):
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        events = [
+            {"type": "session", "version": 3, "id": "abc", "cwd": "/tmp"},
+            {"type": "agent_start"},
+            {"type": "turn_start"},
+            {
+                "type": "tool_execution_start",
+                "toolCallId": "toolu_1",
+                "toolName": "write",
+                "args": {"path": "notes.txt", "content": "HELLO"},
+            },
+            {
+                "type": "tool_execution_end",
+                "toolCallId": "toolu_1",
+                "toolName": "write",
+                "result": {
+                    "content": [{"type": "text", "text": "Successfully wrote 5 bytes to notes.txt"}]
+                },
+                "isError": False,
+            },
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "All done."}],
+                },
+            },
+            {"type": "turn_end"},
+            {"type": "agent_end", "messages": []},
+        ]
+        stdout = "\n".join(json.dumps(e) for e in events)
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.pi.subprocess.run", fake_run)
+
+    result = PiHarness().run(
+        task_id="task-001",
+        attempt=1,
+        prompt="Write a file",
+        skill_path=None,
+        model=None,
+        timeout=12,
+        isolated_home=str(tmp_path),
+    )
+
+    assert result.final_output == "All done."
+    assert [turn.role for turn in result.transcript] == [
+        "tool_use",
+        "tool_result",
+        "assistant",
+    ]
+    assert result.transcript[0].tool_name == "write"
+    # tool_input carries file paths so the cheat-detector can inspect them
+    assert result.transcript[0].tool_input == {"path": "notes.txt", "content": "HELLO"}
+    assert "Successfully wrote 5 bytes" in result.transcript[1].tool_output
+
+
+def test_pi_missing_cli_raises_configuration_error(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: None)
+    monkeypatch.delenv("PI_CLI_PATH", raising=False)
+
+    with pytest.raises(HarnessConfigurationError, match="pi CLI is not available"):
+        PiHarness().run(
+            task_id="task-001",
+            attempt=1,
+            prompt="Hello",
+            skill_path=None,
+            model=None,
+            timeout=12,
+            isolated_home=str(tmp_path),
+        )
+
+
+def test_pi_auth_failure_raises_configuration_error(monkeypatch, tmp_path) -> None:
+    def fake_run(cmd, **kwargs):
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr="Error: not authenticated. Please run /login."
+        )
+
+    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.pi.subprocess.run", fake_run)
+
+    with pytest.raises(HarnessConfigurationError, match="authentication"):
+        PiHarness().run(
+            task_id="task-001",
+            attempt=1,
+            prompt="Hello",
+            skill_path=None,
+            model=None,
+            timeout=12,
+            isolated_home=str(tmp_path),
+        )


### PR DESCRIPTION
Closes #9.

Adds a `pi` CLI-subprocess backend that drives the [pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) in non-interactive JSON mode, loading the skill-under-test natively via pi's `--skill` flag (the agentskills.io standard) — closer to `claude-code` than to `codex`'s prompt-injection.

## What's included
- **`caliper/harness/pi.py`** — `PiHarness`: runs `pi --print --mode json --no-session --approve [--model] [--skill] "<prompt>"`, copies `~/.pi/agent/{auth.json,settings.json}` verbatim into an isolated `PI_CODING_AGENT_DIR` (parallel-safe; never mutates real config), parses the JSONL event stream (`tool_execution_*`, `message_end`), and emits moderate auth/provider diagnostics.
- **Wiring** — `get_harness`, `BackendName`/`_VALID_BACKENDS`, the wizard, `caliper new`, `caliper update-cli pi`, `caliper install-skill pi` (`~/.pi/agent/skills/evaluate-skill/SKILL.md`).
- **Docs** — README (backend tables, pi setup, spec comments, troubleshooting), `evaluate-skill` + `grill-skill` references (+ packaged copies), and a new `CONTEXT.md` glossary.
- **Tests** — `tests/test_pi_harness.py` (5 tests) + `tests/pi-smoke.eval.yaml`.

## Design notes
- **Config copied verbatim, no model stripping.** The spec's `--model` overrides; an unspecified model falls back to the user's pi default. This matches `claude-code`; codex's config-model stripping is a deliberate legacy exception. Captured as a lightweight ADR in #10.
- **stdin closed + `--approve`.** Live testing revealed `pi --skill` silently blocks on a stdin trust prompt in `--print` mode; `stdin=DEVNULL` + `--approve` fixes it. (Only caught because skill loading was tested against the real CLI, not just mocked.)

## Testing
- Full suite: **66 passed** (incl. `test_install_skill.py` sync check).
- Live against a real pi CLI: file-writing task (tool call captured with path in `tool_input`), native `--skill` loading verified to change behavior, and full `caliper run tests/pi-smoke.eval.yaml` → **PASS 100%**.
- `install-skill pi --dry-run` and `update-cli pi --check` verified.