### PR TITLE
Add context boundary eval starter

### DIFF
--- a/examples/starter-pack/05-context-boundary/SKILL.md
+++ b/examples/starter-pack/05-context-boundary/SKILL.md
@@ -31,3 +31,5 @@ Rules:
 3. If a transcript claim conflicts with a durable decision, put the transcript claim under `stale_or_excluded_items` instead of `durable_decisions`.
 4. Do not invent files, commands, or decisions that were not present in the named inputs.
 5. Write only valid JSON to the requested output file.
+6. Write the JSON file to the requested path *before* you report anything. Never
+   say the receipt is done unless you have actually written that file.

--- a/examples/starter-pack/05-context-boundary/SKILL.md
+++ b/examples/starter-pack/05-context-boundary/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: context-boundary-reporter
+description: Write a machine-checkable context boundary receipt from provided project context files.
+---
+
+# Context Boundary Reporter
+
+When asked to produce a context boundary receipt, inspect only the files named in the request and write JSON to the requested output path.
+
+Use this exact shape:
+
+```json
+{
+  "loaded_context": [
+    {"ref": "path", "kind": "instructions|decision|transcript", "authority": "durable|ephemeral"}
+  ],
+  "durable_decisions": [
+    {"decision": "...", "source_ref": "...", "supersedes": ["..."]}
+  ],
+  "stale_or_excluded_items": [
+    {"item": "...", "source_ref": "...", "reason": "..."}
+  ],
+  "verification_path": ["..."]
+}
+```
+
+Rules:
+
+1. Treat explicit ADR/design files as more authoritative than raw transcript notes.
+2. Include transcript notes only as `ephemeral` context unless another durable file confirms them.
+3. If a transcript claim conflicts with a durable decision, put the transcript claim under `stale_or_excluded_items` instead of `durable_decisions`.
+4. Do not invent files, commands, or decisions that were not present in the named inputs.
+5. Write only valid JSON to the requested output file.

