### PR TITLE
Add eval starter pack (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,6 @@ Use Caliper to answer questions like:
 
 ## Quick start
 
-> **New to evals?** Start with the **[Eval Starter Pack](examples/starter-pack/)** —
-> four copy-paste `.eval.yaml` templates, each catching a real agent failure
-> (false success, tool misuse, runaway loops, prompt regressions). Every
-> template runs green as-is against a bundled example, so you can prove your
-> setup works before changing a line, then point it at your own skill by editing
-> two or three commented lines.
-
 ### Path A — Agentic (let your agent drive)
 
 **1. Install the skills**
@@ -137,6 +130,14 @@ Delta          +43%   up
 
 Results saved to .caliper/results/my-skill/2026-06-19T14-23-01Z.json
 ```
+
+### Not sure what to put in a spec?
+
+The **[Eval Starter Pack](examples/starter-pack/)** has four copy-paste
+templates, each catching a real agent failure (false success, tool misuse,
+runaway loops, prompt regressions). Every template runs green as-is against a
+bundled example, then points at your own skill by editing two or three
+commented lines.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Use Caliper to answer questions like:
 
 ## Quick start
 
+> **New to evals?** Start with the **[Eval Starter Pack](examples/starter-pack/)** —
+> four copy-paste `.eval.yaml` templates, each catching a real agent failure
+> (false success, tool misuse, runaway loops, prompt regressions). Every
+> template runs green as-is against a bundled example, so you can prove your
+> setup works before changing a line, then point it at your own skill by editing
+> two or three commented lines.
+
 ### Path A — Agentic (let your agent drive)
 
 **1. Install the skills**

--- a/examples/starter-pack/01-false-success/SKILL.md
+++ b/examples/starter-pack/01-false-success/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: save-note
+description: Save a short note to a file. Use when asked to record, save, or jot down a note.
+---
+
+# Save note
+
+When the user asks you to save a note:
+
+1. Write the exact note text to the file path they give you.
+2. Confirm the absolute path you wrote to.
+
+Always create the file before reporting success. Never claim a note was
+saved unless you actually wrote it.

--- a/examples/starter-pack/01-false-success/false-success.eval.yaml
+++ b/examples/starter-pack/01-false-success/false-success.eval.yaml
@@ -1,0 +1,51 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# FAILURE MODE: FALSE SUCCESS
+#
+# An agent can confidently say "Done! I saved your note." without ever writing
+# the file. If you only grade the agent's final message, you'll be fooled.
+#
+# The fix: grade the INTENDED OUTCOME with `expect:` AND check the real SIDE
+# EFFECT with `assert:`. The assert reads the actual file — that's what catches
+# an agent that reports success it didn't earn.
+#
+# Run it as-is (it passes against the bundled save-note skill):
+#   caliper run false-success.eval.yaml --k 3
+# ─────────────────────────────────────────────────────────────────────────────
+
+skill:
+  # 👉 EDIT 1: point this at your own SKILL.md (or delete `path:` to test the
+  #            bare agent with no skill).
+  path: ./SKILL.md
+  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi | claude-api | openai-api
+  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
+
+judge:
+  backend: claude-code
+  model: claude-haiku-4-5-20251001
+
+tasks:
+  # 👉 EDIT 3: rename this task — it becomes the row label in your results.
+  - name: Actually writes the note it claims to have saved
+    # 👉 EDIT 4: the output path below appears in setup, cleanup, prompt, expect,
+    #            and assert — change it in every one. The setup/cleanup lines
+    #            start clean so a leftover file from a previous run can't fake a
+    #            pass — exactly the false success this template catches.
+    setup: rm -f /tmp/caliper-note.txt
+    cleanup: rm -f /tmp/caliper-note.txt
+    # 👉 EDIT 5: replace this prompt with a real request for your own agent.
+    prompt: "Save the note 'ship the release on Friday' to /tmp/caliper-note.txt"
+
+    # The self-report check: did the agent SAY it did the right thing?
+    expect: >
+      The agent reports that it saved the note to /tmp/caliper-note.txt.
+      It does not merely explain how to save a note or ask clarifying questions.
+
+    # The side-effect check: did it ACTUALLY happen? This line is the whole
+    # point — it fails a "Done!" message when the file isn't really there.
+    assert: |
+      from pathlib import Path
+
+      note = Path("/tmp/caliper-note.txt")
+      assert note.exists(), "Agent claimed success but the note file does not exist"
+      assert "ship the release on Friday" in note.read_text(), \
+          "Note file exists but is missing the requested text"

--- a/examples/starter-pack/02-tool-misuse/SKILL.md
+++ b/examples/starter-pack/02-tool-misuse/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: alert
+description: Send an operational alert. Use when asked to send an alert, page, or notification.
+---
+
+# Alert
+
+To send an alert, call the `notify` CLI:
+
+- Always pass `--channel ops`. Alerts must go to the ops channel — never the
+  default channel and never a personal channel.
+- Pass the alert message as the final argument.
+
+Example:
+
+```
+notify --channel ops "disk almost full on web-01"
+```
+
+Never send an alert without `--channel ops`.

--- a/examples/starter-pack/02-tool-misuse/bin/notify
+++ b/examples/starter-pack/02-tool-misuse/bin/notify
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Test double for a real "notify" CLI, used so this template runs without any
+# external service. It records the exact arguments it was called with, then
+# exits 0 as if the alert was delivered.
+#
+# When you point this template at your OWN agent, delete this fake and let the
+# agent call your real tool — then make the assert read your real side effect
+# (an API log, a row in a table, a sent message) instead of this file.
+
+# Document the interface so any agent (with or without the skill loaded) can
+# discover that alerts require --channel.
+if [[ "$1" == "--help" || "$1" == "-h" || $# -eq 0 ]]; then
+  cat <<'USAGE'
+notify — send an operational alert to a channel
+
+Usage:
+  notify --channel <name> "<message>"
+
+Alerts must specify a channel. Operational alerts go to: ops
+USAGE
+  exit 0
+fi
+
+# A real CLI rejects a missing required flag — so does this one. This keeps the
+# example deterministic: the agent is pushed to use --channel rather than
+# guessing a positional argument, so the only thing left to get wrong (and the
+# thing we assert on) is the channel VALUE.
+case " $* " in
+  *" --channel "*|*" --channel="*|*" -c "*) : ;;
+  *)
+    echo "ERROR: --channel <name> is required. See 'notify --help'." >&2
+    exit 2
+    ;;
+esac
+
+echo "$*" >> "${CALIPER_NOTIFY_LOG:-/tmp/caliper-notify-args.log}"
+echo "alert delivered"

--- a/examples/starter-pack/02-tool-misuse/tool-misuse.eval.yaml
+++ b/examples/starter-pack/02-tool-misuse/tool-misuse.eval.yaml
@@ -1,0 +1,59 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# FAILURE MODE: TOOL MISUSE
+#
+# "The agent called the tool" is not enough. A misused tool fires with the
+# WRONG arguments — alerts the wrong channel, deploys to prod instead of
+# staging, emails the wrong list. The tool ran; the outcome is still wrong.
+#
+# The fix: assert on the tool-call ARGUMENTS, not just that the tool fired.
+# Here a tiny logging wrapper (./bin/notify) records every argument the agent
+# passes, and the assert checks that the alert went to the `ops` channel.
+#
+# Run it as-is (it passes against the bundled alert skill):
+#   caliper run tool-misuse.eval.yaml --k 3
+# ─────────────────────────────────────────────────────────────────────────────
+
+skill:
+  # 👉 EDIT 1: point this at your own SKILL.md.
+  path: ./SKILL.md
+  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi | claude-api | openai-api
+  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
+
+judge:
+  backend: claude-code
+  model: claude-haiku-4-5-20251001
+
+sandbox:
+  # Puts the fake `notify` CLI on PATH inside each attempt. When testing your
+  # own agent, drop this and let it call your real tool.
+  extra_path:
+    - ./bin
+
+tasks:
+  # 👉 EDIT 3: rename this task — it becomes the row label in your results.
+  - name: Sends the alert to the required ops channel
+    # setup/cleanup clear the wrapper's argument log between attempts. When you
+    # switch to your own tool, point these (and the assert) at your real signal.
+    setup: rm -f /tmp/caliper-notify-args.log
+    cleanup: rm -f /tmp/caliper-notify-args.log
+    # 👉 EDIT 4: replace with a real request that should trigger your tool.
+    #            (Name the tool so the agent reaches for it — the skill's job is
+    #            to enforce the *right arguments*, which is what we assert on.)
+    prompt: >
+      Use the notify CLI to send an alert to the ops channel that the disk is
+      almost full on web-01.
+
+    # The argument check: the tool must have been called for the `ops` channel.
+    # A bare "did notify run?" check would pass even if the alert went nowhere
+    # useful. We read the recorded arguments and accept any flag spelling
+    # (--channel ops, --channel=ops, -c ops) — what matters is the value, and a
+    # wrong channel is the actual misuse this catches.
+    assert: |
+      import re
+      from pathlib import Path
+
+      log = Path("/tmp/caliper-notify-args.log")
+      assert log.exists(), "The notify tool was never called"
+      calls = log.read_text()
+      assert re.search(r"(--channel[ =]|-c )ops\b", calls), \
+          f"notify was called, but not for the ops channel. Calls: {calls!r}"

--- a/examples/starter-pack/03-runaway-loops/SKILL.md
+++ b/examples/starter-pack/03-runaway-loops/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: resilient-fetch
+description: Fetch data with a strict retry budget. Use when asked to fetch data that may be unavailable.
+---
+
+# Resilient fetch
+
+Use the `flaky-fetch` CLI to fetch the data the user asks for.
+
+Retry budget — this is a hard rule:
+
+- Call `flaky-fetch` **at most 3 times**.
+- If it still fails after 3 attempts, **STOP** and report that the source is
+  unavailable. Do not keep retrying.
+- An `HTTP 404 - permanent` error means retrying will never help. Report it and
+  stop immediately; do not use up the rest of the budget.

--- a/examples/starter-pack/03-runaway-loops/bin/flaky-fetch
+++ b/examples/starter-pack/03-runaway-loops/bin/flaky-fetch
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Test double for an unreliable data source. It ALWAYS fails with a permanent
+# error and records each call, so the eval can count how many times the agent
+# retried before giving up.
+#
+# When you point this template at your own agent, replace this with whatever
+# tool or step you want to bound, and make the assert count your real signal.
+echo "called $(date +%s%N)" >> "${CALIPER_FETCH_LOG:-/tmp/caliper-fetch-calls.log}"
+echo "ERROR: source unavailable (HTTP 404 - permanent)" >&2
+exit 1

--- a/examples/starter-pack/03-runaway-loops/runaway-loops.eval.yaml
+++ b/examples/starter-pack/03-runaway-loops/runaway-loops.eval.yaml
@@ -1,0 +1,56 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# FAILURE MODE: RUNAWAY LOOPS
+#
+# An agent that hits a failing step can retry forever — burning tokens, time,
+# and money while making no progress. You want it to give up after a sensible
+# number of tries.
+#
+# The fix, two layers:
+#   1. `--timeout` bounds wall-clock time per attempt (a backstop).
+#   2. The sharper signal is STEP COUNT. Here a wrapper (./bin/flaky-fetch)
+#      always fails and logs every call; the assert fails if the agent looped
+#      past its budget of 3 calls.
+#
+# Run it as-is (it passes against the bundled resilient-fetch skill):
+#   caliper run runaway-loops.eval.yaml --k 3 --timeout 90
+# ─────────────────────────────────────────────────────────────────────────────
+
+skill:
+  # 👉 EDIT 1: point this at your own SKILL.md.
+  path: ./SKILL.md
+  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi | claude-api | openai-api
+  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
+
+judge:
+  backend: claude-code
+  model: claude-haiku-4-5-20251001
+
+sandbox:
+  extra_path:
+    - ./bin
+
+tasks:
+  # 👉 EDIT 3: rename this task — it becomes the row label in your results.
+  - name: Stops retrying within the budget instead of looping forever
+    setup: rm -f /tmp/caliper-fetch-calls.log
+    cleanup: rm -f /tmp/caliper-fetch-calls.log
+    # 👉 EDIT 4: replace with a real request that exercises your retry path.
+    prompt: >
+      Run the command `flaky-fetch metrics` to fetch the latest metrics, then
+      tell me what happened.
+
+    # The self-report check: the agent must not lie about succeeding. Kept
+    # lenient on purpose — the real demonstration is the budget assert below.
+    expect: >
+      The agent does not claim it successfully fetched the data. (The source is
+      unavailable, so a correct answer reports the failure.)
+
+    # The budget check: count the calls. This is what catches a runaway loop —
+    # 👉 EDIT 5 (optional): raise/lower the budget to match your own tool.
+    assert: |
+      from pathlib import Path
+
+      log = Path("/tmp/caliper-fetch-calls.log")
+      calls = log.read_text().strip().splitlines() if log.exists() else []
+      assert len(calls) <= 3, \
+          f"Agent exceeded its retry budget: {len(calls)} calls (budget is 3)"

--- a/examples/starter-pack/04-prompt-regression/SKILL.md
+++ b/examples/starter-pack/04-prompt-regression/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: slugify
+description: Convert a title into a URL slug. Use when asked to slugify a title or make a URL slug.
+---
+
+# Slugify
+
+Turn a title into a URL slug with these rules, in order:
+
+1. Trim leading and trailing whitespace.
+2. Lowercase everything.
+3. Remove any character that is not a letter, digit, space, or hyphen.
+4. Replace each run of spaces with a single hyphen.
+
+Write **only** the resulting slug to the file path you are given — no quotes,
+no surrounding text, no trailing newline beyond the slug itself.

--- a/examples/starter-pack/04-prompt-regression/prompt-regression.eval.yaml
+++ b/examples/starter-pack/04-prompt-regression/prompt-regression.eval.yaml
@@ -1,0 +1,58 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# FAILURE MODE: PROMPT REGRESSIONS
+#
+# You tweak a prompt to fix one case — and silently break three others that
+# used to work. Regressions hide because nobody re-checks the old cases.
+#
+# The fix: keep a small, FIXED set of cases that already work and re-run it on
+# every prompt change. These aren't adversarial edge cases; they're your
+# baseline. When one flips from green to red, your last edit caused it.
+#
+# Each case uses a deterministic `assert:` (exact expected output) so a pass is
+# unambiguous — no LLM judgment, no flakiness.
+#
+# Run it as-is (all four pass against the bundled slugify skill):
+#   caliper run prompt-regression.eval.yaml --k 3
+# Re-run it after every edit to your prompt/SKILL.md and watch for reds.
+# ─────────────────────────────────────────────────────────────────────────────
+
+skill:
+  # 👉 EDIT 1: point this at your own SKILL.md.
+  path: ./SKILL.md
+  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi | claude-api | openai-api
+  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
+
+judge:
+  backend: claude-code
+  model: claude-haiku-4-5-20251001
+
+# 👉 EDIT 3: replace these four cases with the fixed set that matters for your
+#            skill. Keep them simple and unambiguous — they are your tripwire.
+tasks:
+  - name: Basic two-word title
+    cleanup: rm -f /tmp/caliper-slug-1.txt
+    prompt: "Slugify 'Hello World' and write the result to /tmp/caliper-slug-1.txt"
+    assert: |
+      from pathlib import Path
+      assert Path("/tmp/caliper-slug-1.txt").read_text().strip() == "hello-world"
+
+  - name: Multi-word title
+    cleanup: rm -f /tmp/caliper-slug-2.txt
+    prompt: "Slugify 'The Quick Brown Fox' and write the result to /tmp/caliper-slug-2.txt"
+    assert: |
+      from pathlib import Path
+      assert Path("/tmp/caliper-slug-2.txt").read_text().strip() == "the-quick-brown-fox"
+
+  - name: Strips punctuation
+    cleanup: rm -f /tmp/caliper-slug-3.txt
+    prompt: "Slugify 'Report: Q3 2026!' and write the result to /tmp/caliper-slug-3.txt"
+    assert: |
+      from pathlib import Path
+      assert Path("/tmp/caliper-slug-3.txt").read_text().strip() == "report-q3-2026"
+
+  - name: Collapses padding and extra spaces
+    cleanup: rm -f /tmp/caliper-slug-4.txt
+    prompt: "Slugify '  Padded   Title  ' and write the result to /tmp/caliper-slug-4.txt"
+    assert: |
+      from pathlib import Path
+      assert Path("/tmp/caliper-slug-4.txt").read_text().strip() == "padded-title"

--- a/examples/starter-pack/README.md
+++ b/examples/starter-pack/README.md
@@ -1,0 +1,121 @@
+# Caliper Eval Starter Pack
+
+Four copy-paste eval templates that take you from install to a real,
+running eval in about five minutes. Each one targets a specific way agents
+fail — and each one runs **green as-is** against a tiny bundled example, so you
+can prove your setup works before you change a single line.
+
+## Before you start
+
+Install the CLI and make sure your agent backend is authenticated:
+
+```bash
+pipx install caliper-eval        # or: pip install caliper-eval
+```
+
+The templates default to the `claude-code` backend. If you use a different
+agent, change the `backend:` line in any template (see
+[Choosing a backend](../../README.md#choosing-a-backend)).
+
+Two terms you'll see in every template:
+
+- **`expect:`** is graded by an LLM judge that reads the run's transcript.
+  **`assert:`** is plain Python that runs against the real side effect (a file,
+  a log, command output). When both are present, both must pass.
+- **`--k N`** runs each task `N` times; **pass@k** is the resulting reliability
+  score — what fraction of runs succeeded, not whether one lucky run passed.
+
+## The four templates
+
+| # | Template | The failure it catches |
+|---|----------|------------------------|
+| 1 | [`01-false-success`](01-false-success/false-success.eval.yaml) | The agent says "Done!" but never did the work. |
+| 2 | [`02-tool-misuse`](02-tool-misuse/tool-misuse.eval.yaml) | The agent calls the right tool with the **wrong arguments**. |
+| 3 | [`03-runaway-loops`](03-runaway-loops/runaway-loops.eval.yaml) | The agent retries forever, burning time and tokens. |
+| 4 | [`04-prompt-regression`](04-prompt-regression/prompt-regression.eval.yaml) | A prompt edit silently breaks cases that used to pass. |
+
+### 1. False success — *grade the outcome, not the bragging*
+
+An agent can confidently report success it never earned. If you only read its
+final message, you'll believe it. This template grades the intended outcome
+with `expect:` **and** checks the real side effect with `assert:` — the assert
+reads the actual file, which is what catches the lie.
+
+**Reach for it when** your skill is supposed to *produce* something — a file, a
+commit, a database row, an API call.
+
+### 2. Tool misuse — *check the arguments, not just that the tool fired*
+
+"The agent called the tool" is not success. A misused tool fires with the wrong
+arguments: deploys to prod instead of staging, alerts the wrong channel, emails
+the wrong list. This template puts a tiny logging wrapper on `PATH` that records
+every argument, then asserts on the arguments that matter.
+
+**Reach for it when** your skill drives a tool where the *parameters* are the
+whole point.
+
+### 3. Runaway loops — *bound the step count*
+
+An agent stuck on a failing step can loop forever. `--timeout` caps wall-clock
+time as a backstop, but the sharper signal is **how many steps** it took. This
+template gives the agent a tool that always fails plus a rule to stop after a
+budget, and asserts that it didn't blow past the budget.
+
+**Reach for it when** your skill has retries, polling, or any loop that could
+run away.
+
+### 4. Prompt regressions — *a fixed set you re-run on every change*
+
+You fix one case and silently break three others. This template is a small,
+fixed set of cases that already work, each with a deterministic `assert:`.
+Re-run it after every prompt edit; when a case flips from green to red, your
+last change caused a regression.
+
+**Reach for it when** you're actively editing a prompt or `SKILL.md` and want a
+tripwire.
+
+## Run them
+
+Each template runs from its own folder. From the repo:
+
+```bash
+cd examples/starter-pack/01-false-success
+caliper run false-success.eval.yaml --k 3
+```
+
+You should see all tasks pass. That confirms Caliper is wired up correctly —
+the CLI, your backend auth, and the judge all work end to end.
+
+Do the same for the other three:
+
+```bash
+cd ../02-tool-misuse      && caliper run tool-misuse.eval.yaml --k 3
+cd ../03-runaway-loops    && caliper run runaway-loops.eval.yaml --k 3 --timeout 90
+cd ../04-prompt-regression && caliper run prompt-regression.eval.yaml --k 3
+```
+
+## Point a template at your own agent
+
+Each template marks the lines you edit with a `👉 EDIT` comment — follow the
+numbered markers and you'll catch every line that needs changing (watch for the
+side-effect path, which can appear in `setup`, `cleanup`, `prompt`, and
+`assert` at once). The edits boil down to:
+
+1. **`skill.path`** — point it at your own `SKILL.md` (or delete it to test the
+   bare agent with no skill).
+2. **`skill.backend`** — your agent: `claude-code`, `codex`, `pi`, `claude-api`,
+   or `openai-api`.
+3. **`tasks[].prompt`** (and the matching `expect:`/`assert:`) — describe a real
+   request and what a correct result looks like for *your* skill.
+
+For templates 2 and 3, the fake tool under `bin/` is a stand-in so the example
+runs without any external service. When you switch to your own agent, delete the
+fake and point the `assert:` at your real side effect instead.
+
+## What's a good next step?
+
+- Add `--baseline` to prove the skill is doing the work, not the base agent:
+  `caliper run false-success.eval.yaml --k 3 --baseline`.
+- Commit your edited template next to your skill so contributors run the same eval.
+- See the [main README](../../README.md) for the full spec format, judging, and
+  CLI reference, or use `/grill-skill` to generate a spec interactively.


### PR DESCRIPTION
Closes #13.

## What this adds

A copy-paste **Eval Starter Pack** under [`examples/starter-pack/`](examples/starter-pack/) that takes a newcomer from install to a real, running eval in ~5 minutes. Four heavily-commented `.eval.yaml` templates, one per common agent failure mode, each runnable **green as-is** against a tiny bundled example skill (proof the setup is wired before changing a line).

| Template | Failure it catches |
|---|---|
| `01-false-success` | Agent says "Done!" but never did the work — graded against the real side effect, not the self-report. |
| `02-tool-misuse` | Agent calls the right tool with the **wrong arguments** — asserts on the recorded call. |
| `03-runaway-loops` | Agent retries forever — bounds the step count via a call-counting wrapper + `--timeout`. |
| `04-prompt-regression` | A prompt edit silently breaks cases that used to pass — a fixed deterministic case set. |

Each template flags the 2–3 lines a user edits (`👉 EDIT` markers) to point it at their own agent. A `starter-pack/README.md` explains each failure mode in plain language, and the main README quick start links the pack as a single shareable URL (for the LinkedIn "EVAL" CTA).

## Design notes

- Templates 2 and 3 ship a tiny fake CLI under `bin/` (on `extra_path`) so they run with no external service. `notify` rejects a missing `--channel` flag like a real CLI would, and the asserts accept any flag spelling — this keeps the bundled runs deterministic regardless of how the agent phrases the call.
- The bundled examples default to `claude-haiku-4-5-20251001` for speed/cost; the model line is commented as optional.

## Verification

All four validated and run green against the bundled examples on the `claude-code` backend (haiku):

- `01-false-success` — 4/4
- `02-tool-misuse` — 6/6
- `03-runaway-loops` — 6/6 (`--timeout 90`)
- `04-prompt-regression` — 4/4 across all four cases

Also dry-run tested by a simulated newcomer who, using only the starter-pack README, proved wiring and pointed `01-false-success` at a fresh toy skill by editing only the marked lines; their feedback (define `--k`/`pass@k` locally, clarify `expect:` vs `assert:`, mark the `setup`/`cleanup`/task-name lines that share the side-effect path) is incorporated.

## Acceptance criteria

- [x] All four templates run green against the bundled examples via the documented CLI command.
- [x] A first-time user can point a template at their own agent by editing only the commented lines.
- [x] README explains each failure mode in plain language.
- [x] Single shareable link to the pack (linked from main README).