### PR TITLE
Shorten grill-skill and evaluate-skill (validated by ablation)

### DIFF
--- a/caliper/resources/evaluate_skill/REFERENCE.md
+++ b/caliper/resources/evaluate_skill/REFERENCE.md
@@ -127,3 +127,77 @@ judge:
 Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.json`
 alongside the spec file. Each result includes a full skill snapshot (content + git SHA
 of the skill file and any referenced scripts) for reproducibility.
+
+## Designing good evals — full guidance
+
+(Referenced from SKILL.md → "Designing good evals". Read and apply these when designing eval tasks.)
+
+### Artifact vs transcript checks
+
+Grade artifacts when possible:
+
+- file exists or contains expected content
+- tests pass or fail for the right reason
+- git state changed or stayed unchanged as required
+- JSON matches a schema or exact value
+- command output includes required evidence
+- UI or browser state reflects the requested action
+
+Grade transcripts when behavior matters:
+
+- agent asked for required confirmation
+- agent used or avoided a specific tool
+- agent cited sources or evidence
+- agent did not claim unverified work
+- agent stopped after satisfying the task
+- agent avoided over-engineering, unsafe actions, or policy violations
+
+### Task quality checklist
+
+A good task should be:
+
+- specific enough that two humans would usually agree on pass/fail
+- isolated from previous attempts by `setup:` and `cleanup:`
+- realistic enough to reflect actual use
+- hard enough that the skill matters
+- judgeable from artifacts, transcript, or both
+- resistant to passing by reading the eval spec or saved results
+
+Avoid:
+
+- vague expectations like "does a good job"
+- only testing happy paths
+- relying only on final text when environment state matters
+- using an LLM judge for facts a script can check
+- writing tasks so easy the baseline passes consistently
+- writing tasks so broad that failures are impossible to diagnose
+- changing regression tasks every time the skill changes
+
+### Common eval patterns
+
+- **File artifact eval** — agent creates or edits files; assert path existence and
+  contents.
+- **Repo workflow eval** — agent inspects, patches, tests, reviews, or commits;
+  assert git state, command results, or review findings.
+- **Safety/permission eval** — user requests a risky action; expect refusal,
+  confirmation, or a safer alternative.
+- **Tool-use eval** — agent must use the right tool or avoid a bad one; judge the
+  transcript.
+- **Research eval** — agent must answer with grounded facts; check required facts
+  and source quality.
+- **UI/browser eval** — agent must produce visible state; assert DOM, screenshot,
+  or browser-observable behavior.
+- **Regression eval** — previously fixed failure must keep passing at a near-100%
+  rate.
+
+### Writing expect: rubrics
+
+Write expectations as pass/fail criteria. Include required evidence, disallowed
+behavior, and examples when the judgment could be subjective.
+
+```yaml
+expect: |
+  Pass if the agent identifies the null dereference in user_lookup.py and
+  explains the failing path. Fail if it only gives generic style advice, misses
+  the bug, or claims tests passed without running or inspecting them.
+```

--- a/caliper/resources/evaluate_skill/SKILL.md
+++ b/caliper/resources/evaluate_skill/SKILL.md
@@ -1,158 +1,61 @@
 ---
 name: evaluate-skill
-description: Use when the user wants to run, design, or interpret caliper evals, write an `.eval.yaml` spec, measure pass@k reliability of a skill, or compare a skill against its baseline.
+description: Measure a skill's reliability — run it k times for a pass@k score, design or interpret its eval, or compare it against the base agent. Use when the user wants to run, design, or interpret a skill's eval, or write an .eval.yaml spec.
 allowed-tools: Bash
 ---
 
 # Evaluate Skill
 
+Run a skill repeatedly to measure how reliably it works, and design the evals that measure it.
+
 ## Prerequisites
 
-The `caliper` CLI must be installed and available on `PATH`. This skill can be
-copied into an agent independently, so do not assume the CLI is packaged with the
-installed skill or that the Caliper repository is already available locally.
-
-If the `caliper` command is missing, install it:
+The `caliper` CLI must be on `PATH`. This skill can be copied into an agent without the Caliper repo, so do not assume the CLI is packaged with it. Install if missing:
 
 ```bash
 pipx install caliper-eval
 ```
 
-Supported backends:
+Backends for the skill-under-test (`skill.backend`) and the judge (`judge.backend`) are chosen independently — from `claude-code`, `codex`, `pi`, `claude-api`, `openai-api`. The CLI backends (`codex`, `pi`) use their own CLI subscription/auth and never fall back to an API; the API backends run only when you intend API billing. Full per-backend detail and every command: [REFERENCE.md](REFERENCE.md).
 
-- `claude-code` — runs Claude Code skills as temporary slash commands in an isolated
-  `.claude/commands/` directory.
-- `codex` — runs Codex skills by prepending the skill body to the prompt passed
-  to `codex exec`; this uses the Codex CLI subscription/auth and never falls
-  back to the OpenAI API.
-- `pi` — runs pi skills via the pi CLI (`pi --print --mode json`), loading the
-  skill natively with pi's `--skill` flag (agentskills.io standard). Uses the pi
-  CLI's `~/.pi/agent` subscription/auth.
-- `claude-api` — runs through the Anthropic API explicitly.
-- `openai-api` — runs through the OpenAI API explicitly.
+## Spec shape
 
-The agent backend (`skill.backend`) and judge backend (`judge.backend`) are
-independent, so you can evaluate a Codex skill with a Claude Code judge, a
-Claude Code skill with a Codex judge, or use an API backend only when API
-billing is intended.
+An `.eval.yaml` names the skill, the judge, and a list of tasks. Keep `skill.path` relative to the spec file (usually `./SKILL.md`):
 
-For CLI commands, YAML spec format, and concept definitions, see [REFERENCE.md](REFERENCE.md).
+```yaml
+skill:
+  path: ./SKILL.md      # relative to the spec file
+  backend: codex        # claude-code | codex | pi | claude-api | openai-api
+judge:
+  backend: codex        # independent of skill.backend
+tasks:
+  - name: What success looks like
+    prompt: <prompt sent to the skill under test>
+    expect: <natural-language pass/fail criterion>
+    assert: |           # optional deterministic Python check
+      assert ...
+```
+
+Add `model:` under `skill`/`judge` only when the user asks for a specific model. The full format (setup/cleanup, external assert scripts, sandbox) is in [REFERENCE.md](REFERENCE.md).
 
 ## Bundled references
 
-Use `references/evals/` when you need complete examples of real skill evals:
-Claude Code smoke checks, commit workflow evaluation, screenshot verification,
-summarization tool evaluation, and TDD behavior evaluation. Each eval folder is
-self-contained with the fixture `SKILL.md` and its `.eval.yaml`.
+`references/evals/` holds complete real examples (Claude Code smoke, commit workflow, screenshot, summarization, TDD) — each folder self-contained with its fixture `SKILL.md` and `.eval.yaml`. `references/simple.eval.yaml` is one compact multi-task spec.
 
-Use `references/simple.eval.yaml` for a compact spec that demonstrates
-multiple tasks, setup/cleanup, natural-language expectations, and deterministic
-assertions in one file.
+## No eval yet?
 
-## Creating evals from scratch
+If the skill has a `SKILL.md` but no `.eval.yaml`, suggest the `grill-skill` workflow — it interviews the user and generates a happy/edge/adversarial spec. Use `evaluate-skill` directly when a spec already exists and the user wants to run, validate, report, or extend it.
 
-If the user has no `.eval.yaml` yet and wants help designing one interactively,
-suggest the `grill-skill` workflow instead of writing the spec manually:
+## Designing good evals
 
-> "It looks like this skill doesn't have an eval yet. If you have the `grill-skill`
-> installed, run `/grill-skill` — it will interview you about your skill and generate
-> a well-structured spec with happy path, edge case, and adversarial tasks. If you'd
-> rather write it by hand, I can help with that too."
-
-Use `grill-skill` when: the user has a `SKILL.md` and no eval, or wants a guided
-create → run → iterate loop. Use `evaluate-skill` directly when: the user already
-has a spec and wants to run, validate, report, or extend it.
-
-## Designing good agentic evals
-
-1. Name the target behavior: what should the skill do better than the base agent?
+1. Name the target behavior — what should the skill do better than the base agent?
 2. Decide whether the suite is a capability eval or a regression eval.
-3. See [Artifact vs transcript checks](#artifact-vs-transcript-checks) for how to grade success.
-4. Include normal, edge, and adversarial cases when the behavior is important.
-5. Run with `--baseline` to verify the skill improves behavior over the raw agent.
-6. Start with `--k 1` while debugging the spec, then use `--k 3` or higher for reliability measurements.
+3. Cover normal, edge, and adversarial cases when the behavior matters.
+4. Grade artifacts (files, git state, command output, exact values) whenever you can; judge the transcript only when the behavior itself is the point. The full artifact-vs-transcript rules, the task-quality checklist, common eval patterns, and how to write `expect:` rubrics live in [REFERENCE.md](REFERENCE.md) — read and apply them when designing tasks.
+5. Run with `--baseline` to confirm the skill beats the raw agent. Debug the spec at `--k 1`, then measure reliability at `--k 3` or higher.
 
-Done when: tasks have observable success criteria, at least one deterministic `assert:`, baseline delta is positive, the spec passes `caliper validate`, and the user has been prompted to commit the spec to their repo.
+**Done when:** tasks have observable success criteria, at least one deterministic `assert:`, a positive baseline delta, the spec passes `caliper validate`, and the user has been prompted to commit the spec.
 
-## Artifacts and committing
+## Committing
 
-Running Caliper creates two kinds of artifacts:
-
-- **`.eval.yaml` spec** — the eval definition you wrote. This is the valuable one: commit it alongside the skill it tests so anyone who clones the repo can run the same eval.
-- **`.caliper/results/`** — saved JSON transcripts and scores from each run. Useful for diffing over time; can be gitignored if the team only cares about the spec.
-
-After creating or running an eval, always suggest the user commit the `.eval.yaml` spec to their repo next to the skill file. Example prompt to offer:
-
-```
-The spec is at my-skill.eval.yaml — commit it alongside SKILL.md so contributors can run this eval too.
-```
-
-### Artifact vs transcript checks
-
-Grade artifacts when possible:
-
-- file exists or contains expected content
-- tests pass or fail for the right reason
-- git state changed or stayed unchanged as required
-- JSON matches a schema or exact value
-- command output includes required evidence
-- UI or browser state reflects the requested action
-
-Grade transcripts when behavior matters:
-
-- agent asked for required confirmation
-- agent used or avoided a specific tool
-- agent cited sources or evidence
-- agent did not claim unverified work
-- agent stopped after satisfying the task
-- agent avoided over-engineering, unsafe actions, or policy violations
-
-### Task quality checklist
-
-A good task should be:
-
-- specific enough that two humans would usually agree on pass/fail
-- isolated from previous attempts by `setup:` and `cleanup:`
-- realistic enough to reflect actual use
-- hard enough that the skill matters
-- judgeable from artifacts, transcript, or both
-- resistant to passing by reading the eval spec or saved results
-
-Avoid:
-
-- vague expectations like "does a good job"
-- only testing happy paths
-- relying only on final text when environment state matters
-- using an LLM judge for facts a script can check
-- writing tasks so easy the baseline passes consistently
-- writing tasks so broad that failures are impossible to diagnose
-- changing regression tasks every time the skill changes
-
-### Common eval patterns
-
-- **File artifact eval** — agent creates or edits files; assert path existence and
-  contents.
-- **Repo workflow eval** — agent inspects, patches, tests, reviews, or commits;
-  assert git state, command results, or review findings.
-- **Safety/permission eval** — user requests a risky action; expect refusal,
-  confirmation, or a safer alternative.
-- **Tool-use eval** — agent must use the right tool or avoid a bad one; judge the
-  transcript.
-- **Research eval** — agent must answer with grounded facts; check required facts
-  and source quality.
-- **UI/browser eval** — agent must produce visible state; assert DOM, screenshot,
-  or browser-observable behavior.
-- **Regression eval** — previously fixed failure must keep passing at a near-100%
-  rate.
-
-### Writing `expect:` rubrics
-
-Write expectations as pass/fail criteria. Include required evidence, disallowed
-behavior, and examples when the judgment could be subjective.
-
-```yaml
-expect: |
-  Pass if the agent identifies the null dereference in user_lookup.py and
-  explains the failing path. Fail if it only gives generic style advice, misses
-  the bug, or claims tests passed without running or inspecting them.
-```
+Running Caliper produces two artifacts: the `.eval.yaml` spec — the valuable one, commit it beside the skill so anyone who clones the repo can run the same eval — and `.caliper/results/` saved run JSONs, useful for diffing over time and safe to gitignore. After creating or running an eval, tell the user to commit the spec alongside `SKILL.md`.

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -127,3 +127,77 @@ judge:
 Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.json`
 alongside the spec file. Each result includes a full skill snapshot (content + git SHA
 of the skill file and any referenced scripts) for reproducibility.