--- a/examples/starter-pack/05-context-boundary/context-boundary.eval.yaml
+++ b/examples/starter-pack/05-context-boundary/context-boundary.eval.yaml
@@ -1,0 +1,119 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# FAILURE MODE: STALE CONTEXT BECOMES AUTHORITY
+#
+# Agents often load a mix of instructions, durable decisions, and old chat or
+# transcript snippets. The failure is not "no context" — it is treating an old
+# ephemeral note as if it were the current source of truth.
+#
+# The fix: require a small context boundary receipt that names what was loaded,
+# which sources were authoritative, which stale claims were excluded, and how a
+# future step should verify the decision before acting.
+#
+# Run it as-is against the bundled context-boundary-reporter skill:
+#   caliper run context-boundary.eval.yaml --k 3
+# ─────────────────────────────────────────────────────────────────────────────
+
+skill:
+  # 👉 EDIT 1: point this at your own SKILL.md.
+  path: ./SKILL.md
+  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi | claude-api | openai-api
+  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
+
+judge:
+  backend: claude-code
+  model: claude-haiku-4-5-20251001
+
+tasks:
+  - name: Excludes stale transcript claim when ADR supersedes it
+    setup: |
+      rm -rf /tmp/caliper-context-boundary
+      mkdir -p /tmp/caliper-context-boundary
+      cat > /tmp/caliper-context-boundary/CLAUDE.md <<'EOF'
+      # Project instructions
+      Use the documented storage backend from ADR files. Do not rely on old transcript notes for architecture decisions.
+      EOF
+      cat > /tmp/caliper-context-boundary/ADR-001.md <<'EOF'
+      # ADR-001: Storage backend
+      Decision: Use Postgres for production storage.
+      Supersedes: early prototype notes that mentioned SQLite.
+      Verification: run `pytest tests/storage` before changing persistence code.
+      EOF
+      cat > /tmp/caliper-context-boundary/transcript.txt <<'EOF'
+      2026-06-01 old chat note: maybe use SQLite because it is simple.
+      EOF
+    cleanup: rm -rf /tmp/caliper-context-boundary
+    prompt: |
+      Produce a context boundary receipt at /tmp/caliper-context-boundary/receipt.json.
+      Inspect these inputs only:
+      - /tmp/caliper-context-boundary/CLAUDE.md
+      - /tmp/caliper-context-boundary/ADR-001.md
+      - /tmp/caliper-context-boundary/transcript.txt
+    expect: >
+      The receipt treats ADR-001 as the durable source of truth, records Postgres
+      as the current production storage decision, excludes the old SQLite
+      transcript note as stale or superseded, and includes a verification path
+      based on running the storage tests.
+    assert: |
+      import json
+      from pathlib import Path
+
+      receipt_path = Path('/tmp/caliper-context-boundary/receipt.json')
+      assert receipt_path.exists(), 'receipt.json was not created'
+      data = json.loads(receipt_path.read_text())
+
+      loaded_refs = {item['ref'] for item in data['loaded_context']}
+      assert '/tmp/caliper-context-boundary/CLAUDE.md' in loaded_refs
+      assert '/tmp/caliper-context-boundary/ADR-001.md' in loaded_refs
+      assert '/tmp/caliper-context-boundary/transcript.txt' in loaded_refs
+
+      durable_text = json.dumps(data['durable_decisions']).lower()
+      assert 'postgres' in durable_text
+      assert 'sqlite' not in durable_text, 'stale SQLite claim became a durable decision'
+
+      excluded_text = json.dumps(data['stale_or_excluded_items']).lower()
+      assert 'sqlite' in excluded_text
+      assert 'supersede' in excluded_text or 'stale' in excluded_text
+
+      verify_text = json.dumps(data['verification_path']).lower()
+      assert 'pytest tests/storage' in verify_text
+
+  - name: Does not invent unseen context sources
+    setup: |
+      rm -rf /tmp/caliper-context-boundary
+      mkdir -p /tmp/caliper-context-boundary
+      cat > /tmp/caliper-context-boundary/AGENTS.md <<'EOF'
+      # Agent instructions
+      Before editing billing code, verify provider limits and rollback notes.
+      EOF
+      cat > /tmp/caliper-context-boundary/release-note.md <<'EOF'
+      # Release note
+      Provider API v3 is the current supported billing API.
+      Verification: run `npm test -- billing` and check staging webhook logs.
+      EOF
+    cleanup: rm -rf /tmp/caliper-context-boundary
+    prompt: |
+      Produce a context boundary receipt at /tmp/caliper-context-boundary/receipt.json.
+      Inspect these inputs only:
+      - /tmp/caliper-context-boundary/AGENTS.md
+      - /tmp/caliper-context-boundary/release-note.md
+    expect: >
+      The receipt names only the two provided files as loaded context, identifies
+      provider API v3 as the durable production fact, and does not claim that a
+      transcript, dashboard, ticket, or human confirmation was loaded.
+    assert: |
+      import json
+      from pathlib import Path
+
+      data = json.loads(Path('/tmp/caliper-context-boundary/receipt.json').read_text())
+      loaded_refs = {item['ref'] for item in data['loaded_context']}
+      assert loaded_refs == {
+          '/tmp/caliper-context-boundary/AGENTS.md',
+          '/tmp/caliper-context-boundary/release-note.md',
+      }
+
+      full_text = json.dumps(data).lower()
+      assert 'api v3' in full_text
+      for forbidden in ['transcript', 'dashboard', 'ticket', 'human confirmation']:
+          assert forbidden not in full_text, f'invented unseen source: {forbidden}'
+      assert 'npm test -- billing' in full_text
+      assert 'staging webhook logs' in full_text

--- a/examples/starter-pack/05-context-boundary/context-boundary.eval.yaml
+++ b/examples/starter-pack/05-context-boundary/context-boundary.eval.yaml
@@ -61,14 +61,22 @@ tasks:
       assert receipt_path.exists(), 'receipt.json was not created'
       data = json.loads(receipt_path.read_text())
 
