### PR TITLE
Bump publish workflow actions off deprecated Node 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Build distributions


### PR DESCRIPTION
The `v0.4.0` publish run flagged that `actions/checkout@v4` and `actions/setup-python@v5` target Node 20, which GitHub is [deprecating](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) — runs are currently being force-migrated to Node 24.

Bumps both to the versions that run on Node 24 natively:
- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`

`pypa/gh-action-pypi-publish@release/v1` is Docker-based and unaffected. No behavior change; this only silences the deprecation warning and future-proofs the release pipeline. Takes effect on the next published release.