### PR TITLE
Add attempt outcome taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,17 @@ For each task:
 pass@k = 1 - (1 - successes / k) ^ k
 ```
 
+Each attempt also has an `outcome` in the saved JSON:
+
+- `pass` — the attempt satisfied the judge(s).
+- `task_fail` — the skill got a fair attempt but failed the task.
+- `judge_error` — the judge did not produce a usable verdict.
+- `infra_error` — the harness or CLI failed before the task could be judged.
+- `timeout` — the attempt exceeded its time budget.
+- `cheat` — forbidden-file access was detected.
+
+`infra_error`, `timeout`, and `judge_error` are counted as unusable attempts and excluded from the pass@k denominator. They are reported separately so infrastructure noise does not look like a skill regression. `passed` remains available in the JSON and is equivalent to `outcome == "pass"`.
+
 The aggregate score is the average task pass@k. With `--baseline`, Caliper runs the same tasks without the skill and reports the delta.
 
 ---

--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -15,7 +15,7 @@ from rich.table import Table
 from rich.table import Column
 from rich.text import Text
 
-from caliper.schema.results import RunResults, TaskResult
+from caliper.schema.results import Outcome, RunResults, TaskResult
 
 console = Console()
 
@@ -38,8 +38,12 @@ _BAR_FULL = "█" if _UNICODE else "#"
 _BAR_EMPTY = "░" if _UNICODE else "-"
 
 
-def print_banner(spec_name: str, k: int, backend: str, model: str | None = None) -> None:
-    target = f"[cyan]{backend}[/cyan]" + (f" [dim]{_SEP} {model}[/dim]" if model else "")
+def print_banner(
+    spec_name: str, k: int, backend: str, model: str | None = None
+) -> None:
+    target = f"[cyan]{backend}[/cyan]" + (
+        f" [dim]{_SEP} {model}[/dim]" if model else ""
+    )
     console.print(
         Panel(
             f"{_BANNER}  {_SEP}  [bold]{spec_name}[/bold]  {_SEP}  k=[cyan]{k}[/cyan]  {_SEP}  {target}",
@@ -89,7 +93,11 @@ def update_progress(
     if cheated:
         status = f"[bold yellow]{_WARN} cheat[/bold yellow]"
     elif completed == k:
-        status = f"[bold green]{_CHECK}[/bold green]" if passed == k else f"[bold red]{_CROSS}[/bold red]"
+        status = (
+            f"[bold green]{_CHECK}[/bold green]"
+            if passed == k
+            else f"[bold red]{_CROSS}[/bold red]"
+        )
     else:
         status = f"[dim]{completed}/{k}[/dim]"
     progress.update(tid, total=k, completed=completed, status=status)
@@ -111,7 +119,9 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
     )
     console.print()
 
-    table = Table(box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False)
+    table = Table(
+        box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False
+    )
     table.add_column("ID", style="dim", no_wrap=True)
     table.add_column("Task")
     table.add_column(f"k ({k})", justify="center")
@@ -121,10 +131,14 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
     for tr in results.task_results:
         cheated_count = sum(1 for a in tr.attempts if a.cheated)
         status_text = _status_cell(tr, cheated_count > 0)
+        usable_attempts = len(tr.attempts) - tr.unusable_attempts
+        attempts_text = f"{tr.successes}/{usable_attempts}"
+        if tr.unusable_attempts:
+            attempts_text += f" (+{tr.unusable_attempts} unusable)"
         table.add_row(
             tr.task_id,
             tr.task_name,
-            f"{tr.successes}/{k}",
+            attempts_text,
             f"{tr.pass_at_k * 100:.1f}%",
             status_text,
         )
@@ -148,7 +162,11 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
 def _status_cell(tr: TaskResult, any_cheat: bool) -> Text:
     if any_cheat:
         return Text(f"{_WARN} CHEAT", style="bold yellow")
-    if tr.successes == tr.pass_at_k * len(tr.attempts) and tr.successes == len(tr.attempts):
+    if tr.unusable_attempts and tr.unusable_attempts == len(tr.attempts):
+        return Text(f"{_WARN} UNUSABLE", style="bold yellow")
+    if tr.successes == tr.pass_at_k * len(tr.attempts) and tr.successes == len(
+        tr.attempts
+    ):
         pass
     if tr.pass_at_k >= 0.99:
         return Text(f"{_CHECK} PASS", style="bold green")
@@ -163,11 +181,19 @@ def _print_aggregate(results: RunResults) -> None:
 
     def score_bar(score: float, width: int = 20) -> str:
         filled = round(score * width)
-        return "[green]" + _BAR_FULL * filled + "[/green][dim]" + _BAR_EMPTY * (width - filled) + "[/dim]"
+        return (
+            "[green]"
+            + _BAR_FULL * filled
+            + "[/green][dim]"
+            + _BAR_EMPTY * (width - filled)
+            + "[/dim]"
+        )
 
     console.print(
         f" [bold]With skill[/bold]    [cyan]{agg.avg_pass_at_k * 100:.1f}%[/cyan]  {score_bar(agg.avg_pass_at_k)}"
     )
+    if agg.unusable_attempts:
+        console.print(f" [yellow]{agg.unusable_attempts} unusable attempts[/yellow]")
 
     if results.baseline:
         base = results.baseline
@@ -202,12 +228,23 @@ def _format_output(output: str) -> str:
 def _print_task_detail(tr: TaskResult, k: int) -> None:
     lines: list[str] = []
     for attempt in tr.attempts:
+        outcome = attempt.outcome or (
+            Outcome.PASS if attempt.passed else Outcome.TASK_FAIL
+        )
         prefix = (
             f"[green]{_CHECK}[/green]"
             if attempt.passed
-            else (f"[yellow]{_WARN}[/yellow]" if attempt.cheated else f"[red]{_CROSS}[/red]")
+            else (
+                f"[yellow]{_WARN}[/yellow]"
+                if attempt.cheated
+                or outcome
+                in {Outcome.INFRA_ERROR, Outcome.TIMEOUT, Outcome.JUDGE_ERROR}
+                else f"[red]{_CROSS}[/red]"
+            )
         )
-        lines.append(f"  Attempt {attempt.attempt}  {prefix}  ({attempt.duration_seconds:.1f}s)")
+        lines.append(
+            f"  Attempt {attempt.attempt}  {prefix}  {outcome.value}  ({attempt.duration_seconds:.1f}s)"
+        )
         if attempt.cheated:
             for ev in attempt.cheat_evidence:
                 lines.append(f"    [yellow]cheat:[/yellow] {ev}")

--- a/caliper/resources/evaluate_skill/REFERENCE.md
+++ b/caliper/resources/evaluate_skill/REFERENCE.md
@@ -115,6 +115,7 @@ judge:
 ## Key concepts
 
 - **pass@k** — probability that at least 1 of k attempts passes (default k=3)
+- **outcome** — per-attempt result tag: `pass`, `task_fail`, `judge_error`, `infra_error`, `timeout`, or `cheat`
 - **baseline** — runs each task without the skill to compute a delta score
 - **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
@@ -127,6 +128,11 @@ judge:
 Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.json`
 alongside the spec file. Each result includes a full skill snapshot (content + git SHA
 of the skill file and any referenced scripts) for reproducibility.