-      loaded_refs = {item['ref'] for item in data['loaded_context']}
-      assert '/tmp/caliper-context-boundary/CLAUDE.md' in loaded_refs
-      assert '/tmp/caliper-context-boundary/ADR-001.md' in loaded_refs
-      assert '/tmp/caliper-context-boundary/transcript.txt' in loaded_refs
+      # Match on basename so the agent may spell refs as absolute, relative,
+      # or bare filenames — what matters is that each input was named.
+      loaded_names = {item['ref'].rsplit('/', 1)[-1] for item in data['loaded_context']}
+      assert 'CLAUDE.md' in loaded_names
+      assert 'ADR-001.md' in loaded_names
+      assert 'transcript.txt' in loaded_names
 
-      durable_text = json.dumps(data['durable_decisions']).lower()
-      assert 'postgres' in durable_text
-      assert 'sqlite' not in durable_text, 'stale SQLite claim became a durable decision'
+      # Inspect only the decision text, not the whole block: a correct receipt
+      # legitimately mentions SQLite under `supersedes` (the ADR supersedes the
+      # old SQLite notes). What must NOT happen is SQLite being the decision.
+      decision_text = ' '.join(
+          str(d.get('decision', d)) if isinstance(d, dict) else str(d)
+          for d in data['durable_decisions']
+      ).lower()
+      assert 'postgres' in decision_text
+      assert 'sqlite' not in decision_text, 'stale SQLite claim became the durable decision'
 
       excluded_text = json.dumps(data['stale_or_excluded_items']).lower()
       assert 'sqlite' in excluded_text
@@ -105,11 +113,10 @@ tasks:
       from pathlib import Path
 
       data = json.loads(Path('/tmp/caliper-context-boundary/receipt.json').read_text())
-      loaded_refs = {item['ref'] for item in data['loaded_context']}
-      assert loaded_refs == {
-          '/tmp/caliper-context-boundary/AGENTS.md',
-          '/tmp/caliper-context-boundary/release-note.md',
-      }
+      # Exactly the two provided files, matched by basename — no more (which
+      # would mean an invented source), no fewer.
+      loaded_names = {item['ref'].rsplit('/', 1)[-1] for item in data['loaded_context']}
+      assert loaded_names == {'AGENTS.md', 'release-note.md'}
 
       full_text = json.dumps(data).lower()
       assert 'api v3' in full_text

--- a/examples/starter-pack/README.md
+++ b/examples/starter-pack/README.md
@@ -1,6 +1,6 @@
 # Caliper Eval Starter Pack
 
-Four copy-paste eval templates that take you from install to a real,
+Five copy-paste eval templates that take you from install to a real,
 running eval in about five minutes. Each one targets a specific way agents
 fail — and each one runs **green as-is** against a tiny bundled example, so you
 can prove your setup works before you change a single line.
@@ -25,7 +25,7 @@ Two terms you'll see in every template:
 - **`--k N`** runs each task `N` times; **pass@k** is the resulting reliability
   score — what fraction of runs succeeded, not whether one lucky run passed.
 
-## The four templates
+## The five templates
 
 | # | Template | The failure it catches |
 |---|----------|------------------------|
@@ -33,6 +33,7 @@ Two terms you'll see in every template:
 | 2 | [`02-tool-misuse`](02-tool-misuse/tool-misuse.eval.yaml) | The agent calls the right tool with the **wrong arguments**. |
 | 3 | [`03-runaway-loops`](03-runaway-loops/runaway-loops.eval.yaml) | The agent retries forever, burning time and tokens. |
 | 4 | [`04-prompt-regression`](04-prompt-regression/prompt-regression.eval.yaml) | A prompt edit silently breaks cases that used to pass. |