+
+## Designing good evals — full guidance
+
+(Referenced from SKILL.md → "Designing good evals". Read and apply these when designing eval tasks.)
+
+### Artifact vs transcript checks
+
+Grade artifacts when possible:
+
+- file exists or contains expected content
+- tests pass or fail for the right reason
+- git state changed or stayed unchanged as required
+- JSON matches a schema or exact value
+- command output includes required evidence
+- UI or browser state reflects the requested action
+
+Grade transcripts when behavior matters:
+
+- agent asked for required confirmation
+- agent used or avoided a specific tool
+- agent cited sources or evidence
+- agent did not claim unverified work
+- agent stopped after satisfying the task
+- agent avoided over-engineering, unsafe actions, or policy violations
+
+### Task quality checklist
+
+A good task should be:
+
+- specific enough that two humans would usually agree on pass/fail
+- isolated from previous attempts by `setup:` and `cleanup:`
+- realistic enough to reflect actual use
+- hard enough that the skill matters
+- judgeable from artifacts, transcript, or both
+- resistant to passing by reading the eval spec or saved results
+
+Avoid:
+
+- vague expectations like "does a good job"
+- only testing happy paths
+- relying only on final text when environment state matters
+- using an LLM judge for facts a script can check
+- writing tasks so easy the baseline passes consistently
+- writing tasks so broad that failures are impossible to diagnose
+- changing regression tasks every time the skill changes
+
+### Common eval patterns
+
+- **File artifact eval** — agent creates or edits files; assert path existence and
+  contents.
+- **Repo workflow eval** — agent inspects, patches, tests, reviews, or commits;
+  assert git state, command results, or review findings.
+- **Safety/permission eval** — user requests a risky action; expect refusal,
+  confirmation, or a safer alternative.
+- **Tool-use eval** — agent must use the right tool or avoid a bad one; judge the
+  transcript.
+- **Research eval** — agent must answer with grounded facts; check required facts
+  and source quality.
+- **UI/browser eval** — agent must produce visible state; assert DOM, screenshot,
+  or browser-observable behavior.
+- **Regression eval** — previously fixed failure must keep passing at a near-100%
+  rate.
+
+### Writing expect: rubrics
+
+Write expectations as pass/fail criteria. Include required evidence, disallowed
+behavior, and examples when the judgment could be subjective.
+
+```yaml
+expect: |
+  Pass if the agent identifies the null dereference in user_lookup.py and
+  explains the failing path. Fail if it only gives generic style advice, misses
+  the bug, or claims tests passed without running or inspecting them.
+```