+
+Each attempt keeps `passed` for compatibility and adds `outcome` for diagnosis.
+`infra_error`, `timeout`, and `judge_error` are unusable attempts: they are shown
+separately and excluded from the pass@k denominator so rate limits, CLI failures,
+timeouts, or judge failures do not masquerade as skill regressions.
 
 ## Designing good evals — full guidance
 

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -22,9 +22,15 @@ from caliper.schema.results import (
     RunResults,
     SkillSnapshot,
     TaskResult,
+    Outcome,
 )
 from caliper.schema.spec import EvalSpec, TaskSpec, spec_name
-from caliper.scoring import aggregate_scores, compute_delta, pass_at_k
+from caliper.scoring import (
+    aggregate_scores,
+    classify_outcome,
+    compute_delta,
+    score_outcomes,
+)
 
 
 @dataclass
@@ -60,16 +66,34 @@ def run(
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures_with = {
             pool.submit(
-                _run_task, task, harness, judge, cheat, spec, spec_path,
-                k, timeout, True, on_attempt_done,
+                _run_task,
+                task,
+                harness,
+                judge,
+                cheat,
+                spec,
+                spec_path,
+                k,
+                timeout,
+                True,
+                on_attempt_done,
             ): task
             for task in spec.tasks
         }
         futures_without = (
             {
                 pool.submit(
-                    _run_task, task, harness, judge, cheat, spec, spec_path,
-                    k, timeout, False, on_attempt_done,
+                    _run_task,
+                    task,
+                    harness,
+                    judge,
+                    cheat,
+                    spec,
+                    spec_path,
+                    k,
+                    timeout,
+                    False,
+                    on_attempt_done,
                 ): task
                 for task in spec.tasks
             }
@@ -88,7 +112,13 @@ def run(
     task_results_without.sort(key=lambda r: r.task_id)
 
     pass_counts_with = {
-        r.task_id: (r.task_name, r.successes, k) for r in task_results_with
+        r.task_id: (
+            r.task_name,
+            r.successes,
+            len(r.attempts) - r.unusable_attempts,
+            r.unusable_attempts,
+        )
+        for r in task_results_with
     }
     agg_with = aggregate_scores(pass_counts_with)
 
@@ -96,7 +126,13 @@ def run(
     delta: DeltaReport | None = None
     if baseline and task_results_without:
         pass_counts_without = {
-            r.task_id: (r.task_name, r.successes, k) for r in task_results_without
+            r.task_id: (
+                r.task_name,
+                r.successes,
+                len(r.attempts) - r.unusable_attempts,
+                r.unusable_attempts,
+            )
+            for r in task_results_without
         }
         agg_without = aggregate_scores(pass_counts_without)
         delta = compute_delta(agg_with, agg_without)
@@ -132,18 +168,27 @@ def _run_task(
     attempts: list[AttemptRecord] = []
     for attempt_num in range(1, k + 1):
         record = _run_attempt(
-            task, attempt_num, harness, judge, cheat,
-            spec, spec_path, timeout, with_skill, on_attempt_done,
+            task,
+            attempt_num,
+            harness,
+            judge,
+            cheat,
+            spec,
+            spec_path,
+            timeout,
+            with_skill,
+            on_attempt_done,
         )
         attempts.append(record)
 
-    successes = sum(1 for a in attempts if a.passed)
+    score = score_outcomes([a.outcome for a in attempts if a.outcome is not None])
     return TaskResult(
         task_id=task.id,
         task_name=task.name,
         attempts=attempts,
-        successes=successes,
-        pass_at_k=pass_at_k(successes, k),
+        successes=score.successes,
+        pass_at_k=score.pass_at_k,
+        unusable_attempts=score.unusable_attempts,
     )
 
 
@@ -163,8 +208,7 @@ def _run_attempt(
     try:
         _run_shell(task.setup)
         resolved_extra_path = [
-            str((spec_path.parent / p).resolve())
-            for p in spec.sandbox.extra_path
+            str((spec_path.parent / p).resolve()) for p in spec.sandbox.extra_path
         ]
         skill_path = _resolve_skill_path(spec, spec_path) if with_skill else None
         if skill_path:
@@ -184,13 +228,24 @@ def _run_attempt(
 
         if attempt_result.exit_code != 0:
             error = attempt_result.error or f"harness exited {attempt_result.exit_code}"
+            outcome = classify_outcome(
+                exit_code=attempt_result.exit_code,
+                error=error,
+                cheated=False,
+                judge_result=None,
+            )
             if on_attempt_done:
-                on_attempt_done(AttemptEvent(task_id=task.id, attempt=attempt, passed=False, cheated=False))
+                on_attempt_done(
+                    AttemptEvent(
+                        task_id=task.id, attempt=attempt, passed=False, cheated=False
+                    )
+                )
             return AttemptRecord(
                 attempt=attempt,
                 output=attempt_result.final_output,
                 duration_seconds=attempt_result.duration_seconds,
                 passed=False,
+                outcome=outcome,
                 cheated=False,
                 assert_passed=False,
                 assert_evidence=error,
@@ -198,13 +253,24 @@ def _run_attempt(
 
         cheat_violations = cheat.check(attempt_result.transcript)
         if cheat_violations:
+            outcome = classify_outcome(
+                exit_code=attempt_result.exit_code,
+                error=attempt_result.error,
+                cheated=True,
+                judge_result=None,
+            )
             if on_attempt_done:
-                on_attempt_done(AttemptEvent(task_id=task.id, attempt=attempt, passed=False, cheated=True))
+                on_attempt_done(
+                    AttemptEvent(
+                        task_id=task.id, attempt=attempt, passed=False, cheated=True
+                    )
+                )
             return AttemptRecord(
                 attempt=attempt,
                 output=attempt_result.final_output,
                 duration_seconds=attempt_result.duration_seconds,
                 passed=False,
+                outcome=outcome,
                 cheated=True,
                 cheat_evidence=cheat_violations,
             )
@@ -216,15 +282,26 @@ def _run_attempt(
             spec_dir=str(spec_path.parent),
         )
 
-        passed = judge_result.passed
+        outcome = classify_outcome(
+            exit_code=attempt_result.exit_code,
+            error=attempt_result.error,
+            cheated=False,
+            judge_result=judge_result,
+        )
+        passed = outcome == Outcome.PASS
         if on_attempt_done:
-            on_attempt_done(AttemptEvent(task_id=task.id, attempt=attempt, passed=passed, cheated=False))
+            on_attempt_done(
+                AttemptEvent(
+                    task_id=task.id, attempt=attempt, passed=passed, cheated=False
+                )
+            )
 
         return AttemptRecord(
             attempt=attempt,
             output=attempt_result.final_output,
             duration_seconds=attempt_result.duration_seconds,
             passed=passed,
+            outcome=outcome,
             cheated=False,
             assert_passed=judge_result.assert_passed,
             assert_evidence=judge_result.assert_evidence,

--- a/caliper/schema/results.py
+++ b/caliper/schema/results.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class FileSnapshot(BaseModel):
@@ -25,17 +26,42 @@ class RunMeta(BaseModel):
     model: str | None = None
 
 
+class Outcome(str, Enum):
+    PASS = "pass"
+    TASK_FAIL = "task_fail"
+    JUDGE_ERROR = "judge_error"
+    INFRA_ERROR = "infra_error"
+    TIMEOUT = "timeout"
+    CHEAT = "cheat"
+
+
 class AttemptRecord(BaseModel):
     attempt: int
     output: str
     duration_seconds: float
     passed: bool
+    outcome: Outcome | None = None
     cheated: bool = False
     cheat_evidence: list[str] = Field(default_factory=list)
     assert_passed: bool | None = None
     assert_evidence: str | None = None
     autorater_passed: bool | None = None
     autorater_reasoning: str | None = None
+
+    @model_validator(mode="after")
+    def sync_outcome_and_passed(self) -> AttemptRecord:
+        if self.outcome is None:
+            if self.passed:
+                self.outcome = Outcome.PASS
+            elif self.cheated:
+                self.outcome = Outcome.CHEAT
+            else:
+                self.outcome = Outcome.TASK_FAIL
+
+        self.passed = self.outcome == Outcome.PASS
+        if self.outcome == Outcome.CHEAT:
+            self.cheated = True
+        return self
 
 
 class TaskResult(BaseModel):
@@ -44,6 +70,7 @@ class TaskResult(BaseModel):
     attempts: list[AttemptRecord]
     successes: int
     pass_at_k: float
+    unusable_attempts: int = 0
 
 
 class TaskScore(BaseModel):
@@ -52,11 +79,13 @@ class TaskScore(BaseModel):
     k: int
     successes: int
     score: float
+    unusable_attempts: int = 0
 
 
 class AggregateScore(BaseModel):
     avg_pass_at_k: float
     per_task: list[TaskScore]
+    unusable_attempts: int = 0
 
 
 class DeltaReport(BaseModel):

--- a/caliper/scoring.py
+++ b/caliper/scoring.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
 
-from caliper.schema.results import AggregateScore, DeltaReport, TaskScore
+from dataclasses import dataclass
+
+from caliper.judge.base import JudgeResult
+from caliper.schema.results import AggregateScore, DeltaReport, Outcome, TaskScore
+
+
+@dataclass(frozen=True)
+class OutcomeScore:
+    successes: int
+    usable_attempts: int
+    unusable_attempts: int
+    pass_at_k: float
 
 
 def pass_at_k(successes: int, k: int) -> float:
@@ -10,22 +21,104 @@ def pass_at_k(successes: int, k: int) -> float:
     return 1.0 - (1.0 - p) ** k
 
 
-def aggregate_scores(task_pass_counts: dict[str, tuple[str, int, int]]) -> AggregateScore:
+UNUSABLE_OUTCOMES = {
+    Outcome.INFRA_ERROR,
+    Outcome.TIMEOUT,
+    Outcome.JUDGE_ERROR,
+}
+
+
+def classify_outcome(
+    *,
+    exit_code: int,
+    error: str | None,
+    cheated: bool,
+    judge_result: JudgeResult | None,
+) -> Outcome:
+    error_text = (error or "").lower()
+    if exit_code == 124 or "timeout" in error_text or "timed out" in error_text:
+        return Outcome.TIMEOUT
+    if exit_code != 0 or error:
+        return Outcome.INFRA_ERROR
+    if cheated:
+        return Outcome.CHEAT
+    if judge_result is None:
+        return Outcome.TASK_FAIL
+    if judge_result.passed:
+        return Outcome.PASS
+    if _is_judge_error(judge_result):
+        return Outcome.JUDGE_ERROR
+    return Outcome.TASK_FAIL
+
+
+def _is_judge_error(judge_result: JudgeResult) -> bool:
+    text = " ".join(
+        part
+        for part in (
+            judge_result.reasoning,
+            judge_result.assert_evidence,
+            judge_result.autorater_reasoning,
+        )
+        if part
+    ).lower()
+    markers = (
+        "judge returned unparseable",
+        "judge returned empty script",
+        "judge timed out",
+        "judge failed",
+        "codex judge failed",
+        "claude-api judge failed",
+        "openai-api judge failed",
+        "assertion script timed out",
+    )
+    return any(marker in text for marker in markers)
+
+
+def score_outcomes(outcomes: list[Outcome]) -> OutcomeScore:
+    successes = sum(1 for outcome in outcomes if outcome == Outcome.PASS)
+    unusable_attempts = sum(1 for outcome in outcomes if outcome in UNUSABLE_OUTCOMES)
+    usable_attempts = len(outcomes) - unusable_attempts
+    return OutcomeScore(
+        successes=successes,
+        usable_attempts=usable_attempts,
+        unusable_attempts=unusable_attempts,
+        pass_at_k=pass_at_k(successes, usable_attempts),
+    )
+
+
+def aggregate_scores(
+    task_pass_counts: dict[str, tuple[str, int, int] | tuple[str, int, int, int]],
+) -> AggregateScore:
     """
-    task_pass_counts: {task_id: (task_name, successes, k)}
+    task_pass_counts: {task_id: (task_name, successes, usable_attempts[, unusable_attempts])}
     """
     per_task: list[TaskScore] = []
-    for task_id, (task_name, successes, k) in task_pass_counts.items():
+    total_unusable = 0
+    for task_id, counts in task_pass_counts.items():
+        task_name, successes, k = counts[:3]
+        unusable_attempts = counts[3] if len(counts) > 3 else 0
+        total_unusable += unusable_attempts
         score = pass_at_k(successes, k)
         per_task.append(
-            TaskScore(task_id=task_id, task_name=task_name, k=k, successes=successes, score=score)
+            TaskScore(
+                task_id=task_id,
+                task_name=task_name,
+                k=k,
+                successes=successes,
+                score=score,
+                unusable_attempts=unusable_attempts,
+            )
         )
 
     avg = sum(t.score for t in per_task) / len(per_task) if per_task else 0.0
-    return AggregateScore(avg_pass_at_k=avg, per_task=per_task)
+    return AggregateScore(
+        avg_pass_at_k=avg, per_task=per_task, unusable_attempts=total_unusable
+    )
 
 
-def compute_delta(with_skill: AggregateScore, without_skill: AggregateScore) -> DeltaReport:
+def compute_delta(
+    with_skill: AggregateScore, without_skill: AggregateScore
+) -> DeltaReport:
     return DeltaReport(
         with_skill=with_skill,
         without_skill=without_skill,

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -115,6 +115,7 @@ judge:
 ## Key concepts
 
 - **pass@k** — probability that at least 1 of k attempts passes (default k=3)
+- **outcome** — per-attempt result tag: `pass`, `task_fail`, `judge_error`, `infra_error`, `timeout`, or `cheat`
 - **baseline** — runs each task without the skill to compute a delta score
 - **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
@@ -127,6 +128,11 @@ judge:
 Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.json`
 alongside the spec file. Each result includes a full skill snapshot (content + git SHA
 of the skill file and any referenced scripts) for reproducibility.
+
+Each attempt keeps `passed` for compatibility and adds `outcome` for diagnosis.
+`infra_error`, `timeout`, and `judge_error` are unusable attempts: they are shown
+separately and excluded from the pass@k denominator so rate limits, CLI failures,
+timeouts, or judge failures do not masquerade as skill regressions.
 
 ## Designing good evals — full guidance
 

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -39,6 +39,11 @@ caliper report path/to/spec.eval.yaml --verbose
 caliper report path/to/spec.eval.yaml --run 2026-06-21T14-53-12Z --verbose
 ```
 
+Each saved attempt includes an `outcome`: `pass`, `task_fail`, `judge_error`,
+`infra_error`, `timeout`, or `cheat`. Treat `infra_error`, `timeout`, and
+`judge_error` as unusable attempt noise rather than skill regressions; Caliper
+shows them separately and excludes them from the pass@k denominator.
+
 ## Spec skeleton (claude-code backend)
 
 ```yaml

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
 import io
+import json
 from datetime import datetime, timezone
 
 from rich.console import Console
 
-from caliper.reporter import _OUTPUT_TRUNCATE_AT, _format_output, make_progress, print_results
+from caliper.reporter import (
+    _OUTPUT_TRUNCATE_AT,
+    _format_output,
+    make_progress,
+    print_results,
+    results_to_json,
+)
 from caliper.schema.results import (
     AggregateScore,
     AttemptRecord,
+    Outcome,
     RunMeta,
     RunResults,
     SkillSnapshot,
@@ -35,12 +43,14 @@ def _make_attempt(
     output: str = "some output",
     assert_evidence: str | None = None,
     autorater_reasoning: str | None = None,
+    outcome: Outcome | None = None,
 ) -> AttemptRecord:
     return AttemptRecord(
         attempt=1,
         output=output,
         duration_seconds=5.0,
         passed=passed,
+        outcome=outcome,
         assert_passed=passed if assert_evidence is None else not passed,
         assert_evidence=assert_evidence,
         autorater_passed=None,
@@ -55,12 +65,15 @@ def _make_task(
     output: str = "some output",
     assert_evidence: str | None = None,
     autorater_reasoning: str | None = None,
+    outcome: Outcome | None = None,
+    unusable_attempts: int = 0,
 ) -> TaskResult:
     attempt = _make_attempt(
         passed=passed,
         output=output,
         assert_evidence=assert_evidence,
         autorater_reasoning=autorater_reasoning,
+        outcome=outcome,
     )
     return TaskResult(
         task_id=task_id,
@@ -68,6 +81,7 @@ def _make_task(
         attempts=[attempt],
         successes=1 if passed else 0,
         pass_at_k=1.0 if passed else 0.0,
+        unusable_attempts=unusable_attempts,
     )
 
 
@@ -79,6 +93,7 @@ def _make_results(task_results: list[TaskResult]) -> RunResults:
             k=1,
             successes=tr.successes,
             score=tr.pass_at_k,
+            unusable_attempts=tr.unusable_attempts,
         )
         for tr in task_results
     ]
@@ -94,6 +109,7 @@ def _make_results(task_results: list[TaskResult]) -> RunResults:
         aggregate=AggregateScore(
             avg_pass_at_k=sum(tr.pass_at_k for tr in task_results) / len(task_results),
             per_task=scores,
+            unusable_attempts=sum(tr.unusable_attempts for tr in task_results),
         ),
     )
 
@@ -180,7 +196,12 @@ def test_only_failed_tasks_shown_in_mixed_results() -> None:
     results = _make_results(
         [
             _make_task("task-001", passed=True, output="pass output"),
-            _make_task("task-002", passed=False, output="fail output", assert_evidence="file not found"),
+            _make_task(
+                "task-002",
+                passed=False,
+                output="fail output",
+                assert_evidence="file not found",
+            ),
         ]
     )
     out = _render(results)
@@ -221,9 +242,7 @@ def test_verbose_shows_all_tasks() -> None:
 
 def test_long_output_truncated_in_rendered_output() -> None:
     long_output = "z" * (_OUTPUT_TRUNCATE_AT + 200)
-    results = _make_results(
-        [_make_task("task-001", passed=False, output=long_output)]
-    )
+    results = _make_results([_make_task("task-001", passed=False, output=long_output)])
     out = _render(results)
     assert "truncated" in out
     # Rich wraps long lines; count total z's to verify the tail was included
@@ -231,9 +250,7 @@ def test_long_output_truncated_in_rendered_output() -> None:
 
 
 def test_empty_output_renders_no_output_marker() -> None:
-    results = _make_results(
-        [_make_task("task-001", passed=False, output="")]
-    )
+    results = _make_results([_make_task("task-001", passed=False, output="")])
     out = _render(results)
     assert "no output" in out
 
@@ -249,3 +266,40 @@ def test_autorater_reasoning_shown_for_failed_task() -> None:
     )
     out = _render(results)
     assert "judge said no" in out
+
+
+def test_unusable_attempt_count_shown_in_report_summary() -> None:
+    results = _make_results(
+        [
+            _make_task(
+                "task-001",
+                passed=False,
+                output="Spending cap reached resets 4:30am",
+                outcome=Outcome.INFRA_ERROR,
+                assert_evidence="Spending cap reached resets 4:30am",
+                unusable_attempts=1,
+            )
+        ]
+    )
+
+    out = _render(results)
+
+    assert "1 unusable" in out
+    assert "infra_error" in out
+
+
+def test_results_json_includes_outcome() -> None:
+    results = _make_results(
+        [
+            _make_task(
+                "task-001",
+                passed=False,
+                outcome=Outcome.INFRA_ERROR,
+                unusable_attempts=1,
+            )
+        ]
+    )
+
+    payload = json.loads(results_to_json(results))
+
+    assert payload["task_results"][0]["attempts"][0]["outcome"] == "infra_error"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from caliper.harness.base import AttemptResult, HarnessBackend
 from caliper.judge.base import Judge, JudgeResult
 from caliper.runner import _stage_skill_directory, run
+from caliper.schema.results import Outcome
 from caliper.schema.spec import EvalSpec, SkillConfig, TaskSpec
 
 
@@ -71,8 +72,11 @@ def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
 
     attempt = results.task_results[0].attempts[0]
     assert attempt.passed is False
+    assert attempt.outcome == Outcome.INFRA_ERROR
     assert attempt.assert_passed is False
     assert attempt.assert_evidence == "agent failed"
+    assert results.task_results[0].unusable_attempts == 1
+    assert results.aggregate.unusable_attempts == 1
     assert results.aggregate.avg_pass_at_k == 0
     assert judge.calls == 0
 
@@ -107,9 +111,7 @@ def test_stage_excludes_cheat_surfaces(tmp_path) -> None:
     home = tmp_path / "home"
     home.mkdir()
 
-    _stage_skill_directory(
-        str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"]
-    )
+    _stage_skill_directory(str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"])
 
     assert not (home / ".caliper").exists()
     assert not (home / "my-skill.eval.yaml").exists()

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+
+from caliper.judge.base import JudgeResult
+from caliper.schema.results import AttemptRecord, Outcome
+from caliper.scoring import classify_outcome, pass_at_k, score_outcomes
+
+
+def test_classify_outcome_covers_attempt_taxonomy() -> None:
+    assert (
+        classify_outcome(
+            exit_code=0,
+            error=None,
+            cheated=False,
+            judge_result=JudgeResult(passed=True, reasoning="ok"),
+        )
+        == Outcome.PASS
+    )
+    assert (
+        classify_outcome(
+            exit_code=0,
+            error=None,
+            cheated=False,
+            judge_result=JudgeResult(passed=False, reasoning="wrong answer"),
+        )
+        == Outcome.TASK_FAIL
+    )
+    assert (
+        classify_outcome(
+            exit_code=1,
+            error="Spending cap reached resets 4:30am",
+            cheated=False,
+            judge_result=None,
+        )
+        == Outcome.INFRA_ERROR
+    )
+    assert (
+        classify_outcome(
+            exit_code=124,
+            error="timeout",
+            cheated=False,
+            judge_result=None,
+        )
+        == Outcome.TIMEOUT
+    )
+    assert (
+        classify_outcome(
+            exit_code=0,
+            error=None,
+            cheated=True,
+            judge_result=None,
+        )
+        == Outcome.CHEAT
+    )
+    assert (
+        classify_outcome(
+            exit_code=0,
+            error=None,
+            cheated=False,
+            judge_result=JudgeResult(
+                passed=False,
+                reasoning="Judge returned unparseable response: nope",
+                autorater_passed=False,
+                autorater_reasoning="Judge returned unparseable response: nope",
+            ),
+        )
+        == Outcome.JUDGE_ERROR
+    )
+
+
+def test_score_outcomes_excludes_unusable_attempts_from_pass_at_k() -> None:
+    score = score_outcomes(
+        [
+            Outcome.PASS,
+            Outcome.TASK_FAIL,
+            Outcome.INFRA_ERROR,
+            Outcome.TIMEOUT,
+            Outcome.JUDGE_ERROR,
+            Outcome.CHEAT,
+        ]
+    )
+
+    assert score.successes == 1
+    assert score.usable_attempts == 3
+    assert score.unusable_attempts == 3
+    assert score.pass_at_k == pytest.approx(pass_at_k(successes=1, k=3))
+
+
+def test_attempt_record_defaults_outcome_for_old_json() -> None:
+    assert (
+        AttemptRecord(
+            attempt=1,
+            output="ok",
+            duration_seconds=0.1,
+            passed=True,
+        ).outcome
+        == Outcome.PASS
+    )
+    assert (
+        AttemptRecord(
+            attempt=1,
+            output="bad",
+            duration_seconds=0.1,
+            passed=False,
+            cheated=True,
+        ).outcome
+        == Outcome.CHEAT
+    )
+
+
+def test_attempt_record_keeps_passed_equal_to_outcome() -> None:
+    record = AttemptRecord(
+        attempt=1,
+        output="rate limited",
+        duration_seconds=0.1,
+        passed=True,
+        outcome=Outcome.INFRA_ERROR,
+    )
+
+    assert record.passed is False


### PR DESCRIPTION
## Summary
- add an `Outcome` taxonomy and `AttemptRecord.outcome` while keeping `passed` backward compatible
- classify harness failures, timeouts, cheat detections, task failures, and explicit judge errors in one scoring path
- exclude `infra_error`, `timeout`, and `judge_error` from the pass@k denominator and report unusable attempts in table/detail output
- document the result JSON/schema behavior in README and packaged skill references

Fixes #22.

## Tests
- `.venv/bin/python -m pytest tests/test_scoring.py tests/test_runner.py tests/test_reporter.py -q`
- `.venv/bin/python -m pytest -q -k 'not test_install_skill_refuses_to_overwrite_without_force'`\n- `.venv/bin/ruff check caliper/schema/results.py caliper/scoring.py caliper/runner.py caliper/reporter.py tests/test_scoring.py tests/test_runner.py tests/test_reporter.py`\n- `.venv/bin/ruff format --check caliper/schema/results.py caliper/scoring.py caliper/runner.py caliper/reporter.py tests/test_scoring.py tests/test_runner.py tests/test_reporter.py`\n\nNote: full `.venv/bin/python -m pytest -q` still has the pre-existing `tests/test_install_skill.py::test_install_skill_refuses_to_overwrite_without_force` failure in this environment: the `ClickException` message is present on the result exception, but `result.output` is empty. I observed the same failure before this change.