### PR TITLE
Add fail-fast for repeated unusable attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ When both `expect` and `assert` are present, both must pass.
 | `--baseline` | off | Also run each task without the skill |
 | `--workers INT` | `4` | Parallel task workers |
 | `--timeout INT` | `120` | Seconds per attempt |
+| `--fail-fast INT` | `0` | Stop a task after N consecutive `infra_error`/`timeout` attempts (`0` disables) |
 | `--model TARGET` | — | Override skill backend and/or model (see below) |
 | `--judge-model TARGET` | — | Override judge backend and/or model (see below) |
 | `--verbose` | off | Show per-attempt judge reasoning |
@@ -451,6 +452,13 @@ The aggregate score is the average task pass@k, skipping tasks with no usable
 attempts. With `--baseline`, Caliper runs the same tasks without the skill and
 reports the delta. A throttled or judge-flaked run therefore no longer
 masquerades as a regression.
+
+For persistent infrastructure failures, `--fail-fast N` can stop scheduling new
+attempts for a task after N consecutive `infra_error` or `timeout` outcomes.
+The default `0` keeps the historical behavior and runs all k attempts. An
+early-stopped task is shown as `ABORTED` in the report; if every completed
+attempt was unusable, its `pass_at_k` remains `null` and it is skipped in the
+aggregate score.
 
 ---
 

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -29,11 +29,32 @@ def run_cmd(
     k: int = typer.Option(3, "--k", help="Attempts per task"),
     workers: int = typer.Option(4, "--workers", help="Parallel task workers"),
     timeout: int = typer.Option(120, "--timeout", help="Seconds per attempt"),
-    baseline: bool = typer.Option(False, "--baseline", help="Also run without skill for delta"),
-    output: Optional[Path] = typer.Option(None, "--output", help="Save results JSON to path"),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show per-attempt reasoning"),
-    model: Optional[str] = typer.Option(None, "--model", "-m", help="Override skill backend/model (e.g. claude-api:claude-sonnet-4-6 or claude-sonnet-4-6)"),
-    judge_model: Optional[str] = typer.Option(None, "--judge-model", help="Override judge backend/model (e.g. claude-api:claude-haiku-4-5-20251001)"),
+    fail_fast_unusable: int = typer.Option(
+        0,
+        "--fail-fast",
+        min=0,
+        help="Stop a task after N consecutive infra_error/timeout attempts (0 disables)",
+    ),
+    baseline: bool = typer.Option(
+        False, "--baseline", help="Also run without skill for delta"
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", help="Save results JSON to path"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show per-attempt reasoning"
+    ),
+    model: Optional[str] = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help="Override skill backend/model (e.g. claude-api:claude-sonnet-4-6 or claude-sonnet-4-6)",
+    ),
+    judge_model: Optional[str] = typer.Option(
+        None,
+        "--judge-model",
+        help="Override judge backend/model (e.g. claude-api:claude-haiku-4-5-20251001)",
+    ),
 ) -> None:
     if not spec_file.exists():
         console.print(f"[bold red]Error:[/bold red] File not found: {spec_file}")
@@ -107,6 +128,7 @@ def run_cmd(
                 k=k,
                 workers=workers,
                 timeout=timeout,
+                fail_fast_unusable=fail_fast_unusable,
                 baseline=baseline,
                 on_attempt_done=on_attempt_done,
             )

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -18,7 +18,7 @@ from caliper.reporter import (
     update_progress,
 )
 from caliper.runner import run, AttemptEvent
-from caliper.schema.results import Outcome
+from caliper.schema.results import Outcome, TaskResult
 from caliper.schema.spec import load_spec, parse_target, spec_name
 
 console = Console()
@@ -118,6 +118,21 @@ def run_cmd(
             unusable=unusable_counts[task.name],
         )
 