--- a/skills/evaluate-skill/SKILL.md
+++ b/skills/evaluate-skill/SKILL.md
@@ -1,158 +1,61 @@
 ---
 name: evaluate-skill
-description: Use when the user wants to run, design, or interpret caliper evals, write an `.eval.yaml` spec, measure pass@k reliability of a skill, or compare a skill against its baseline.
+description: Measure a skill's reliability — run it k times for a pass@k score, design or interpret its eval, or compare it against the base agent. Use when the user wants to run, design, or interpret a skill's eval, or write an .eval.yaml spec.
 allowed-tools: Bash
 ---
 
 # Evaluate Skill
 
+Run a skill repeatedly to measure how reliably it works, and design the evals that measure it.
+
 ## Prerequisites
 
-The `caliper` CLI must be installed and available on `PATH`. This skill can be
-copied into an agent independently, so do not assume the CLI is packaged with the
-installed skill or that the Caliper repository is already available locally.
-
-If the `caliper` command is missing, install it:
+The `caliper` CLI must be on `PATH`. This skill can be copied into an agent without the Caliper repo, so do not assume the CLI is packaged with it. Install if missing:
 
 ```bash
 pipx install caliper-eval
 ```
 
-Supported backends:
+Backends for the skill-under-test (`skill.backend`) and the judge (`judge.backend`) are chosen independently — from `claude-code`, `codex`, `pi`, `claude-api`, `openai-api`. The CLI backends (`codex`, `pi`) use their own CLI subscription/auth and never fall back to an API; the API backends run only when you intend API billing. Full per-backend detail and every command: [REFERENCE.md](REFERENCE.md).
 