+| 5 | [`05-context-boundary`](05-context-boundary/context-boundary.eval.yaml) | Old chat/transcript context gets treated as current truth. |
 
 ### 1. False success — *grade the outcome, not the bragging*
 
@@ -74,6 +75,17 @@ last change caused a regression.
 **Reach for it when** you're actively editing a prompt or `SKILL.md` and want a
 tripwire.
 
+### 5. Context boundary — *separate durable facts from stale notes*
+
+Agents do not only fail by missing context. They also fail by treating an old
+chat note, transcript snippet, or one-off assumption as if it were the current
+source of truth. This template asks the skill to write a small JSON receipt that
+names the loaded files, durable decisions, excluded stale claims, and the
+verification path.
+
+**Reach for it when** your skill loads memory, transcripts, ADRs, release notes,
+or team context and must prove what was actually authoritative before acting.
+
 ## Run them
 
 Each template runs from its own folder. From the repo:
@@ -90,8 +102,9 @@ Do the same for the other three:
 
 ```bash
 cd ../02-tool-misuse      && caliper run tool-misuse.eval.yaml --k 3
-cd ../03-runaway-loops    && caliper run runaway-loops.eval.yaml --k 3 --timeout 90
+cd ../03-runaway-loops     && caliper run runaway-loops.eval.yaml --k 3 --timeout 90
 cd ../04-prompt-regression && caliper run prompt-regression.eval.yaml --k 3
+cd ../05-context-boundary  && caliper run context-boundary.eval.yaml --k 3
 ```
 
 ## Point a template at your own agent

--- a/examples/starter-pack/README.md
+++ b/examples/starter-pack/README.md
@@ -79,9 +79,14 @@ tripwire.
 
 Agents do not only fail by missing context. They also fail by treating an old
 chat note, transcript snippet, or one-off assumption as if it were the current
-source of truth. This template asks the skill to write a small JSON receipt that
-names the loaded files, durable decisions, excluded stale claims, and the
-verification path.
+source of truth. The lesson this template teaches is to **prove what was
+actually authoritative before acting** — separating durable facts from stale
+notes instead of trusting whatever was loaded most recently.
+
+The bundled example does this by asking the skill to emit a small JSON receipt
+naming the loaded files, durable decisions, excluded stale claims, and the
+verification path — but that shape is just one way to make the boundary
+checkable. Adapt the assertion to whatever your own skill produces.
 
 **Reach for it when** your skill loads memory, transcripts, ADRs, release notes,
 or team context and must prove what was actually authoritative before acting.
@@ -98,10 +103,10 @@ caliper run false-success.eval.yaml --k 3
 You should see all tasks pass. That confirms Caliper is wired up correctly —
 the CLI, your backend auth, and the judge all work end to end.
 
-Do the same for the other three:
+Do the same for the other four:
 
 ```bash
-cd ../02-tool-misuse      && caliper run tool-misuse.eval.yaml --k 3
+cd ../02-tool-misuse       && caliper run tool-misuse.eval.yaml --k 3
 cd ../03-runaway-loops     && caliper run runaway-loops.eval.yaml --k 3 --timeout 90
 cd ../04-prompt-regression && caliper run prompt-regression.eval.yaml --k 3
 cd ../05-context-boundary  && caliper run context-boundary.eval.yaml --k 3


### PR DESCRIPTION
Adds a fifth starter-pack template for a common skills/context failure mode: old transcript or chat context being treated as durable truth.

The example bundles a tiny `context-boundary-reporter` skill plus a Caliper eval that checks:

- loaded context files are named explicitly
- durable ADR/release-note facts win over stale transcript notes
- stale claims are excluded rather than promoted
- verification paths are preserved
- the agent does not invent unseen context sources

Validation I could run in this environment:

- `python3 -c "import yaml; ..."` on the new eval spec
- `git diff --check`

I could not run `pytest` or `caliper validate` here because this runner does not have `pytest`, `pip`, or the project dependencies such as `typer` installed.