+    def on_task_done(result: TaskResult) -> None:
+        if len(result.attempts) >= k:
+            return
+        update_progress(
+            progress,
+            task_ids,
+            result.task_name,
+            k,
+            len(result.attempts),
+            result.successes,
+            cheated=any(attempt.outcome == Outcome.CHEAT for attempt in result.attempts),
+            unusable=result.unusable,
+            finished=True,
+        )
+
     with progress:
         try:
             results = run(
@@ -131,6 +146,7 @@ def run_cmd(
                 fail_fast_unusable=fail_fast_unusable,
                 baseline=baseline,
                 on_attempt_done=on_attempt_done,
+                on_task_done=on_task_done,
             )
         except HarnessConfigurationError as exc:
             console.print(

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -29,32 +29,12 @@ def run_cmd(
     k: int = typer.Option(3, "--k", help="Attempts per task"),
     workers: int = typer.Option(4, "--workers", help="Parallel task workers"),
     timeout: int = typer.Option(120, "--timeout", help="Seconds per attempt"),
-    fail_fast_unusable: int = typer.Option(
-        0,
-        "--fail-fast",
-        min=0,
-        help="Stop a task after N consecutive infra_error/timeout attempts (0 disables)",
-    ),
-    baseline: bool = typer.Option(
-        False, "--baseline", help="Also run without skill for delta"
-    ),
-    output: Optional[Path] = typer.Option(
-        None, "--output", help="Save results JSON to path"
-    ),
-    verbose: bool = typer.Option(
-        False, "--verbose", "-v", help="Show per-attempt reasoning"
-    ),
-    model: Optional[str] = typer.Option(
-        None,
-        "--model",
-        "-m",
-        help="Override skill backend/model (e.g. claude-api:claude-sonnet-4-6 or claude-sonnet-4-6)",
-    ),
-    judge_model: Optional[str] = typer.Option(
-        None,
-        "--judge-model",
-        help="Override judge backend/model (e.g. claude-api:claude-haiku-4-5-20251001)",
-    ),
+    fail_fast_unusable: int = typer.Option(0, "--fail-fast", min=0, help="Stop a task after N consecutive infra_error/timeout attempts (0 disables)"),
+    baseline: bool = typer.Option(False, "--baseline", help="Also run without skill for delta"),
+    output: Optional[Path] = typer.Option(None, "--output", help="Save results JSON to path"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show per-attempt reasoning"),
+    model: Optional[str] = typer.Option(None, "--model", "-m", help="Override skill backend/model (e.g. claude-api:claude-sonnet-4-6 or claude-sonnet-4-6)"),
+    judge_model: Optional[str] = typer.Option(None, "--judge-model", help="Override judge backend/model (e.g. claude-api:claude-haiku-4-5-20251001)"),
 ) -> None:
     if not spec_file.exists():
         console.print(f"[bold red]Error:[/bold red] File not found: {spec_file}")

--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -50,12 +50,8 @@ _OUTCOME_GLYPH = {
 }
 
 
-def print_banner(
-    spec_name: str, k: int, backend: str, model: str | None = None
-) -> None:
-    target = f"[cyan]{backend}[/cyan]" + (
-        f" [dim]{_SEP} {model}[/dim]" if model else ""
-    )
+def print_banner(spec_name: str, k: int, backend: str, model: str | None = None) -> None:
+    target = f"[cyan]{backend}[/cyan]" + (f" [dim]{_SEP} {model}[/dim]" if model else "")
     console.print(
         Panel(
             f"{_BANNER}  {_SEP}  [bold]{spec_name}[/bold]  {_SEP}  k=[cyan]{k}[/cyan]  {_SEP}  {target}",
@@ -99,23 +95,22 @@ def update_progress(
     passed: int,
     cheated: bool = False,
     unusable: int = 0,
+    finished: bool = False,
 ) -> None:
     tid = task_ids.get(task_name)
     if tid is None:
         return
+    terminal = completed == k or finished
     if cheated:
         status = f"[bold yellow]{_WARN} cheat[/bold yellow]"
-    elif completed == k and unusable:
+    elif terminal and unusable:
         status = f"[bold yellow]{_UNUSABLE}{unusable}[/bold yellow]"
-    elif completed == k:
-        status = (
-            f"[bold green]{_CHECK}[/bold green]"
-            if passed == k
-            else f"[bold red]{_CROSS}[/bold red]"
-        )
+    elif terminal:
+        status = f"[bold green]{_CHECK}[/bold green]" if passed == k else f"[bold red]{_CROSS}[/bold red]"
     else:
         status = f"[dim]{completed}/{k}[/dim]"
-    progress.update(tid, total=k, completed=completed, status=status)
+    rendered_completed = k if finished and completed < k else completed
+    progress.update(tid, total=k, completed=rendered_completed, status=status)
 
 
 def print_results(results: RunResults, verbose: bool = False) -> None:
@@ -134,9 +129,7 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
     )
     console.print()
 
-    table = Table(
-        box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False
-    )
+    table = Table(box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False)
     table.add_column("ID", style="dim", no_wrap=True)
     table.add_column("Task")
     table.add_column(f"k ({k})", justify="center")
@@ -196,13 +189,7 @@ def _print_aggregate(results: RunResults) -> None:
 
     def score_bar(score: float, width: int = 20) -> str:
         filled = round(score * width)
-        return (
-            "[green]"
-            + _BAR_FULL * filled
-            + "[/green][dim]"
-            + _BAR_EMPTY * (width - filled)
-            + "[/dim]"
-        )
+        return "[green]" + _BAR_FULL * filled + "[/green][dim]" + _BAR_EMPTY * (width - filled) + "[/dim]"
 
     console.print(
         f" [bold]With skill[/bold]    [cyan]{agg.avg_pass_at_k * 100:.1f}%[/cyan]  {score_bar(agg.avg_pass_at_k)}"
@@ -260,17 +247,13 @@ def _format_output(output: str) -> str:
 
 def _print_task_detail(tr: TaskResult, k: int) -> None:
     lines: list[str] = []
-    if len(tr.attempts) < k:
+    if len(tr.attempts) < k and tr.pass_at_k is None:
         lines.append(
             f"  [yellow]ABORTED[/yellow] after {len(tr.attempts)}/{k} attempts"
         )
     for attempt in tr.attempts:
         prefix = _OUTCOME_GLYPH.get(attempt.outcome, f"[red]{_CROSS}[/red]")
-        label = (
-            ""
-            if attempt.outcome.is_usable
-            else f"  [yellow]{attempt.outcome.value}[/yellow]"
-        )
+        label = "" if attempt.outcome.is_usable else f"  [yellow]{attempt.outcome.value}[/yellow]"
         lines.append(
             f"  Attempt {attempt.attempt}  {prefix}{label}  ({attempt.duration_seconds:.1f}s)"
         )

--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -50,8 +50,12 @@ _OUTCOME_GLYPH = {
 }
 
 
-def print_banner(spec_name: str, k: int, backend: str, model: str | None = None) -> None:
-    target = f"[cyan]{backend}[/cyan]" + (f" [dim]{_SEP} {model}[/dim]" if model else "")
+def print_banner(
+    spec_name: str, k: int, backend: str, model: str | None = None
+) -> None:
+    target = f"[cyan]{backend}[/cyan]" + (
+        f" [dim]{_SEP} {model}[/dim]" if model else ""
+    )
     console.print(
         Panel(
             f"{_BANNER}  {_SEP}  [bold]{spec_name}[/bold]  {_SEP}  k=[cyan]{k}[/cyan]  {_SEP}  {target}",
@@ -104,7 +108,11 @@ def update_progress(
     elif completed == k and unusable:
         status = f"[bold yellow]{_UNUSABLE}{unusable}[/bold yellow]"
     elif completed == k:
-        status = f"[bold green]{_CHECK}[/bold green]" if passed == k else f"[bold red]{_CROSS}[/bold red]"
+        status = (
+            f"[bold green]{_CHECK}[/bold green]"
+            if passed == k
+            else f"[bold red]{_CROSS}[/bold red]"
+        )
     else:
         status = f"[dim]{completed}/{k}[/dim]"
     progress.update(tid, total=k, completed=completed, status=status)
@@ -126,7 +134,9 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
     )
     console.print()
 
-    table = Table(box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False)
+    table = Table(
+        box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False
+    )
     table.add_column("ID", style="dim", no_wrap=True)
     table.add_column("Task")
     table.add_column(f"k ({k})", justify="center")
@@ -135,7 +145,7 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
 
     for tr in results.task_results:
         cheated_count = sum(1 for a in tr.attempts if a.cheated)
-        status_text = _status_cell(tr, cheated_count > 0)
+        status_text = _status_cell(tr, k, cheated_count > 0)
         pass_at_k = "—" if tr.pass_at_k is None else f"{tr.pass_at_k * 100:.1f}%"
         table.add_row(
             tr.task_id,
@@ -165,9 +175,11 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
             _print_task_detail(tr, k)
 
 
-def _status_cell(tr: TaskResult, any_cheat: bool) -> Text:
+def _status_cell(tr: TaskResult, k: int, any_cheat: bool) -> Text:
     if any_cheat:
         return Text(f"{_WARN} CHEAT", style="bold yellow")
+    if len(tr.attempts) < k and tr.pass_at_k is None:
+        return Text(f"{_UNUSABLE} ABORTED", style="bold yellow")
     if tr.pass_at_k is None:
         return Text(f"{_UNUSABLE} UNUSABLE", style="bold yellow")
     suffix = f" ({tr.unusable} {_UNUSABLE})" if tr.unusable else ""
@@ -184,7 +196,13 @@ def _print_aggregate(results: RunResults) -> None:
 
     def score_bar(score: float, width: int = 20) -> str:
         filled = round(score * width)
-        return "[green]" + _BAR_FULL * filled + "[/green][dim]" + _BAR_EMPTY * (width - filled) + "[/dim]"
+        return (
+            "[green]"
+            + _BAR_FULL * filled
+            + "[/green][dim]"
+            + _BAR_EMPTY * (width - filled)
+            + "[/dim]"
+        )
 
     console.print(
         f" [bold]With skill[/bold]    [cyan]{agg.avg_pass_at_k * 100:.1f}%[/cyan]  {score_bar(agg.avg_pass_at_k)}"
@@ -242,9 +260,17 @@ def _format_output(output: str) -> str:
 
 def _print_task_detail(tr: TaskResult, k: int) -> None:
     lines: list[str] = []
+    if len(tr.attempts) < k:
+        lines.append(
+            f"  [yellow]ABORTED[/yellow] after {len(tr.attempts)}/{k} attempts"
+        )
     for attempt in tr.attempts:
         prefix = _OUTCOME_GLYPH.get(attempt.outcome, f"[red]{_CROSS}[/red]")
-        label = "" if attempt.outcome.is_usable else f"  [yellow]{attempt.outcome.value}[/yellow]"
+        label = (
+            ""
+            if attempt.outcome.is_usable
+            else f"  [yellow]{attempt.outcome.value}[/yellow]"
+        )
         lines.append(
             f"  Attempt {attempt.attempt}  {prefix}{label}  ({attempt.duration_seconds:.1f}s)"
         )

--- a/caliper/resources/evaluate_skill/REFERENCE.md
+++ b/caliper/resources/evaluate_skill/REFERENCE.md
@@ -116,6 +116,7 @@ judge:
 
 - **pass@k** — probability that at least 1 of k attempts passes (default k=3), computed over the *usable* attempts only
 - **outcome** — each attempt is typed `pass`, `task_fail`, `cheat`, `infra_error`, `timeout`, or `judge_error`; the last three are *unusable* (infrastructure/judge noise) and are excluded from the pass@k denominator and reported as a separate "N unusable" count, so a throttled or judge-flaked run is not mistaken for a regression. `passed` in the JSON equals `outcome == pass`.
+- **`--fail-fast N`** — optional run control that stops scheduling new attempts for a task after N consecutive `infra_error`/`timeout` outcomes; `0` disables it. Early-stopped tasks report as `ABORTED`, and tasks with no usable attempts keep `pass_at_k: null`.
 - **baseline** — runs each task without the skill to compute a delta score
 - **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
@@ -129,7 +130,8 @@ Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.jso
 alongside the spec file. Each result includes a full skill snapshot (content + git SHA
 of the skill file and any referenced scripts) for reproducibility. Each attempt
 records its `outcome` (see above) and per-task results include an `unusable` count;
-a task with no usable attempts has `pass_at_k: null`.
+a task with no usable attempts has `pass_at_k: null`. When `--fail-fast N` stops
+a task early, that task may contain fewer than k attempt records.
 
 ## Designing good evals — full guidance
 

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -28,6 +28,8 @@ from caliper.schema.results import (
 from caliper.schema.spec import EvalSpec, TaskSpec, spec_name
 from caliper.scoring import aggregate_scores, compute_delta, pass_at_k
 
+_FAIL_FAST_OUTCOMES = {Outcome.INFRA_ERROR, Outcome.TIMEOUT}
+
 
 @dataclass
 class AttemptEvent:
@@ -46,6 +48,7 @@ def run(
     timeout: int = 120,
     baseline: bool = False,
     on_attempt_done: Callable[[AttemptEvent], None] | None = None,
+    fail_fast_unusable: int = 0,
 ) -> RunResults:
     skill_snapshot = _SkillSnapshotter().snapshot(_resolve_skill_path(spec, spec_path))
 
@@ -61,16 +64,36 @@ def run(
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures_with = {
             pool.submit(
-                _run_task, task, harness, judge, cheat, spec, spec_path,
-                k, timeout, True, on_attempt_done,
+                _run_task,
+                task,
+                harness,
+                judge,
+                cheat,
+                spec,
+                spec_path,
+                k,
+                timeout,
+                True,
+                on_attempt_done,
+                fail_fast_unusable,
             ): task
             for task in spec.tasks
         }
         futures_without = (
             {
                 pool.submit(
-                    _run_task, task, harness, judge, cheat, spec, spec_path,
-                    k, timeout, False, on_attempt_done,
+                    _run_task,
+                    task,
+                    harness,
+                    judge,
+                    cheat,
+                    spec,
+                    spec_path,
+                    k,
+                    timeout,
+                    False,
+                    on_attempt_done,
+                    fail_fast_unusable,
                 ): task
                 for task in spec.tasks
             }
@@ -131,14 +154,30 @@ def _run_task(
     timeout: int,
     with_skill: bool,
     on_attempt_done: Callable[[AttemptEvent], None] | None,
+    fail_fast_unusable: int,
 ) -> TaskResult:
     attempts: list[AttemptRecord] = []
+    consecutive_unusable = 0
     for attempt_num in range(1, k + 1):
         record = _run_attempt(
-            task, attempt_num, harness, judge, cheat,
-            spec, spec_path, timeout, with_skill, on_attempt_done,
+            task,
+            attempt_num,
+            harness,
+            judge,
+            cheat,
+            spec,
+            spec_path,
+            timeout,
+            with_skill,
+            on_attempt_done,
         )
         attempts.append(record)
+        if record.outcome in _FAIL_FAST_OUTCOMES:
+            consecutive_unusable += 1
+        else:
+            consecutive_unusable = 0
+        if fail_fast_unusable > 0 and consecutive_unusable >= fail_fast_unusable:
+            break
 
     successes = sum(1 for a in attempts if a.outcome == Outcome.PASS)
     usable = sum(1 for a in attempts if a.outcome.is_usable)
@@ -169,8 +208,7 @@ def _run_attempt(
     try:
         _run_shell(task.setup)
         resolved_extra_path = [
-            str((spec_path.parent / p).resolve())
-            for p in spec.sandbox.extra_path
+            str((spec_path.parent / p).resolve()) for p in spec.sandbox.extra_path
         ]
         skill_path = _resolve_skill_path(spec, spec_path) if with_skill else None
         if skill_path:
@@ -200,7 +238,9 @@ def _run_attempt(
             or looks_like_infra_failure(infra_text)
         ):
             outcome = classify_outcome(attempt_result, [], None)
-            evidence = attempt_result.error or f"harness exited {attempt_result.exit_code}"
+            evidence = (
+                attempt_result.error or f"harness exited {attempt_result.exit_code}"
+            )
             return _finish(
                 AttemptRecord(
                     attempt=attempt,
@@ -262,7 +302,9 @@ def _finish(
 ) -> AttemptRecord:
     if on_attempt_done:
         on_attempt_done(
-            AttemptEvent(task_id=task.id, attempt=record.attempt, outcome=record.outcome)
+            AttemptEvent(
+                task_id=task.id, attempt=record.attempt, outcome=record.outcome
+            )
         )
     return record
 

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -48,6 +48,7 @@ def run(
     timeout: int = 120,
     baseline: bool = False,
     on_attempt_done: Callable[[AttemptEvent], None] | None = None,
+    on_task_done: Callable[[TaskResult], None] | None = None,
     fail_fast_unusable: int = 0,
 ) -> RunResults:
     skill_snapshot = _SkillSnapshotter().snapshot(_resolve_skill_path(spec, spec_path))
@@ -75,6 +76,7 @@ def run(
                 timeout,
                 True,
                 on_attempt_done,
+                on_task_done,
                 fail_fast_unusable,
             ): task
             for task in spec.tasks
@@ -93,6 +95,7 @@ def run(
                     timeout,
                     False,
                     on_attempt_done,
+                    on_task_done,
                     fail_fast_unusable,
                 ): task
                 for task in spec.tasks
@@ -154,35 +157,31 @@ def _run_task(
     timeout: int,
     with_skill: bool,
     on_attempt_done: Callable[[AttemptEvent], None] | None,
+    on_task_done: Callable[[TaskResult], None] | None,
     fail_fast_unusable: int,
 ) -> TaskResult:
     attempts: list[AttemptRecord] = []
-    consecutive_unusable = 0
+    consecutive_fail_fast_triggers = 0
     for attempt_num in range(1, k + 1):
         record = _run_attempt(
-            task,
-            attempt_num,
-            harness,
-            judge,
-            cheat,
-            spec,
-            spec_path,
-            timeout,
-            with_skill,
-            on_attempt_done,
+            task, attempt_num, harness, judge, cheat,
+            spec, spec_path, timeout, with_skill, on_attempt_done,
         )
         attempts.append(record)
         if record.outcome in _FAIL_FAST_OUTCOMES:
-            consecutive_unusable += 1
-        else:
-            consecutive_unusable = 0
-        if fail_fast_unusable > 0 and consecutive_unusable >= fail_fast_unusable:
+            consecutive_fail_fast_triggers += 1
+        elif record.outcome.is_usable:
+            consecutive_fail_fast_triggers = 0
+        if (
+            fail_fast_unusable > 0
+            and consecutive_fail_fast_triggers >= fail_fast_unusable
+        ):
             break
 
     successes = sum(1 for a in attempts if a.outcome == Outcome.PASS)
     usable = sum(1 for a in attempts if a.outcome.is_usable)
     unusable = len(attempts) - usable
-    return TaskResult(
+    result = TaskResult(
         task_id=task.id,
         task_name=task.name,
         attempts=attempts,
@@ -190,6 +189,9 @@ def _run_task(
         unusable=unusable,
         pass_at_k=pass_at_k(successes, usable) if usable > 0 else None,
     )
+    if on_task_done and len(attempts) < k:
+        on_task_done(result)
+    return result
 
 
 def _run_attempt(
@@ -208,7 +210,8 @@ def _run_attempt(
     try:
         _run_shell(task.setup)
         resolved_extra_path = [
-            str((spec_path.parent / p).resolve()) for p in spec.sandbox.extra_path
+            str((spec_path.parent / p).resolve())
+            for p in spec.sandbox.extra_path
         ]
         skill_path = _resolve_skill_path(spec, spec_path) if with_skill else None
         if skill_path:
@@ -238,9 +241,7 @@ def _run_attempt(
             or looks_like_infra_failure(infra_text)
         ):
             outcome = classify_outcome(attempt_result, [], None)
-            evidence = (
-                attempt_result.error or f"harness exited {attempt_result.exit_code}"
-            )
+            evidence = attempt_result.error or f"harness exited {attempt_result.exit_code}"
             return _finish(
                 AttemptRecord(
                     attempt=attempt,
@@ -302,9 +303,7 @@ def _finish(
 ) -> AttemptRecord:
     if on_attempt_done:
         on_attempt_done(
-            AttemptEvent(
-                task_id=task.id, attempt=record.attempt, outcome=record.outcome
-            )
+            AttemptEvent(task_id=task.id, attempt=record.attempt, outcome=record.outcome)
         )
     return record
 

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -65,38 +65,16 @@ def run(
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures_with = {
             pool.submit(
-                _run_task,
-                task,
-                harness,
-                judge,
-                cheat,
-                spec,
-                spec_path,
-                k,
-                timeout,
-                True,
-                on_attempt_done,
-                on_task_done,
-                fail_fast_unusable,
+                _run_task, task, harness, judge, cheat, spec, spec_path,
+                k, timeout, True, on_attempt_done, on_task_done, fail_fast_unusable,
             ): task
             for task in spec.tasks
         }
         futures_without = (
             {
                 pool.submit(
-                    _run_task,
-                    task,
-                    harness,
-                    judge,
-                    cheat,
-                    spec,
-                    spec_path,
-                    k,
-                    timeout,
-                    False,
-                    on_attempt_done,
-                    on_task_done,
-                    fail_fast_unusable,
+                    _run_task, task, harness, judge, cheat, spec, spec_path,
+                    k, timeout, False, on_attempt_done, on_task_done, fail_fast_unusable,
                 ): task
                 for task in spec.tasks
             }

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -116,6 +116,7 @@ judge:
 
 - **pass@k** — probability that at least 1 of k attempts passes (default k=3), computed over the *usable* attempts only
 - **outcome** — each attempt is typed `pass`, `task_fail`, `cheat`, `infra_error`, `timeout`, or `judge_error`; the last three are *unusable* (infrastructure/judge noise) and are excluded from the pass@k denominator and reported as a separate "N unusable" count, so a throttled or judge-flaked run is not mistaken for a regression. `passed` in the JSON equals `outcome == pass`.
+- **`--fail-fast N`** — optional run control that stops scheduling new attempts for a task after N consecutive `infra_error`/`timeout` outcomes; `0` disables it. Early-stopped tasks report as `ABORTED`, and tasks with no usable attempts keep `pass_at_k: null`.
 - **baseline** — runs each task without the skill to compute a delta score
 - **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
@@ -129,7 +130,8 @@ Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.jso
 alongside the spec file. Each result includes a full skill snapshot (content + git SHA
 of the skill file and any referenced scripts) for reproducibility. Each attempt
 records its `outcome` (see above) and per-task results include an `unusable` count;
-a task with no usable attempts has `pass_at_k: null`.
+a task with no usable attempts has `pass_at_k: null`. When `--fail-fast N` stops
+a task early, that task may contain fewer than k attempt records.
 
 ## Designing good evals — full guidance
 

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -33,8 +33,10 @@ and `assert_evidence` — no extra command needed. Each attempt is tagged with a
 (`infra_error` from a rate-limit / spending-cap, `timeout`, or `judge_error`)
 read as `⊘` and are excluded from the pass@k denominator, with a separate
 "N unusable" count in the summary — so a throttled or judge-flaked run is not
-mistaken for a skill regression. If a failure is still unclear, use `--verbose`
-to see full output for all tasks (including passing ones):
+mistaken for a skill regression. If `caliper run --fail-fast N` stopped a task
+after repeated `infra_error` / `timeout` outcomes, the report marks it as
+`ABORTED` and shows how many attempts ran. If a failure is still unclear, use
+`--verbose` to see full output for all tasks (including passing ones):
 
 ```bash
 # Full output for all tasks (passing + failing), untruncated

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -5,13 +5,7 @@ from datetime import datetime, timezone
 
 from rich.console import Console
 
-from caliper.reporter import (
-    _OUTPUT_TRUNCATE_AT,
-    _format_output,
-    make_progress,
-    print_results,
-    update_progress,
-)
+from caliper.reporter import _OUTPUT_TRUNCATE_AT, _format_output, make_progress, print_results, update_progress
 from caliper.schema.results import (
     AggregateScore,
     AttemptRecord,
@@ -206,12 +200,7 @@ def test_only_failed_tasks_shown_in_mixed_results() -> None:
     results = _make_results(
         [
             _make_task("task-001", passed=True, output="pass output"),
-            _make_task(
-                "task-002",
-                passed=False,
-                output="fail output",
-                assert_evidence="file not found",
-            ),
+            _make_task("task-002", passed=False, output="fail output", assert_evidence="file not found"),
         ]
     )
     out = _render(results)
@@ -252,7 +241,9 @@ def test_verbose_shows_all_tasks() -> None:
 
 def test_long_output_truncated_in_rendered_output() -> None:
     long_output = "z" * (_OUTPUT_TRUNCATE_AT + 200)
-    results = _make_results([_make_task("task-001", passed=False, output=long_output)])
+    results = _make_results(
+        [_make_task("task-001", passed=False, output=long_output)]
+    )
     out = _render(results)
     assert "truncated" in out
     # Rich wraps long lines; count total z's to verify the tail was included
@@ -260,7 +251,9 @@ def test_long_output_truncated_in_rendered_output() -> None:
 
 
 def test_empty_output_renders_no_output_marker() -> None:
-    results = _make_results([_make_task("task-001", passed=False, output="")])
+    results = _make_results(
+        [_make_task("task-001", passed=False, output="")]
+    )
     out = _render(results)
     assert "no output" in out
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -10,6 +10,7 @@ from caliper.reporter import (
     _format_output,
     make_progress,
     print_results,
+    update_progress,
 )
 from caliper.schema.results import (
     AggregateScore,
@@ -28,6 +29,25 @@ def test_make_progress_initializes_task_totals() -> None:
 
     assert progress.tasks[task_ids["Task one"]].total == 3
     assert progress.tasks[task_ids["Task two"]].total == 3
+
+
+def test_update_progress_marks_early_stopped_task_finished() -> None:
+    progress, task_ids = make_progress(["Task one"], k=3)
+
+    update_progress(
+        progress,
+        task_ids,
+        "Task one",
+        k=3,
+        completed=1,
+        passed=0,
+        unusable=1,
+        finished=True,
+    )
+
+    task = progress.tasks[task_ids["Task one"]]
+    assert task.completed == 3
+    assert task.fields["status"] == "[bold yellow]⊘1[/bold yellow]"
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +309,65 @@ def test_aborted_unusable_task_is_reported_as_aborted() -> None:
 
     assert "ABORTED" in out
     assert "1/3 attempts" in out
+
+
+def test_early_stopped_task_with_usable_pass_is_not_reported_as_aborted() -> None:
+    task = TaskResult(
+        task_id="task-001",
+        task_name="Task task-001",
+        attempts=[
+            AttemptRecord(
+                attempt=1,
+                output="ok",
+                duration_seconds=1.0,
+                outcome=Outcome.PASS,
+            ),
+            AttemptRecord(
+                attempt=2,
+                output="",
+                duration_seconds=1.0,
+                outcome=Outcome.INFRA_ERROR,
+                assert_evidence="spending cap",
+            ),
+            AttemptRecord(
+                attempt=3,
+                output="",
+                duration_seconds=1.0,
+                outcome=Outcome.INFRA_ERROR,
+                assert_evidence="spending cap",
+            ),
+        ],
+        successes=1,
+        unusable=2,
+        pass_at_k=1.0,
+    )
+    results = RunResults(
+        run=RunMeta(
+            spec="test-spec",
+            timestamp=datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc),
+            k=5,
+            backend="claude-code",
+        ),
+        skill_snapshot=SkillSnapshot(path="/fake/SKILL.md"),
+        task_results=[task],
+        aggregate=AggregateScore(
+            avg_pass_at_k=1.0,
+            per_task=[
+                TaskScore(
+                    task_id=task.task_id,
+                    task_name=task.task_name,
+                    k=5,
+                    successes=1,
+                    score=1.0,
+                )
+            ],
+        ),
+    )
+
+    out = _render(results, verbose=True)
+
+    assert "ABORTED" not in out
+    assert "PASS" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -5,7 +5,12 @@ from datetime import datetime, timezone
 
 from rich.console import Console
 
-from caliper.reporter import _OUTPUT_TRUNCATE_AT, _format_output, make_progress, print_results
+from caliper.reporter import (
+    _OUTPUT_TRUNCATE_AT,
+    _format_output,
+    make_progress,
+    print_results,
+)
 from caliper.schema.results import (
     AggregateScore,
     AttemptRecord,
@@ -181,7 +186,12 @@ def test_only_failed_tasks_shown_in_mixed_results() -> None:
     results = _make_results(
         [
             _make_task("task-001", passed=True, output="pass output"),
-            _make_task("task-002", passed=False, output="fail output", assert_evidence="file not found"),
+            _make_task(
+                "task-002",
+                passed=False,
+                output="fail output",
+                assert_evidence="file not found",
+            ),
         ]
     )
     out = _render(results)
@@ -222,9 +232,7 @@ def test_verbose_shows_all_tasks() -> None:
 
 def test_long_output_truncated_in_rendered_output() -> None:
     long_output = "z" * (_OUTPUT_TRUNCATE_AT + 200)
-    results = _make_results(
-        [_make_task("task-001", passed=False, output=long_output)]
-    )
+    results = _make_results([_make_task("task-001", passed=False, output=long_output)])
     out = _render(results)
     assert "truncated" in out
     # Rich wraps long lines; count total z's to verify the tail was included
@@ -232,11 +240,55 @@ def test_long_output_truncated_in_rendered_output() -> None:
 
 
 def test_empty_output_renders_no_output_marker() -> None:
-    results = _make_results(
-        [_make_task("task-001", passed=False, output="")]
-    )
+    results = _make_results([_make_task("task-001", passed=False, output="")])
     out = _render(results)
     assert "no output" in out
+
+
+def test_aborted_unusable_task_is_reported_as_aborted() -> None:
+    task = TaskResult(
+        task_id="task-001",
+        task_name="Task task-001",
+        attempts=[
+            AttemptRecord(
+                attempt=1,
+                output="",
+                duration_seconds=1.0,
+                outcome=Outcome.INFRA_ERROR,
+                assert_evidence="spending cap",
+            )
+        ],
+        successes=0,
+        unusable=1,
+        pass_at_k=None,
+    )
+    results = RunResults(
+        run=RunMeta(
+            spec="test-spec",
+            timestamp=datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc),
+            k=3,
+            backend="claude-code",
+        ),
+        skill_snapshot=SkillSnapshot(path="/fake/SKILL.md"),
+        task_results=[task],
+        aggregate=AggregateScore(
+            avg_pass_at_k=0.0,
+            per_task=[
+                TaskScore(
+                    task_id=task.task_id,
+                    task_name=task.task_name,
+                    k=3,
+                    successes=0,
+                    score=None,
+                )
+            ],
+        ),
+    )
+
+    out = _render(results)
+
+    assert "ABORTED" in out
+    assert "1/3 attempts" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from caliper.main import app
+from caliper.schema.results import AggregateScore, RunMeta, RunResults, SkillSnapshot
+
+
+runner = CliRunner()
+
+
+class _Progress:
+    console = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_run_cli_passes_fail_fast_unusable(monkeypatch, tmp_path) -> None:
+    spec_file = tmp_path / "sample.eval.yaml"
+    spec_file.write_text(
+        """
+skill:
+  backend: codex
+tasks:
+  - name: One
+    prompt: Do it
+    assert: assert True
+"""
+    )
+    calls = {}
+
+    def fake_run(**kwargs):
+        calls.update(kwargs)
+        return RunResults(
+            run=RunMeta(
+                spec="sample",
+                timestamp=datetime(2026, 7, 3, tzinfo=timezone.utc),
+                k=kwargs["k"],
+                backend="codex",
+            ),
+            skill_snapshot=SkillSnapshot(path=""),
+            task_results=[],
+            aggregate=AggregateScore(avg_pass_at_k=0.0, per_task=[]),
+        )
+
+    monkeypatch.setattr(
+        "caliper.commands.run.get_harness", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.EvalJudge", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.make_progress", lambda *args, **kwargs: (_Progress(), {})
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.update_progress", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.print_banner", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.print_results", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.save_results",
+        lambda *args, **kwargs: tmp_path / "results.json",
+    )
+    monkeypatch.setattr("caliper.commands.run.run", fake_run)
+
+    result = runner.invoke(app, ["run", str(spec_file), "--k", "3", "--fail-fast", "2"])
+
+    assert result.exit_code == 0, result.output
+    assert calls["fail_fast_unusable"] == 2

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -5,14 +5,28 @@ from datetime import datetime, timezone
 from typer.testing import CliRunner
 
 from caliper.main import app
-from caliper.schema.results import AggregateScore, RunMeta, RunResults, SkillSnapshot
+from caliper.runner import AttemptEvent
+from caliper.schema.results import (
+    AggregateScore,
+    AttemptRecord,
+    Outcome,
+    RunMeta,
+    RunResults,
+    SkillSnapshot,
+    TaskResult,
+)
 
 
 runner = CliRunner()
 
 
+class _Console:
+    def print(self, *args, **kwargs):
+        return None
+
+
 class _Progress:
-    console = None
+    console = _Console()
 
     def __enter__(self):
         return self
@@ -77,3 +91,85 @@ tasks:
 
     assert result.exit_code == 0, result.output
     assert calls["fail_fast_unusable"] == 2
+
+
+def test_run_cli_repaints_early_stopped_task_as_finished(
+    monkeypatch, tmp_path
+) -> None:
+    spec_file = tmp_path / "sample.eval.yaml"
+    spec_file.write_text(
+        """
+skill:
+  backend: codex
+tasks:
+  - name: One
+    prompt: Do it
+    assert: assert True
+"""
+    )
+    progress_updates = []
+
+    def stopped_task() -> TaskResult:
+        return TaskResult(
+            task_id="task-001",
+            task_name="One",
+            attempts=[
+                AttemptRecord(
+                    attempt=1,
+                    output="",
+                    duration_seconds=0.1,
+                    outcome=Outcome.INFRA_ERROR,
+                    assert_evidence="agent failed",
+                )
+            ],
+            successes=0,
+            unusable=1,
+            pass_at_k=None,
+        )
+
+    def fake_run(**kwargs):
+        kwargs["on_attempt_done"](
+            AttemptEvent(task_id="task-001", attempt=1, outcome=Outcome.INFRA_ERROR)
+        )
+        kwargs["on_task_done"](stopped_task())
+        return RunResults(
+            run=RunMeta(
+                spec="sample",
+                timestamp=datetime(2026, 7, 3, tzinfo=timezone.utc),
+                k=kwargs["k"],
+                backend="codex",
+            ),
+            skill_snapshot=SkillSnapshot(path=""),
+            task_results=[stopped_task()],
+            aggregate=AggregateScore(avg_pass_at_k=0.0, per_task=[]),
+        )
+
+    def fake_update_progress(*args, **kwargs):
+        progress_updates.append(kwargs)
+
+    monkeypatch.setattr(
+        "caliper.commands.run.get_harness", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.EvalJudge", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.make_progress", lambda *args, **kwargs: (_Progress(), {})
+    )
+    monkeypatch.setattr("caliper.commands.run.update_progress", fake_update_progress)
+    monkeypatch.setattr(
+        "caliper.commands.run.print_banner", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.print_results", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "caliper.commands.run.save_results",
+        lambda *args, **kwargs: tmp_path / "results.json",
+    )
+    monkeypatch.setattr("caliper.commands.run.run", fake_run)
+
+    result = runner.invoke(app, ["run", str(spec_file), "--k", "3", "--fail-fast", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert any(update.get("finished") for update in progress_updates)

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -5,28 +5,14 @@ from datetime import datetime, timezone
 from typer.testing import CliRunner
 
 from caliper.main import app
-from caliper.runner import AttemptEvent
-from caliper.schema.results import (
-    AggregateScore,
-    AttemptRecord,
-    Outcome,
-    RunMeta,
-    RunResults,
-    SkillSnapshot,
-    TaskResult,
-)
+from caliper.schema.results import AggregateScore, RunMeta, RunResults, SkillSnapshot
 
 
 runner = CliRunner()
 
 
-class _Console:
-    def print(self, *args, **kwargs):
-        return None
-
-
 class _Progress:
-    console = _Console()
+    console = None
 
     def __enter__(self):
         return self
@@ -91,85 +77,3 @@ tasks:
 
     assert result.exit_code == 0, result.output
     assert calls["fail_fast_unusable"] == 2
-
-
-def test_run_cli_repaints_early_stopped_task_as_finished(
-    monkeypatch, tmp_path
-) -> None:
-    spec_file = tmp_path / "sample.eval.yaml"
-    spec_file.write_text(
-        """
-skill:
-  backend: codex
-tasks:
-  - name: One
-    prompt: Do it
-    assert: assert True
-"""
-    )
-    progress_updates = []
-
-    def stopped_task() -> TaskResult:
-        return TaskResult(
-            task_id="task-001",
-            task_name="One",
-            attempts=[
-                AttemptRecord(
-                    attempt=1,
-                    output="",
-                    duration_seconds=0.1,
-                    outcome=Outcome.INFRA_ERROR,
-                    assert_evidence="agent failed",
-                )
-            ],
-            successes=0,
-            unusable=1,
-            pass_at_k=None,
-        )
-
-    def fake_run(**kwargs):
-        kwargs["on_attempt_done"](
-            AttemptEvent(task_id="task-001", attempt=1, outcome=Outcome.INFRA_ERROR)
-        )
-        kwargs["on_task_done"](stopped_task())
-        return RunResults(
-            run=RunMeta(
-                spec="sample",
-                timestamp=datetime(2026, 7, 3, tzinfo=timezone.utc),
-                k=kwargs["k"],
-                backend="codex",
-            ),
-            skill_snapshot=SkillSnapshot(path=""),
-            task_results=[stopped_task()],
-            aggregate=AggregateScore(avg_pass_at_k=0.0, per_task=[]),
-        )
-
-    def fake_update_progress(*args, **kwargs):
-        progress_updates.append(kwargs)
-
-    monkeypatch.setattr(
-        "caliper.commands.run.get_harness", lambda *args, **kwargs: object()
-    )
-    monkeypatch.setattr(
-        "caliper.commands.run.EvalJudge", lambda *args, **kwargs: object()
-    )
-    monkeypatch.setattr(
-        "caliper.commands.run.make_progress", lambda *args, **kwargs: (_Progress(), {})
-    )
-    monkeypatch.setattr("caliper.commands.run.update_progress", fake_update_progress)
-    monkeypatch.setattr(
-        "caliper.commands.run.print_banner", lambda *args, **kwargs: None
-    )
-    monkeypatch.setattr(
-        "caliper.commands.run.print_results", lambda *args, **kwargs: None
-    )
-    monkeypatch.setattr(
-        "caliper.commands.run.save_results",
-        lambda *args, **kwargs: tmp_path / "results.json",
-    )
-    monkeypatch.setattr("caliper.commands.run.run", fake_run)
-
-    result = runner.invoke(app, ["run", str(spec_file), "--k", "3", "--fail-fast", "1"])
-
-    assert result.exit_code == 0, result.output
-    assert any(update.get("finished") for update in progress_updates)

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -21,7 +21,7 @@ class _Progress:
         return False
 
 
-def test_run_cli_passes_fail_fast_unusable(monkeypatch, tmp_path) -> None:
+def test_run_cli_forwards_options_to_run(monkeypatch, tmp_path) -> None:
     spec_file = tmp_path / "sample.eval.yaml"
     spec_file.write_text(
         """
@@ -73,7 +73,16 @@ tasks:
     )
     monkeypatch.setattr("caliper.commands.run.run", fake_run)
 
-    result = runner.invoke(app, ["run", str(spec_file), "--k", "3", "--fail-fast", "2"])
+    result = runner.invoke(
+        app,
+        ["run", str(spec_file), "--k", "3", "--workers", "2", "--fail-fast", "2"],
+    )
 
     assert result.exit_code == 0, result.output
+    # Explicitly passed flags reach run(...)
+    assert calls["k"] == 3
+    assert calls["workers"] == 2
     assert calls["fail_fast_unusable"] == 2
+    # Defaults flow through unchanged when the flag is omitted
+    assert calls["timeout"] == 120
+    assert calls["baseline"] is False

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -64,6 +64,47 @@ class InfraErrorHarness(FailingHarness):
         )
 
 
+class MixedOutcomeHarness(HarnessBackend):
+    def __init__(self) -> None:
+        self.attempts: list[int] = []
+
+    @property
+    def name(self) -> str:
+        return "mixed"
+
+    def run(
+        self,
+        task_id: str,
+        attempt: int,
+        prompt: str,
+        *,
+        skill_path: str | None,
+        model: str | None,
+        timeout: int,
+        isolated_home: str,
+        extra_path: list[str] | None = None,
+    ) -> AttemptResult:
+        self.attempts.append(attempt)
+        if attempt in (1, 3):
+            return AttemptResult(
+                task_id=task_id,
+                attempt=attempt,
+                transcript=[],
+                final_output="",
+                exit_code=1,
+                duration_seconds=0.1,
+                error="agent failed",
+            )
+        return AttemptResult(
+            task_id=task_id,
+            attempt=attempt,
+            transcript=[],
+            final_output="judge this",
+            exit_code=0,
+            duration_seconds=0.1,
+        )
+
+
 class RecordingJudge(Judge):
     def __init__(self) -> None:
         self.calls = 0
@@ -71,6 +112,17 @@ class RecordingJudge(Judge):
     def evaluate(self, task, transcript, final_output, spec_dir) -> JudgeResult:
         self.calls += 1
         return JudgeResult(passed=True, reasoning="should not run")
+
+
+class JudgeErrorThenPass(Judge):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def evaluate(self, task, transcript, final_output, spec_dir) -> JudgeResult:
+        self.calls += 1
+        if self.calls == 1:
+            return JudgeResult(passed=False, reasoning="judge flaked", errored=True)
+        return JudgeResult(passed=True, reasoning="ok")
 
 
 def _one_task_spec() -> EvalSpec:
@@ -157,6 +209,56 @@ def test_runner_fail_fast_stops_after_unusable_threshold(tmp_path) -> None:
     assert [attempt.outcome for attempt in task.attempts] == [Outcome.INFRA_ERROR]
     assert task.unusable == 1
     assert task.pass_at_k is None
+
+
+def test_runner_fail_fast_does_not_reset_streak_on_judge_error(tmp_path) -> None:
+    spec_path = tmp_path / "failing.eval.yaml"
+    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    harness = MixedOutcomeHarness()
+
+    results = run(
+        spec=_one_task_spec(),
+        spec_path=spec_path,
+        harness=harness,
+        judge=JudgeErrorThenPass(),
+        k=4,
+        workers=1,
+        timeout=30,
+        fail_fast_unusable=2,
+    )
+
+    task = results.task_results[0]
+    assert harness.attempts == [1, 2, 3]
+    assert [attempt.outcome for attempt in task.attempts] == [
+        Outcome.INFRA_ERROR,
+        Outcome.JUDGE_ERROR,
+        Outcome.INFRA_ERROR,
+    ]
+    assert task.unusable == 3
+    assert task.pass_at_k is None
+
+
+def test_runner_emits_task_done_when_fail_fast_stops_early(tmp_path) -> None:
+    spec_path = tmp_path / "failing.eval.yaml"
+    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    finished_tasks = []
+
+    run(
+        spec=_one_task_spec(),
+        spec_path=spec_path,
+        harness=InfraErrorHarness(),
+        judge=RecordingJudge(),
+        k=3,
+        workers=1,
+        timeout=30,
+        fail_fast_unusable=1,
+        on_task_done=finished_tasks.append,
+    )
+
+    assert len(finished_tasks) == 1
+    assert finished_tasks[0].task_id == "task-001"
+    assert len(finished_tasks[0].attempts) == 1
+    assert finished_tasks[0].pass_at_k is None
 
 
 def _make_skill_dir(tmp_path):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -291,7 +291,9 @@ def test_stage_excludes_cheat_surfaces(tmp_path) -> None:
     home = tmp_path / "home"
     home.mkdir()
 
-    _stage_skill_directory(str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"])
+    _stage_skill_directory(
+        str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"]
+    )
 
     assert not (home / ".caliper").exists()
     assert not (home / "my-skill.eval.yaml").exists()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -35,6 +35,35 @@ class FailingHarness(HarnessBackend):
         )
 
 
+class InfraErrorHarness(FailingHarness):
+    def __init__(self) -> None:
+        self.attempts: list[int] = []
+
+    def run(
+        self,
+        task_id: str,
+        attempt: int,
+        prompt: str,
+        *,
+        skill_path: str | None,
+        model: str | None,
+        timeout: int,
+        isolated_home: str,
+        extra_path: list[str] | None = None,
+    ) -> AttemptResult:
+        self.attempts.append(attempt)
+        return super().run(
+            task_id=task_id,
+            attempt=attempt,
+            prompt=prompt,
+            skill_path=skill_path,
+            model=model,
+            timeout=timeout,
+            isolated_home=isolated_home,
+            extra_path=extra_path,
+        )
+
+
 class RecordingJudge(Judge):
     def __init__(self) -> None:
         self.calls = 0
@@ -44,11 +73,8 @@ class RecordingJudge(Judge):
         return JudgeResult(passed=True, reasoning="should not run")
 
 
-def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
-    spec_path = tmp_path / "failing.eval.yaml"
-    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
-    judge = RecordingJudge()
-    spec = EvalSpec(
+def _one_task_spec() -> EvalSpec:
+    return EvalSpec(
         skill=SkillConfig(backend="codex"),
         tasks=[
             TaskSpec(
@@ -59,6 +85,13 @@ def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
             )
         ],
     )
+
+
+def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
+    spec_path = tmp_path / "failing.eval.yaml"
+    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    judge = RecordingJudge()
+    spec = _one_task_spec()
 
     results = run(
         spec=spec,
@@ -80,6 +113,50 @@ def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
     assert tr.unusable == 1
     assert tr.pass_at_k is None
     assert judge.calls == 0
+
+
+def test_runner_runs_all_infra_failures_by_default(tmp_path) -> None:
+    spec_path = tmp_path / "failing.eval.yaml"
+    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    harness = InfraErrorHarness()
+
+    results = run(
+        spec=_one_task_spec(),
+        spec_path=spec_path,
+        harness=harness,
+        judge=RecordingJudge(),
+        k=3,
+        workers=1,
+        timeout=30,
+    )
+
+    assert harness.attempts == [1, 2, 3]
+    assert len(results.task_results[0].attempts) == 3
+    assert results.task_results[0].unusable == 3
+    assert results.task_results[0].pass_at_k is None
+
+
+def test_runner_fail_fast_stops_after_unusable_threshold(tmp_path) -> None:
+    spec_path = tmp_path / "failing.eval.yaml"
+    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    harness = InfraErrorHarness()
+
+    results = run(
+        spec=_one_task_spec(),
+        spec_path=spec_path,
+        harness=harness,
+        judge=RecordingJudge(),
+        k=3,
+        workers=1,
+        timeout=30,
+        fail_fast_unusable=1,
+    )
+
+    task = results.task_results[0]
+    assert harness.attempts == [1]
+    assert [attempt.outcome for attempt in task.attempts] == [Outcome.INFRA_ERROR]
+    assert task.unusable == 1
+    assert task.pass_at_k is None
 
 
 def _make_skill_dir(tmp_path):
@@ -112,9 +189,7 @@ def test_stage_excludes_cheat_surfaces(tmp_path) -> None:
     home = tmp_path / "home"
     home.mkdir()
 
-    _stage_skill_directory(
-        str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"]
-    )
+    _stage_skill_directory(str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"])
 
     assert not (home / ".caliper").exists()
     assert not (home / "my-skill.eval.yaml").exists()


### PR DESCRIPTION
Closes #26.

## Summary

- add an opt-in `caliper run --fail-fast N` control that stops a task after N consecutive `infra_error` / `timeout` attempts
- keep the default behavior unchanged with `--fail-fast 0`
- report early-stopped all-unusable tasks as `ABORTED` and show how many attempts ran
- document the new flag in README and bundled skill references

## Notes

- This intentionally consumes the outcome taxonomy merged in #27.
- The trigger set is limited to `infra_error` and `timeout`; `judge_error` remains reported as unusable but does not trigger fail-fast.
- Early-stopped tasks may contain fewer than k attempt records. If all completed attempts are unusable, `pass_at_k` remains `null` and the task stays excluded from aggregate scoring.

## Validation

- `uv run --python 3.12 --extra dev pytest tests/test_runner.py tests/test_run_cli.py tests/test_reporter.py -q`
- `.venv/bin/python -m pytest tests -q -k 'not test_install_skill_refuses_to_overwrite_without_force'`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check caliper/commands/run.py caliper/reporter.py caliper/runner.py tests/test_reporter.py tests/test_runner.py tests/test_run_cli.py`
- `git diff --check`
- `diff -u skills/evaluate-skill/REFERENCE.md caliper/resources/evaluate_skill/REFERENCE.md`

Known baseline: `tests/test_install_skill.py::test_install_skill_refuses_to_overwrite_without_force` still fails locally because `CliRunner` returns an empty `result.output` for the existing `ClickException`; I left that unrelated behavior unchanged.
