### PR TITLE
Stage skill directory into runs so referenced files resolve (#19)

### DIFF
--- a/caliper/harness/pi.py
+++ b/caliper/harness/pi.py
@@ -130,7 +130,11 @@ class PiHarness(HarnessBackend):
         if model:
             cmd += ["--model", model]
         if skill_path:
-            skill_src = Path(skill_path).expanduser()
+            # Prefer the staged copy in the run's cwd (siblings staged alongside,
+            # cheat surfaces excluded) over the real skill dir; fall back to the
+            # original path when nothing was staged (e.g. a lone command file).
+            staged = Path(isolated_home) / "SKILL.md"
+            skill_src = staged if staged.exists() else Path(skill_path).expanduser()
             if skill_src.exists():
                 cmd += ["--skill", str(skill_src)]
         cmd.append(prompt)

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -167,6 +167,10 @@ def _run_attempt(
             for p in spec.sandbox.extra_path
         ]
         skill_path = _resolve_skill_path(spec, spec_path) if with_skill else None
+        if skill_path:
+            _stage_skill_directory(
+                skill_path, tmp_dir, list(spec.sandbox.forbidden_files)
+            )
         attempt_result = harness.run(
             task_id=task.id,
             attempt=attempt,
@@ -244,6 +248,61 @@ def _resolve_skill_path(spec: EvalSpec, spec_path: Path) -> str | None:
     if not path.is_absolute():
         path = spec_path.parent / path
     return str(path.resolve())
+
+
+# Directories never staged into a run: results (cheat surface), VCS, caches.
+_STAGE_EXCLUDE_DIRS = {".caliper", ".git", "__pycache__", "node_modules", ".venv"}
+# Per-file cap so a stray large fixture or binary can't bloat every attempt.
+_STAGE_MAX_FILE_BYTES = 5 * 1024 * 1024
+
+
+def _stage_skill_directory(
+    skill_path: str, isolated_home: str, forbidden_files: list[str]
+) -> None:
+    """Copy a directory-based skill's sibling files into the run's working dir.
+
+    Real Claude Code / Codex install a skill as a *directory*, but the harnesses
+    only inject ``SKILL.md``'s text, so relative pointers like
+    ``[REFERENCE.md](REFERENCE.md)`` and ``references/`` were unreachable during a
+    run (see issue #19). Every CLI backend runs the agent with ``cwd`` set to
+    ``isolated_home``; staging the skill directory's contents there makes those
+    pointers resolve — one copy fixes ``claude-code``, ``codex`` and ``pi`` at once.
+
+    Only a real skill *directory* is staged: we key off a file named ``SKILL.md``.
+    A lone slash-command ``.md`` file has no skill directory and is left alone (so
+    we never slurp an arbitrary parent repo into the run).
+
+    Cheat surfaces are never staged: the ``.eval.yaml`` spec, ``.caliper/``
+    results, and anything the spec marks ``forbidden_files`` are all skipped, so
+    staging cannot leak the answer key even if the agent reads what it finds.
+    """
+    src = Path(skill_path)
+    if src.name != "SKILL.md" or not src.exists():
+        return
+
+    skill_dir = src.parent
+    home = Path(isolated_home)
+    forbidden = [re.compile(p) for p in forbidden_files]
+
+    for item in sorted(skill_dir.rglob("*")):
+        if not item.is_file():
+            continue
+        rel = item.relative_to(skill_dir)
+        if any(part in _STAGE_EXCLUDE_DIRS for part in rel.parts):
+            continue
+        if item.name.endswith(".eval.yaml"):
+            continue
+        rel_posix = rel.as_posix()
+        if any(r.search(rel_posix) or r.search("./" + rel_posix) for r in forbidden):
+            continue
+        try:
+            if item.stat().st_size > _STAGE_MAX_FILE_BYTES:
+                continue
+        except OSError:
+            continue
+        dst = home / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, dst)
 
 
 class _CheatDetector:

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -259,22 +259,20 @@ _STAGE_MAX_FILE_BYTES = 5 * 1024 * 1024
 def _stage_skill_directory(
     skill_path: str, isolated_home: str, forbidden_files: list[str]
 ) -> None:
-    """Copy a directory-based skill's sibling files into the run's working dir.
+    """Stage a directory-based skill's files into the run's working dir.
 
-    Real Claude Code / Codex install a skill as a *directory*, but the harnesses
-    only inject ``SKILL.md``'s text, so relative pointers like
-    ``[REFERENCE.md](REFERENCE.md)`` and ``references/`` were unreachable during a
-    run (see issue #19). Every CLI backend runs the agent with ``cwd`` set to
-    ``isolated_home``; staging the skill directory's contents there makes those
-    pointers resolve — one copy fixes ``claude-code``, ``codex`` and ``pi`` at once.
+    Modern skills lean on progressive disclosure: a short ``SKILL.md`` that
+    points at ``REFERENCE.md``, ``references/`` and helper scripts the agent
+    reads on demand. If we hand the agent only ``SKILL.md``'s text those
+    pointers dangle, so we copy the skill directory into ``isolated_home`` (the
+    cwd the agent runs in) and the relative links resolve as they would from a
+    real install.
 
-    Only a real skill *directory* is staged: we key off a file named ``SKILL.md``.
-    A lone slash-command ``.md`` file has no skill directory and is left alone (so
-    we never slurp an arbitrary parent repo into the run).
-
-    Cheat surfaces are never staged: the ``.eval.yaml`` spec, ``.caliper/``
-    results, and anything the spec marks ``forbidden_files`` are all skipped, so
-    staging cannot leak the answer key even if the agent reads what it finds.
+    Only a real skill *directory* is staged, keyed off a file named ``SKILL.md``;
+    a lone slash-command ``.md`` has no directory and is left alone. Cheat
+    surfaces — the ``.eval.yaml`` spec, ``.caliper/`` results, and anything the
+    spec marks ``forbidden_files`` — are never copied, so staging cannot leak the
+    answer key.
     """
     src = Path(skill_path)
     if src.name != "SKILL.md" or not src.exists():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from caliper.harness.base import AttemptResult, HarnessBackend
 from caliper.judge.base import Judge, JudgeResult
-from caliper.runner import run
+from caliper.runner import _stage_skill_directory, run
 from caliper.schema.spec import EvalSpec, SkillConfig, TaskSpec
 
 
@@ -75,3 +75,57 @@ def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
     assert attempt.assert_evidence == "agent failed"
     assert results.aggregate.avg_pass_at_k == 0
     assert judge.calls == 0
+
+
+def _make_skill_dir(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("See [REFERENCE.md](REFERENCE.md)")
+    (skill_dir / "REFERENCE.md").write_text("token: UNIQUE-REF-42")
+    (skill_dir / "references" / "deep.md").write_text("nested detail")
+    return skill_dir
+
+
+def test_stage_copies_skill_siblings_into_home(tmp_path) -> None:
+    skill_dir = _make_skill_dir(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    _stage_skill_directory(str(skill_dir / "SKILL.md"), str(home), [])
+
+    assert (home / "REFERENCE.md").read_text() == "token: UNIQUE-REF-42"
+    assert (home / "references" / "deep.md").read_text() == "nested detail"
+    assert (home / "SKILL.md").exists()
+
+
+def test_stage_excludes_cheat_surfaces(tmp_path) -> None:
+    skill_dir = _make_skill_dir(tmp_path)
+    (skill_dir / ".caliper" / "results").mkdir(parents=True)
+    (skill_dir / ".caliper" / "results" / "run.json").write_text("answers")
+    (skill_dir / "my-skill.eval.yaml").write_text("expect: the secret")
+    (skill_dir / "secret.txt").write_text("do not stage me")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    _stage_skill_directory(
+        str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"]
+    )
+
+    assert not (home / ".caliper").exists()
+    assert not (home / "my-skill.eval.yaml").exists()
+    assert not (home / "secret.txt").exists()
+    # Legitimate references are still staged.
+    assert (home / "REFERENCE.md").exists()
+
+
+def test_stage_ignores_lone_command_file(tmp_path) -> None:
+    # A bare slash-command .md (not named SKILL.md) has no skill directory;
+    # we must not slurp its siblings (which could be an arbitrary repo).
+    (tmp_path / "review.md").write_text("Review the code.")
+    (tmp_path / "unrelated.md").write_text("do not copy")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    _stage_skill_directory(str(tmp_path / "review.md"), str(home), [])
+
+    assert not (home / "unrelated.md").exists()


### PR DESCRIPTION
## What & why

Fixes #19. The harness injected only `SKILL.md`'s text into a run, so a **directory-based skill**'s siblings — `REFERENCE.md`, `references/`, helper scripts — were unreachable, and relative pointers like `[REFERENCE.md](REFERENCE.md)` couldn't resolve. Progressive disclosure was invisible to Caliper: moving prose out of `SKILL.md` into `REFERENCE.md` behaved, inside the harness, exactly like deleting it.

## The fix — one shared point

Every CLI backend runs the agent with `cwd = isolated_home`. So instead of patching each harness, the runner stages the skill **directory's** contents into `isolated_home` once, before the harness runs. One copy fixes `claude-code`, `codex`, and `pi` together — `claude-code`/`codex` needed no harness changes at all.

Design choices (mapping to the issue's open questions):

- **Copy scope** — whole directory, recursively, with a small denylist (`.git`, `__pycache__`, `node_modules`, `.venv`, `.caliper`) and a 5 MB per-file cap so a stray fixture can't bloat every attempt.
- **Cheat surface** — never staged. The `.eval.yaml` spec and `.caliper/` results are excluded, and the spec's own `sandbox.forbidden_files` patterns are reused as the exclusion list, so staging can't leak the answer key.
- **Lone command files** — a bare slash-command `.md` (not named `SKILL.md`) has no skill directory, so nothing is staged (we never slurp an arbitrary parent repo).
- **pi** — now loads the *staged* `SKILL.md` via `--skill` (siblings alongside) instead of the real skill dir, keeping it off the cheat surface too.

## API backends (out of scope)

`claude-api`/`openai-api` make a single tool-less message call, so no file is reachable and disclosure isn't measurable there — they keep injecting `SKILL.md`'s text only. (Note: those names also power the judge/autorater, so they can't simply be removed.)

## Verification

Unit tests added in `tests/test_runner.py` (siblings copied, cheat surfaces excluded, lone command file ignored). Full suite: **69 passed**.

Live spike — a throwaway skill whose passphrase (`ZORBLAX-QX9471-MERIDIAN`, random, absent from `SKILL.md` and the whole repo) lives only in `REFERENCE.md`; the task asks the agent to retrieve and write it:

- **claude-code** — `pass@1 = 100%`, agent wrote the exact token ✓
- **pi** — `pass@1 = 100%`, agent echoed the exact token ✓

Since the token exists only in the staged sibling, passing proves the agent reached it. `codex` uses the same runner staging + `cwd` path but wasn't spiked live.

## Docs

The `CONTEXT.md` "SKILL-only injection" glossary entry is now stale; it's an untracked WIP file in the working tree, so I updated it locally but left it out of this PR — fold it in when that file lands.