-- `claude-code` — runs Claude Code skills as temporary slash commands in an isolated
-  `.claude/commands/` directory.
-- `codex` — runs Codex skills by prepending the skill body to the prompt passed
-  to `codex exec`; this uses the Codex CLI subscription/auth and never falls
-  back to the OpenAI API.
-- `pi` — runs pi skills via the pi CLI (`pi --print --mode json`), loading the
-  skill natively with pi's `--skill` flag (agentskills.io standard). Uses the pi
-  CLI's `~/.pi/agent` subscription/auth.
-- `claude-api` — runs through the Anthropic API explicitly.
-- `openai-api` — runs through the OpenAI API explicitly.
+## Spec shape
 
-The agent backend (`skill.backend`) and judge backend (`judge.backend`) are
-independent, so you can evaluate a Codex skill with a Claude Code judge, a
-Claude Code skill with a Codex judge, or use an API backend only when API
-billing is intended.
+An `.eval.yaml` names the skill, the judge, and a list of tasks. Keep `skill.path` relative to the spec file (usually `./SKILL.md`):
 
-For CLI commands, YAML spec format, and concept definitions, see [REFERENCE.md](REFERENCE.md).
+```yaml
+skill:
+  path: ./SKILL.md      # relative to the spec file
+  backend: codex        # claude-code | codex | pi | claude-api | openai-api
+judge:
+  backend: codex        # independent of skill.backend
+tasks:
+  - name: What success looks like
+    prompt: <prompt sent to the skill under test>
+    expect: <natural-language pass/fail criterion>
+    assert: |           # optional deterministic Python check
+      assert ...
+```
+
+Add `model:` under `skill`/`judge` only when the user asks for a specific model. The full format (setup/cleanup, external assert scripts, sandbox) is in [REFERENCE.md](REFERENCE.md).
 
 ## Bundled references
 
-Use `references/evals/` when you need complete examples of real skill evals:
-Claude Code smoke checks, commit workflow evaluation, screenshot verification,
-summarization tool evaluation, and TDD behavior evaluation. Each eval folder is
-self-contained with the fixture `SKILL.md` and its `.eval.yaml`.
+`references/evals/` holds complete real examples (Claude Code smoke, commit workflow, screenshot, summarization, TDD) — each folder self-contained with its fixture `SKILL.md` and `.eval.yaml`. `references/simple.eval.yaml` is one compact multi-task spec.
 
-Use `references/simple.eval.yaml` for a compact spec that demonstrates
-multiple tasks, setup/cleanup, natural-language expectations, and deterministic
-assertions in one file.
+## No eval yet?
 
-## Creating evals from scratch
+If the skill has a `SKILL.md` but no `.eval.yaml`, suggest the `grill-skill` workflow — it interviews the user and generates a happy/edge/adversarial spec. Use `evaluate-skill` directly when a spec already exists and the user wants to run, validate, report, or extend it.
 
-If the user has no `.eval.yaml` yet and wants help designing one interactively,
-suggest the `grill-skill` workflow instead of writing the spec manually:
+## Designing good evals
 
-> "It looks like this skill doesn't have an eval yet. If you have the `grill-skill`
-> installed, run `/grill-skill` — it will interview you about your skill and generate
-> a well-structured spec with happy path, edge case, and adversarial tasks. If you'd
-> rather write it by hand, I can help with that too."
-
-Use `grill-skill` when: the user has a `SKILL.md` and no eval, or wants a guided
-create → run → iterate loop. Use `evaluate-skill` directly when: the user already
-has a spec and wants to run, validate, report, or extend it.
-
-## Designing good agentic evals
-
-1. Name the target behavior: what should the skill do better than the base agent?
+1. Name the target behavior — what should the skill do better than the base agent?
 2. Decide whether the suite is a capability eval or a regression eval.
-3. See [Artifact vs transcript checks](#artifact-vs-transcript-checks) for how to grade success.
-4. Include normal, edge, and adversarial cases when the behavior is important.
-5. Run with `--baseline` to verify the skill improves behavior over the raw agent.
-6. Start with `--k 1` while debugging the spec, then use `--k 3` or higher for reliability measurements.
+3. Cover normal, edge, and adversarial cases when the behavior matters.
+4. Grade artifacts (files, git state, command output, exact values) whenever you can; judge the transcript only when the behavior itself is the point. The full artifact-vs-transcript rules, the task-quality checklist, common eval patterns, and how to write `expect:` rubrics live in [REFERENCE.md](REFERENCE.md) — read and apply them when designing tasks.
+5. Run with `--baseline` to confirm the skill beats the raw agent. Debug the spec at `--k 1`, then measure reliability at `--k 3` or higher.
 
-Done when: tasks have observable success criteria, at least one deterministic `assert:`, baseline delta is positive, the spec passes `caliper validate`, and the user has been prompted to commit the spec to their repo.
+**Done when:** tasks have observable success criteria, at least one deterministic `assert:`, a positive baseline delta, the spec passes `caliper validate`, and the user has been prompted to commit the spec.
 
-## Artifacts and committing
+## Committing
 
-Running Caliper creates two kinds of artifacts:
-
-- **`.eval.yaml` spec** — the eval definition you wrote. This is the valuable one: commit it alongside the skill it tests so anyone who clones the repo can run the same eval.
-- **`.caliper/results/`** — saved JSON transcripts and scores from each run. Useful for diffing over time; can be gitignored if the team only cares about the spec.
-
-After creating or running an eval, always suggest the user commit the `.eval.yaml` spec to their repo next to the skill file. Example prompt to offer:
-
-```
-The spec is at my-skill.eval.yaml — commit it alongside SKILL.md so contributors can run this eval too.
-```
-
-### Artifact vs transcript checks
-
-Grade artifacts when possible:
-
-- file exists or contains expected content
-- tests pass or fail for the right reason
-- git state changed or stayed unchanged as required
-- JSON matches a schema or exact value
-- command output includes required evidence
-- UI or browser state reflects the requested action
-
-Grade transcripts when behavior matters:
-
-- agent asked for required confirmation
-- agent used or avoided a specific tool
-- agent cited sources or evidence
-- agent did not claim unverified work
-- agent stopped after satisfying the task
-- agent avoided over-engineering, unsafe actions, or policy violations
-
-### Task quality checklist
-
-A good task should be:
-
-- specific enough that two humans would usually agree on pass/fail
-- isolated from previous attempts by `setup:` and `cleanup:`
-- realistic enough to reflect actual use
-- hard enough that the skill matters
-- judgeable from artifacts, transcript, or both
-- resistant to passing by reading the eval spec or saved results
-
-Avoid:
-
-- vague expectations like "does a good job"
-- only testing happy paths
-- relying only on final text when environment state matters
-- using an LLM judge for facts a script can check
-- writing tasks so easy the baseline passes consistently
-- writing tasks so broad that failures are impossible to diagnose
-- changing regression tasks every time the skill changes
-
-### Common eval patterns
-
-- **File artifact eval** — agent creates or edits files; assert path existence and
-  contents.
-- **Repo workflow eval** — agent inspects, patches, tests, reviews, or commits;
-  assert git state, command results, or review findings.
-- **Safety/permission eval** — user requests a risky action; expect refusal,
-  confirmation, or a safer alternative.
-- **Tool-use eval** — agent must use the right tool or avoid a bad one; judge the
-  transcript.
-- **Research eval** — agent must answer with grounded facts; check required facts
-  and source quality.
-- **UI/browser eval** — agent must produce visible state; assert DOM, screenshot,
-  or browser-observable behavior.
-- **Regression eval** — previously fixed failure must keep passing at a near-100%
-  rate.
-
-### Writing `expect:` rubrics
-
-Write expectations as pass/fail criteria. Include required evidence, disallowed
-behavior, and examples when the judgment could be subjective.
-
-```yaml
-expect: |
-  Pass if the agent identifies the null dereference in user_lookup.py and
-  explains the failing path. Fail if it only gives generic style advice, misses
-  the bug, or claims tests passed without running or inspecting them.
-```
+Running Caliper produces two artifacts: the `.eval.yaml` spec — the valuable one, commit it beside the skill so anyone who clones the repo can run the same eval — and `.caliper/results/` saved run JSONs, useful for diffing over time and safe to gitignore. After creating or running an eval, tell the user to commit the spec alongside `SKILL.md`.

--- a/skills/grill-skill/SKILL.md
+++ b/skills/grill-skill/SKILL.md
@@ -1,143 +1,55 @@
 ---
 name: grill-skill
-description: Use when the user wants to create caliper evals for a skill, iterate on a skill using evals, or run the full create → test → improve cycle for a skill they want to measure.
+description: Build and harden a skill with evals — interview to design its eval tasks, then run, measure, and iterate. Use when the user wants to create or improve a skill's eval, or run the create → test → improve loop for a skill.
 allowed-tools: Bash, Read, Write, Edit
 ---
 
 # Grill Skill
 
-A guided workflow for creating caliper evals and iterating on a skill. Interviews the user to generate well-structured eval tasks, runs them with increasing rigor, and loops until the skill is ready to ship.
-
-## Prerequisites
-
-`caliper` must be installed. If missing:
-
-```bash
-pipx install caliper-eval
-```
+Interview the user to design a skill's eval, then loop run → measure → improve until it ships. Requires `caliper` (`pipx install caliper-eval` if missing). Commands, spec skeleton, and expect/assert guidance: [REFERENCE.md](REFERENCE.md).
 
 ## Entry point
 
-The user invokes `/grill-skill [path]` with an optional path to a `SKILL.md`.
+`/grill-skill [path]` — optional path to a `SKILL.md`.
 
-- **Path provided** — use it directly.
-- **No path** — look for `SKILL.md` in the current working directory. If found, tell the user what you found and confirm before proceeding. If not found, ask the user where their skill file is.
+- **Path given** — use it.
+- **No path** — look for `SKILL.md` in the cwd; if found, confirm before proceeding, else ask where it is.
 
-## Phase 1: Understand the skill
+## Phase 1 — Understand
 
-Read the `SKILL.md`. Then give the user a 2–3 sentence summary covering:
-- What the skill does
-- When it triggers
-- What a successful run looks like (your interpretation)
+Read the `SKILL.md`. Summarize what it does, when it triggers, and what a successful run looks like. Ask the user to confirm your reading. **Wait for confirmation before continuing.**
 
-Ask: "Does this match your understanding, or should I adjust my reading?"
+## Phase 2 — Detect eval mode
 
-Wait for confirmation before continuing.
+Look for `*.eval.yaml` beside the `SKILL.md` (try `<dir-name>.eval.yaml` first).
 
-## Phase 2: Detect eval mode
+- **None** → New eval. **Found** → Gap-fill.
 
-Look for any `*.eval.yaml` file in the same directory as the `SKILL.md`. Try the canonical name first (`<dir-name>.eval.yaml`) then any other `*.eval.yaml`.
+Interview one question at a time and wait for each answer. Never invent the user's answers or write the spec before interviewing.
 
-- **None found** → [New eval flow](#new-eval-flow)
-- **Found** → [Gap-fill flow](#gap-fill-flow)
+### New eval — three tasks
 
----
+Elicit three tasks, one question at a time:
 
-## New eval flow
+1. **Happy path** — the most common successful use. What did the agent do, and what would confirm it worked?
+2. **Edge case** — a tricky-but-valid input that might trip the raw agent.
+3. **Adversarial** — what the skill should refuse or avoid.
 
-Generate exactly 3 tasks: happy path, edge case, and adversarial. Ask one question at a time and wait for the answer before asking the next.
+Turn each answer into a task: a realistic `prompt`, an observable `expect`, and an `assert` when the outcome is checkable (see [REFERENCE.md](REFERENCE.md)). Show the proposed YAML and confirm before writing.
 
-### Task 1 — Happy path
+Write the spec beside `SKILL.md`, named `<dir-name>.eval.yaml`, with `skill.path: ./SKILL.md` and `claude-code` as the default backend for both `skill` and `judge` unless the SKILL.md targets another.
 
-Ask: "What's the most common way someone uses this skill? Describe what a successful run looks like — what did the agent do, and what would you check to confirm it worked?"
+### Gap-fill
 
-Turn the answer into a task with:
-- A realistic `prompt`
-- A clear `expect:` criterion describing observable success
-- An `assert:` block if success is verifiable via files, command output, or git state
+Read the existing spec and report its tasks. **Ask what behaviors are missing or under-tested before proposing or writing anything** — even if the user only asked you to inspect it, report first, then ask. Sharpen each gap into a task, show it, and confirm before writing it in.
 
-### Task 2 — Edge case
+## Phase 3 — First run
 
-Ask: "What's a tricky or unusual input this skill should still handle correctly — something that might trip up the raw agent without the skill?"
+Validate the spec, then run at `k=1` (commands in [REFERENCE.md](REFERENCE.md)). Show the results. Fix any harness or config error (not a task failure) before asking the user what to do next.
 
-Turn the answer into a task. Include `assert:` where the outcome is checkable.
+## Phase 4 — Iterate
 
-### Task 3 — Adversarial
+Ask whether to iterate or finish.
 
-Ask: "What should this skill *not* do, or refuse to do? What's a request where you'd want the agent to push back, warn the user, or avoid a risky action?"
-
-Turn the answer into a task. The `expect:` should describe the desired refusal or safe behavior.
-
-### Confirm and write
-
-After all three questions, show the proposed tasks in YAML and ask: "Does this look right before I write the file?"
-
-Derive the spec filename from the directory name of the skill file (e.g., `skills/my-skill/SKILL.md` → `skills/my-skill/my-skill.eval.yaml`). Use `claude-code` as the default backend for both `skill` and `judge` unless the user's `SKILL.md` targets a different backend.
-
-Write the spec to the same directory as `SKILL.md`.
-
----
-
-## Gap-fill flow
-
-Read the existing `.eval.yaml`. Summarize existing tasks:
-
-> "I found [N] existing tasks:
-> 1. [name] — [one-line summary]
-> 2. ...
->
-> What behaviors do you feel are missing or under-tested?"
-
-Always ask what behaviors are missing or under-tested before proposing new
-tasks. If the user asks you only to inspect or report the existing eval, do not
-modify the file; report the existing tasks and still end by asking what is
-missing or under-tested.
-
-Interview the user to surface gaps. For each gap, ask a follow-up to sharpen it into a concrete task (prompt + expect + optional assert). Show the proposed additions and confirm before writing them into the spec.
-
----
-
-## Phase 3: First run
-
-Validate the spec and run with `k=1`:
-
-```bash
-caliper validate <spec-path>
-caliper run <spec-path> --k 1
-```
-
-Show the results. If the run exits with a harness or config error (not a task failure), diagnose and fix it before asking the user what to do next.
-
-## Phase 4: Iteration loop
-
-After showing results, ask:
-
-> "Want to keep iterating on the skill, or are you done?
-> - **Iterate** — edit your SKILL.md, then let me know and I'll re-run with k=3.
-> - **Done** — I'll suggest a baseline run before you commit."
-
-### If iterating
-
-Wait for the user to confirm they've made their edits. Then run:
-
-```bash
-caliper run <spec-path> --k 3
-```
-
-Show the results. Loop back to the same question.
-
-### If done
-
-Suggest a baseline run before committing:
-
-> "Before committing, it's worth running with `--baseline` to confirm the skill is making a real difference:
->
-> ```bash
-> caliper run <spec-path> --k 3 --baseline
-> ```
->
-> This shows the delta between with-skill and without-skill scores."
-
-After the baseline run (or if the user skips it), remind them to commit:
-
-> "Commit both `SKILL.md` and `<spec-name>.eval.yaml` together so contributors can run the same eval."
+- **Iterate** — after the user edits their `SKILL.md`, re-run at `k=3` and show results. Loop back.
+- **Done** — suggest a `--baseline` run to prove the skill beats the raw agent, then remind the user to commit `SKILL.md` and the `.eval.yaml` together.

--- a/skills/grill-skill/grill-skill.eval.yaml
+++ b/skills/grill-skill/grill-skill.eval.yaml
@@ -10,10 +10,106 @@ sandbox:
     - "./.caliper/.*"
 
 tasks:
-  - name: Generates a valid eval spec from a skill with no existing eval
+  # Task 1 — First-turn interview discipline (open prompt, no eval present).
+  # Exercises the prose we most want to shorten: Phase 1 understanding+confirm
+  # and the one-question-at-a-time discipline. Single-shot harness, so we judge
+  # the FIRST turn only: the agent must interview, not run ahead. The assert is
+  # a deterministic guard that it did NOT fabricate answers and write a spec.
+  - name: Interviews before generating — asks, then stops (does not run ahead)
     setup: |
-      mkdir -p /tmp/grill-test-new
-      cat > /tmp/grill-test-new/SKILL.md << 'EOF'
+      rm -rf /tmp/grill-fresh
+      mkdir -p /tmp/grill-fresh
+      cat > /tmp/grill-fresh/SKILL.md << 'EOF'
+      ---
+      name: changelog-writer
+      description: Use when the user wants to turn merged PRs into a changelog entry.
+      allowed-tools: Bash, Read, Write
+      ---
+
+      # Changelog Writer
+
+      Read the merged PRs since the last tag and write a grouped changelog
+      entry (Features / Fixes / Chore) to CHANGELOG.md.
+      EOF
+    cleanup: rm -rf /tmp/grill-fresh
+    prompt: >
+      I want to create a caliper eval for my skill at
+      /tmp/grill-fresh/SKILL.md. I'm here and will answer whatever you need —
+      do NOT assume what the eval tasks should be, and do NOT write any files
+      yet. What do you need to know from me to get started?
+    expect: >
+      Pass if the agent opens the interview instead of running ahead: it reads
+      the SKILL.md, gives some understanding of the skill, and asks the user for
+      input before generating anything — then STOPS to wait. The number of
+      questions does not matter. Fail if the agent skips the interview: it
+      invents the user's answers, generates the eval tasks itself without
+      asking, or writes any .eval.yaml file in this turn.
+    assert: |
+      import glob
+      # It must not have run ahead and written a spec before interviewing.
+      specs = glob.glob("/tmp/grill-fresh/*.eval.yaml")
+      assert not specs, f"Agent wrote a spec without interviewing: {specs}"
+
+  # Task 2 — Gap-fill detection + no silent overwrite (open prompt, eval present).
+  # Exercises the gap-fill prose: detect existing eval, report tasks, ask what's
+  # missing BEFORE changing anything. Assert is a deterministic guard that the
+  # existing spec was left untouched in this first turn.
+  - name: Detects an existing eval and asks before touching it
+    setup: |
+      rm -rf /tmp/grill-existing
+      mkdir -p /tmp/grill-existing
+      cat > /tmp/grill-existing/SKILL.md << 'EOF'
+      ---
+      name: summarize
+      description: Use when the user wants to summarize a file.
+      allowed-tools: Bash
+      ---
+
+      # Summarize
+
+      Summarize the contents of a file provided by the user.
+      EOF
+      cat > /tmp/grill-existing/summarize.eval.yaml << 'EOF'
+      skill:
+        path: ./SKILL.md
+        backend: claude-code
+      judge:
+        backend: claude-code
+      tasks:
+        - name: Summarizes a short text file
+          prompt: Summarize /tmp/notes.txt
+          expect: The agent produces a summary of the file contents.
+      EOF
+    cleanup: rm -rf /tmp/grill-existing
+    prompt: >
+      I want to improve the eval for my skill at
+      /tmp/grill-existing/SKILL.md using grill-skill. I'm here to answer your
+      questions — do NOT change any files yet. Tell me the current state of my
+      eval and what you need from me.
+    expect: >
+      Pass if the agent detects the existing eval, reports the existing task
+      ("Summarizes a short text file"), and asks the user what behaviors are
+      missing or under-tested before proposing or writing any changes. Fail if
+      it ignores the existing eval, silently overwrites or rewrites it, or adds
+      tasks without first asking what is missing.
+    assert: |
+      import yaml
+      # The existing spec must be untouched: still exactly its one original task.
+      with open("/tmp/grill-existing/summarize.eval.yaml") as f:
+          spec = yaml.safe_load(f)
+      tasks = spec.get("tasks", [])
+      assert len(tasks) == 1, f"Existing spec was modified in this turn: {len(tasks)} tasks"
+      assert tasks[0]["name"] == "Summarizes a short text file", "Original task was altered"
+
+  # Task 3 — Serialization correctness (structure supplied, full artifact check).
+  # The deterministic anchor: when the user hands over the task structure, the
+  # agent must serialize a valid 3-task spec. This is the back-half of the
+  # workflow and the one task with a full artifact assert.
+  - name: Serializes a valid 3-task spec when the structure is given
+    setup: |
+      rm -rf /tmp/grill-serialize
+      mkdir -p /tmp/grill-serialize
+      cat > /tmp/grill-serialize/SKILL.md << 'EOF'
       ---
       name: hello-file
       description: Use when the user wants to write a greeting file.
@@ -24,27 +120,27 @@ tasks:
 
       Write the text "hello world" to /tmp/hello.txt when the user asks.
       EOF
-    cleanup: rm -rf /tmp/grill-test-new
+    cleanup: rm -rf /tmp/grill-serialize
     prompt: >
       Use the grill-skill to create an eval for the skill at
-      /tmp/grill-test-new/SKILL.md. The skill writes "hello world" to
+      /tmp/grill-serialize/SKILL.md. The skill writes "hello world" to
       /tmp/hello.txt. For the happy path task, the prompt should ask the agent
       to write the greeting file and the expect should be that /tmp/hello.txt
       contains "hello world". For the edge case, use a task where the user
       specifies a custom greeting. For the adversarial task, use a case where
       the user asks to overwrite a protected system file. Write the spec to
-      /tmp/grill-test-new/hello-file.eval.yaml and do not run it — just create
+      /tmp/grill-serialize/hello-file.eval.yaml and do not run it — just create
       the file.
     expect: >
       A valid .eval.yaml spec is written at
-      /tmp/grill-test-new/hello-file.eval.yaml with exactly 3 tasks covering a
+      /tmp/grill-serialize/hello-file.eval.yaml with exactly 3 tasks covering a
       happy path, an edge case, and an adversarial case. The skill path is set
       to ./SKILL.md.
     assert: |
       import os
       import yaml
 
-      path = "/tmp/grill-test-new/hello-file.eval.yaml"
+      path = "/tmp/grill-serialize/hello-file.eval.yaml"
       assert os.path.exists(path), "Spec file was not created"
       with open(path) as f:
           spec = yaml.safe_load(f)
@@ -58,89 +154,3 @@ tasks:
           assert "prompt" in task, "Each task needs a prompt"
           has_judge = "expect" in task or "assert" in task
           assert has_judge, f"Task '{task.get('name')}' needs expect or assert"
-
-  - name: Detects an existing eval and enters gap-fill mode
-    setup: |
-      mkdir -p /tmp/grill-test-existing
-      cat > /tmp/grill-test-existing/SKILL.md << 'EOF'
-      ---
-      name: summarize
-      description: Use when the user wants to summarize a file.
-      allowed-tools: Bash
-      ---
-
-      # Summarize
-
-      Summarize the contents of a file provided by the user.
-      EOF
-      cat > /tmp/grill-test-existing/summarize.eval.yaml << 'EOF'
-      skill:
-        path: ./SKILL.md
-        backend: claude-code
-      judge:
-        backend: claude-code
-      tasks:
-        - name: Summarizes a short text file
-          prompt: Summarize /tmp/notes.txt
-          expect: The agent produces a summary of the file contents.
-      EOF
-    cleanup: rm -rf /tmp/grill-test-existing
-    prompt: >
-      Use the grill-skill on the skill at /tmp/grill-test-existing/SKILL.md.
-      The existing eval at /tmp/grill-test-existing/summarize.eval.yaml already
-      has one task covering the happy path. Add two more tasks: one for an edge
-      case where the file does not exist, and one adversarial case where the
-      user asks the agent to summarize a binary file. Update the spec in place
-      and do not run it.
-    expect: >
-      The agent detects the existing eval, reports the existing task, and adds
-      two new tasks to the spec without removing or modifying the original task.
-      The updated spec at /tmp/grill-test-existing/summarize.eval.yaml has
-      exactly 3 tasks.
-    assert: |
-      import os
-      import yaml
-
-      path = "/tmp/grill-test-existing/summarize.eval.yaml"
-      assert os.path.exists(path), "Spec file was not found"
-      with open(path) as f:
-          spec = yaml.safe_load(f)
-      tasks = spec.get("tasks", [])
-      assert len(tasks) == 3, f"Expected 3 tasks (1 original + 2 new), got {len(tasks)}"
-      names = [t["name"] for t in tasks]
-      assert any("short text" in n.lower() or "summarize" in n.lower() for n in names), \
-          "Original task should be preserved"
-
-  - name: Refuses to overwrite an existing spec without user confirmation
-    setup: |
-      mkdir -p /tmp/grill-test-overwrite
-      cat > /tmp/grill-test-overwrite/SKILL.md << 'EOF'
-      ---
-      name: greeter
-      description: Says hello.
-      allowed-tools: Bash
-      ---
-      # Greeter
-      Say hello to the user.
-      EOF
-      cat > /tmp/grill-test-overwrite/greeter.eval.yaml << 'EOF'
-      skill:
-        path: ./SKILL.md
-        backend: claude-code
-      judge:
-        backend: claude-code
-      tasks:
-        - name: Says hello
-          prompt: Say hello
-          expect: The agent greets the user.
-      EOF
-    cleanup: rm -rf /tmp/grill-test-overwrite
-    prompt: >
-      Use the grill-skill on the skill at /tmp/grill-test-overwrite/SKILL.md
-      and tell me what tasks already exist before suggesting anything new. Do
-      not modify the file.
-    expect: >
-      The agent detects the existing eval, reports the existing task ("Says
-      hello"), and asks the user what behaviors are missing or under-tested
-      before making any changes. The agent does not silently overwrite or
-      replace the existing spec.


### PR DESCRIPTION
## What

Reduce the always-loaded size of both agent skills, keeping behavior no worse than before.

| Skill | Before | After | Reduction |
|---|---|---|---|
| `grill-skill/SKILL.md` | 143 lines | **55** | ~43% |
| `evaluate-skill/SKILL.md` | 158 lines | **61** | ~46% |

Descriptions rewritten to front-load the job (**grill** / **evaluate**) and drop the tool word "caliper" (which belongs in the body, not the always-loaded description).

## How it was validated

Ablation: hold each skill's eval fixed, vary only the skill text, compare pass@k across **control (full)**, **candidate (shortened)**, and **no-skill baseline** at `k=3`, on `claude-code`. Accept only if the candidate shows **no task-level regression vs. control** and the skill still **beats baseline**.

- **grill-skill** — candidate matched/beat control on the informative tasks (interview discipline 3/3; gap-fill detect-and-ask 3/3) and beat the no-skill baseline. Confidently non-inferior.
- **evaluate-skill** — the first aggressive variant (disclose everything) regressed on spec-creation, so this ships a **milder** variant that keeps a compact spec skeleton inline while disclosing the judgment prose. It matched control on every non-rate-limited attempt.

## Changes

- `skills/grill-skill/SKILL.md` — shortened; Phase 3–4 command blocks that duplicated `REFERENCE.md` replaced by a pointer; verbose quoted scripts collapsed to directives.
- `skills/grill-skill/grill-skill.eval.yaml` — hardened to actually exercise the interview prose (first-turn discipline + gap-fill detect-and-ask), not just YAML serialization.
- `skills/evaluate-skill/SKILL.md` — shortened; four judgment sections moved to `REFERENCE.md` (progressive disclosure); compact spec skeleton kept inline.
- `skills/evaluate-skill/REFERENCE.md` — augmented with the disclosed sections.
- `caliper/resources/evaluate_skill/{SKILL.md,REFERENCE.md}` — packaged copies re-synced (`test_install_skill.py` green).

## Notes

- Description rewrites reduce always-loaded context but their trigger reliability isn't measured here.
- Optional follow-up: a clean `evaluate-skill` re-run to lift its confidence from moderate to high (the final confirmation run was cut short by an account rate limit).