### PR TITLE
Enforce ruff as the single formatter (CI gate, pre-commit, docs)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Check formatting
+        run: ruff format --check .
+      - name: Lint
+        run: ruff check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# Run `pre-commit install` once to enable these hooks locally.
+# The ruff version here is pinned to match `ruff==0.13.0` in pyproject.toml's
+# dev extras and the CI lint workflow — keep all three in lockstep.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.0
+    hooks:
+      - id: ruff-format
+      - id: ruff
+        args: [--fix]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,15 @@ When any of the following change, update all three locations before marking the 
 
 After editing both REFERENCE.md files, run `python -m pytest tests/test_install_skill.py -q` to verify the packaged SKILL.md is still in sync with `skills/evaluate-skill/SKILL.md`. If it fails, copy the source over the packaged copy.
 
+## Formatting
+
+`ruff` is the single formatting and linting authority for this repo, pinned to
+`ruff==0.13.0`. Run `ruff format .` and `ruff check .` before finishing. Never
+hand-reformat lines outside the scope of your change — the formatter is the
+only style authority, and manual reflow inflates diffs. CI enforces
+`ruff format --check .` and `ruff check .` on every PR. See `CONTRIBUTING.md`
+for details.
+
 ## Local-only decision docs (never commit)
 
 `CONTEXT.md` and everything under `docs/adr/` are local decision artifacts produced by grill-with-docs. They capture in-progress local decisions and must stay on the developer's machine — never stage, commit, or push them to the repo. Both are gitignored; do not remove them from `.gitignore`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to Caliper
+
+## Formatting and linting
+
+Caliper uses [**ruff**](https://docs.astral.sh/ruff/) as the single authority
+for both formatting and linting. There is no other formatter — do **not** run
+Black, autopep8, yapf, or your editor's built-in formatter on this codebase.
+
+### Pinned version
+
+The formatter is pinned to **`ruff==0.13.0`** so that local runs and CI always
+agree. The pin lives in three places that must stay in lockstep:
+
+- `pyproject.toml` — `dev` optional-dependencies (`ruff==0.13.0`)
+- `.pre-commit-config.yaml` — `rev: v0.13.0`
+- CI installs it via `pip install -e ".[dev]"`
+
+When bumping ruff, update all three together in a single PR (expect a
+formatting reflow to land at the same time).
+
+### Commands
+
+```bash
+pip install -e ".[dev]"
+
+ruff format .          # reformat in place
+ruff format --check .  # check only (what CI runs)
+ruff check .           # lint
+ruff check --fix .     # lint and auto-fix
+```
+
+Ruff configuration (line length, target Python version) lives under
+`[tool.ruff]` in `pyproject.toml`.
+
+### Pre-commit hook
+
+Install the hook once so formatting and lint fixes run automatically on every
+commit:
+
+```bash
+pip install -e ".[dev]"   # installs pre-commit
+pre-commit install
+```
+
+Locally the hook **auto-fixes** your files (reformats and applies
+`ruff check --fix`); if it changes anything, the commit aborts so you can
+re-stage the fixes and commit again. CI runs the same checks in **check-only**
+mode and does not mutate files.
+
+### CI enforcement
+
+`.github/workflows/lint.yml` runs `ruff format --check .` and `ruff check .` on
+every pull request. This is a **required status check** on `main` — a PR cannot
+merge until it passes.
+
+If branch protection is ever reset, re-add the required check with:
+
+```bash
+gh api -X PATCH repos/edonadei/caliper/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": { "strict": true, "contexts": ["lint"] },
+  "enforce_admins": null,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+```
+
+### Don't hand-format unrelated lines
+
+The formatter is the **single source of truth** for style. Do not manually
+reformat lines outside the scope of your change, even to "clean them up" —
+that inflates diffs and makes review harder. If `ruff format` wants to reflow
+something, let it; if it doesn't, leave it alone.
+
+## Tests
+
+Before opening a pull request:
+
+```bash
+pip install -e ".[dev,openai]"
+pytest
+ruff format --check .
+ruff check .
+caliper validate skills/evaluate-skill/evaluate-skill.eval.yaml
+```
+
+When changing behavior, include a test or an eval fixture that demonstrates the
+expected outcome. Keep backend-specific logic isolated to the relevant module
+under `caliper/harness/` or `caliper/judge/`.

--- a/README.md
+++ b/README.md
@@ -495,9 +495,12 @@ Before opening a pull request:
 ```bash
 pip install -e ".[dev,openai]"
 pytest
+ruff format --check .
 ruff check .
 caliper validate skills/evaluate-skill/evaluate-skill.eval.yaml
 ```
+
+Formatting is enforced by CI on every PR. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the formatter convention, the pinned ruff version, and the one-time `pre-commit install` step.
 
 When changing behavior, include a test or an eval fixture that demonstrates the expected outcome. Keep backend-specific logic isolated to the relevant module under `caliper/harness/` or `caliper/judge/`.
 

--- a/caliper/commands/install_skill.py
+++ b/caliper/commands/install_skill.py
@@ -38,7 +38,9 @@ def install_skill_cmd(
     normalized = target.strip().lower()
     if normalized not in TARGETS:
         valid = ", ".join(sorted(TARGETS))
-        raise typer.BadParameter(f"unsupported target '{target}'. Choose one of: {valid}")
+        raise typer.BadParameter(
+            f"unsupported target '{target}'. Choose one of: {valid}"
+        )
 
     destination = Path.home() / TARGETS[normalized]
     skill_text = load_packaged_skill()

--- a/caliper/commands/list_cmd.py
+++ b/caliper/commands/list_cmd.py
@@ -14,8 +14,12 @@ console = Console()
 
 
 def list_cmd_fn(
-    spec: Annotated[Optional[str], typer.Argument(help="Spec name to list runs for")] = None,
-    directory: Annotated[Path, typer.Option("--dir", help="Directory to search")] = Path("."),
+    spec: Annotated[
+        Optional[str], typer.Argument(help="Spec name to list runs for")
+    ] = None,
+    directory: Annotated[
+        Path, typer.Option("--dir", help="Directory to search")
+    ] = Path("."),
 ) -> None:
     caliper_dir = directory / ".caliper" / "results"
 
@@ -27,7 +31,9 @@ def list_cmd_fn(
 
 def _list_specs(results_dir: Path) -> None:
     if not results_dir.exists():
-        console.print("[dim]No evaluation results found. Run [bold]caliper run[/bold] first.[/dim]")
+        console.print(
+            "[dim]No evaluation results found. Run [bold]caliper run[/bold] first.[/dim]"
+        )
         return
 
     table = Table(box=box.ROUNDED, header_style="bold cyan", expand=False)

--- a/caliper/commands/new.py
+++ b/caliper/commands/new.py
@@ -7,10 +7,23 @@ import typer
 
 from caliper.wizard import run_wizard
 
+
 def new_cmd(
-    name: Annotated[Optional[str], typer.Argument(help="Eval name (used as default filename)")] = None,
-    skill: Annotated[Optional[str], typer.Option("--skill", help="Pre-populate skill path")] = None,
-    backend: Annotated[str, typer.Option("--backend", help="Pre-populate backend (claude-code, codex, claude-api, openai-api, pi)")] = "claude-code",
-    output: Annotated[Optional[Path], typer.Option("--out", help="Output path for .eval.yaml")] = None,
+    name: Annotated[
+        Optional[str], typer.Argument(help="Eval name (used as default filename)")
+    ] = None,
+    skill: Annotated[
+        Optional[str], typer.Option("--skill", help="Pre-populate skill path")
+    ] = None,
+    backend: Annotated[
+        str,
+        typer.Option(
+            "--backend",
+            help="Pre-populate backend (claude-code, codex, claude-api, openai-api, pi)",
+        ),
+    ] = "claude-code",
+    output: Annotated[
+        Optional[Path], typer.Option("--out", help="Output path for .eval.yaml")
+    ] = None,
 ) -> None:
     run_wizard(name=name, output=output, skill_path=skill, backend=backend)

--- a/caliper/commands/report.py
+++ b/caliper/commands/report.py
@@ -13,14 +13,22 @@ console = Console()
 
 
 def report_cmd(
-    spec_or_file: Annotated[str, typer.Argument(help="Spec name or path to results JSON")],
-    run: Annotated[Optional[str], typer.Option("--run", help="Specific run timestamp")] = None,
-    fmt: Annotated[str, typer.Option("--format", "-f", help="Output format: table | json")] = "table",
+    spec_or_file: Annotated[
+        str, typer.Argument(help="Spec name or path to results JSON")
+    ],
+    run: Annotated[
+        Optional[str], typer.Option("--run", help="Specific run timestamp")
+    ] = None,
+    fmt: Annotated[
+        str, typer.Option("--format", "-f", help="Output format: table | json")
+    ] = "table",
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
     results_path = _resolve_path(spec_or_file, run)
     if results_path is None:
-        console.print(f"[bold red]Error:[/bold red] No results found for {spec_or_file!r}")
+        console.print(
+            f"[bold red]Error:[/bold red] No results found for {spec_or_file!r}"
+        )
         raise typer.Exit(1)
 
     try:

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -29,12 +29,32 @@ def run_cmd(
     k: int = typer.Option(3, "--k", help="Attempts per task"),
     workers: int = typer.Option(4, "--workers", help="Parallel task workers"),
     timeout: int = typer.Option(120, "--timeout", help="Seconds per attempt"),
-    fail_fast_unusable: int = typer.Option(0, "--fail-fast", min=0, help="Stop a task after N consecutive infra_error/timeout attempts (0 disables)"),
-    baseline: bool = typer.Option(False, "--baseline", help="Also run without skill for delta"),
-    output: Optional[Path] = typer.Option(None, "--output", help="Save results JSON to path"),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show per-attempt reasoning"),
-    model: Optional[str] = typer.Option(None, "--model", "-m", help="Override skill backend/model (e.g. claude-api:claude-sonnet-4-6 or claude-sonnet-4-6)"),
-    judge_model: Optional[str] = typer.Option(None, "--judge-model", help="Override judge backend/model (e.g. claude-api:claude-haiku-4-5-20251001)"),
+    fail_fast_unusable: int = typer.Option(
+        0,
+        "--fail-fast",
+        min=0,
+        help="Stop a task after N consecutive infra_error/timeout attempts (0 disables)",
+    ),
+    baseline: bool = typer.Option(
+        False, "--baseline", help="Also run without skill for delta"
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", help="Save results JSON to path"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show per-attempt reasoning"
+    ),
+    model: Optional[str] = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help="Override skill backend/model (e.g. claude-api:claude-sonnet-4-6 or claude-sonnet-4-6)",
+    ),
+    judge_model: Optional[str] = typer.Option(
+        None,
+        "--judge-model",
+        help="Override judge backend/model (e.g. claude-api:claude-haiku-4-5-20251001)",
+    ),
 ) -> None:
     if not spec_file.exists():
         console.print(f"[bold red]Error:[/bold red] File not found: {spec_file}")
@@ -108,7 +128,9 @@ def run_cmd(
             k,
             len(result.attempts),
             result.successes,
-            cheated=any(attempt.outcome == Outcome.CHEAT for attempt in result.attempts),
+            cheated=any(
+                attempt.outcome == Outcome.CHEAT for attempt in result.attempts
+            ),
             unusable=result.unusable,
             finished=True,
         )

--- a/caliper/commands/update_cli.py
+++ b/caliper/commands/update_cli.py
@@ -113,7 +113,11 @@ def _print_checks(targets: list[CliTarget]) -> None:
 def _update(cli: CliTarget, *, yes: bool) -> None:
     command = _command_for(cli)
     app_bundle = _app_bundle_for(cli)
-    if app_bundle and command == str(app_bundle) and not os.environ.get("CODEX_CLI_PATH"):
+    if (
+        app_bundle
+        and command == str(app_bundle)
+        and not os.environ.get("CODEX_CLI_PATH")
+    ):
         console.print(
             "[bold yellow]Codex app bundle detected.[/bold yellow] "
             "Caliper currently uses the Codex CLI inside the desktop app, so "
@@ -124,7 +128,9 @@ def _update(cli: CliTarget, *, yes: bool) -> None:
 
     npm = shutil.which("npm")
     if not npm:
-        console.print("[bold red]Error:[/bold red] npm is required to update agent CLIs.")
+        console.print(
+            "[bold red]Error:[/bold red] npm is required to update agent CLIs."
+        )
         raise typer.Exit(1)
 
     install_cmd = [npm, "install", "-g", cli.npm_package]
@@ -194,7 +200,11 @@ def _latest_npm_version(package: str) -> str | None:
 
 def _update_hint(cli: CliTarget, command: str | None) -> str:
     app_bundle = _app_bundle_for(cli)
-    if app_bundle and command == str(app_bundle) and not os.environ.get("CODEX_CLI_PATH"):
+    if (
+        app_bundle
+        and command == str(app_bundle)
+        and not os.environ.get("CODEX_CLI_PATH")
+    ):
         return "update desktop app or set CODEX_CLI_PATH"
     return f"caliper update-cli {cli.name}"
 

--- a/caliper/harness/__init__.py
+++ b/caliper/harness/__init__.py
@@ -11,6 +11,7 @@ def get_harness(backend: str, model: str | None = None) -> HarnessBackend:
             return ClaudeCodeHarness(model=model)
         case "codex":
             from caliper.harness.codex import CodexHarness
+
             return CodexHarness(model=model)
         case "claude-api":
             return ClaudeAPIHarness(model=model)
@@ -18,6 +19,7 @@ def get_harness(backend: str, model: str | None = None) -> HarnessBackend:
             return OpenAIAPIHarness(model=model)
         case "pi":
             from caliper.harness.pi import PiHarness
+
             return PiHarness(model=model)
         case _:
             raise ValueError(f"Unknown backend: {backend!r}")

--- a/caliper/harness/claude_api.py
+++ b/caliper/harness/claude_api.py
@@ -32,7 +32,9 @@ class ClaudeAPIHarness(HarnessBackend):
         start = time.monotonic()
         output, exit_code, error = self._run_api(full_prompt, effective_model, timeout)
         duration = time.monotonic() - start
-        transcript = [ConversationTurn(role="assistant", content=output)] if output else []
+        transcript = (
+            [ConversationTurn(role="assistant", content=output)] if output else []
+        )
         return AttemptResult(
             task_id=task_id,
             attempt=attempt,
@@ -54,7 +56,9 @@ class ClaudeAPIHarness(HarnessBackend):
         body = re.sub(r"^---\n.*?\n---\n", "", raw, flags=re.DOTALL).strip()
         return f"[Skill context]\n{body}\n[End skill context]\n\n{prompt}"
 
-    def _run_api(self, prompt: str, model: str, timeout: int) -> tuple[str, int, str | None]:
+    def _run_api(
+        self, prompt: str, model: str, timeout: int
+    ) -> tuple[str, int, str | None]:
         try:
             import anthropic
         except ImportError:
@@ -68,7 +72,9 @@ class ClaudeAPIHarness(HarnessBackend):
                 messages=[{"role": "user", "content": prompt}],
             )
             content = "".join(
-                block.text for block in response.content if getattr(block, "type", None) == "text"
+                block.text
+                for block in response.content
+                if getattr(block, "type", None) == "text"
             )
             return content.strip(), 0, None
         except Exception as exc:

--- a/caliper/harness/claude_code.py
+++ b/caliper/harness/claude_code.py
@@ -66,7 +66,10 @@ class ClaudeCodeHarness(HarnessBackend):
         real_home = Path.home()
         for src, dst in [
             (real_home / ".claude.json", home / ".claude.json"),
-            (real_home / ".claude" / ".credentials.json", home / ".claude" / ".credentials.json"),
+            (
+                real_home / ".claude" / ".credentials.json",
+                home / ".claude" / ".credentials.json",
+            ),
         ]:
             if src.exists():
                 dst.parent.mkdir(parents=True, exist_ok=True)
@@ -134,7 +137,9 @@ class ClaudeCodeHarness(HarnessBackend):
             final_output=final_output,
             exit_code=proc.returncode,
             duration_seconds=duration,
-            error=proc.stderr.strip() if proc.returncode != 0 and not final_output else None,
+            error=proc.stderr.strip()
+            if proc.returncode != 0 and not final_output
+            else None,
         )
 
     def _diagnose_configuration_error(
@@ -206,7 +211,8 @@ class ClaudeCodeHarness(HarnessBackend):
             "typeerror:" in lowered
             or "syntaxerror:" in lowered
             or "referenceerror:" in lowered
-            or "file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/" in lowered
+            or "file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/"
+            in lowered
             or "node.js v" in lowered
         ) and "claude-code/cli.js" in lowered
 
@@ -241,7 +247,13 @@ class ClaudeCodeHarness(HarnessBackend):
     def _seed_credentials_from_keychain(self, dst: Path) -> None:
         try:
             result = subprocess.run(
-                ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
+                [
+                    "security",
+                    "find-generic-password",
+                    "-s",
+                    "Claude Code-credentials",
+                    "-w",
+                ],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -255,8 +267,10 @@ class ClaudeCodeHarness(HarnessBackend):
     def _build_cmd(self, prompt: str, model: str | None) -> list[str]:
         cmd = [
             "claude",
-            "-p", prompt,
-            "--output-format", "stream-json",
+            "-p",
+            prompt,
+            "--output-format",
+            "stream-json",
             "--verbose",
             "--dangerously-skip-permissions",
         ]
@@ -265,7 +279,10 @@ class ClaudeCodeHarness(HarnessBackend):
         return cmd
 
     def _build_env(
-        self, isolated_home: str, extra_path: list[str], has_file_credentials: bool = False
+        self,
+        isolated_home: str,
+        extra_path: list[str],
+        has_file_credentials: bool = False,
     ) -> dict[str, str]:
         base_path = os.environ.get("PATH", "")
         path_prefixes = []
@@ -278,7 +295,11 @@ class ClaudeCodeHarness(HarnessBackend):
         # omits Homebrew prefixes. Prepend them when present so tools installed
         # via Homebrew (e.g. on Apple Silicon at /opt/homebrew/bin) are found.
         if sys.platform == "darwin":
-            homebrew_candidates = ["/opt/homebrew/bin", "/opt/homebrew/sbin", "/usr/local/bin"]
+            homebrew_candidates = [
+                "/opt/homebrew/bin",
+                "/opt/homebrew/sbin",
+                "/usr/local/bin",
+            ]
             path_prefixes.extend(p for p in homebrew_candidates if os.path.isdir(p))
 
         if extra_path:
@@ -312,7 +333,6 @@ class ClaudeCodeHarness(HarnessBackend):
 
         return env
 
-
     def _parse_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]:
         transcript: list[ConversationTurn] = []
         final_output = ""
@@ -332,7 +352,9 @@ class ClaudeCodeHarness(HarnessBackend):
                 for block in event.get("message", {}).get("content", []):
                     btype = block.get("type", "")
                     if btype == "text":
-                        transcript.append(ConversationTurn(role="assistant", content=block["text"]))
+                        transcript.append(
+                            ConversationTurn(role="assistant", content=block["text"])
+                        )
                     elif btype == "tool_use":
                         transcript.append(
                             ConversationTurn(
@@ -350,7 +372,9 @@ class ClaudeCodeHarness(HarnessBackend):
                         c.get("text", "") for c in content if isinstance(c, dict)
                     )
                 transcript.append(
-                    ConversationTurn(role="tool_result", content=content, tool_output=content)
+                    ConversationTurn(
+                        role="tool_result", content=content, tool_output=content
+                    )
                 )
 
             elif etype == "result":

--- a/caliper/harness/codex.py
+++ b/caliper/harness/codex.py
@@ -142,7 +142,11 @@ class CodexHarness(HarnessBackend):
                 env=env,
                 cwd=isolated_home,
             )
-            return result.stdout.strip(), result.returncode, result.stderr.strip() or None
+            return (
+                result.stdout.strip(),
+                result.returncode,
+                result.stderr.strip() or None,
+            )
         except subprocess.TimeoutExpired:
             return "", 124, "timeout"
         except OSError as exc:
@@ -337,7 +341,9 @@ class CodexHarness(HarnessBackend):
 
     def _summarize_cli_configuration_error(self, text: str) -> str:
         lines = [line.strip() for line in text.splitlines() if line.strip()]
-        version_line = next((line for line in lines if line.startswith("OpenAI Codex")), None)
+        version_line = next(
+            (line for line in lines if line.startswith("OpenAI Codex")), None
+        )
         error_lines = [line for line in lines if line.startswith("ERROR:")]
         detail_lines = [
             line

--- a/caliper/harness/openai_api.py
+++ b/caliper/harness/openai_api.py
@@ -31,7 +31,9 @@ class OpenAIAPIHarness(HarnessBackend):
         start = time.monotonic()
         output, exit_code, error = self._run_api(full_prompt, effective_model, timeout)
         duration = time.monotonic() - start
-        transcript = [ConversationTurn(role="assistant", content=output)] if output else []
+        transcript = (
+            [ConversationTurn(role="assistant", content=output)] if output else []
+        )
         return AttemptResult(
             task_id=task_id,
             attempt=attempt,
@@ -43,11 +45,17 @@ class OpenAIAPIHarness(HarnessBackend):
             timed_out=exit_code == 124 and error == "timeout",
         )
 
-    def _run_api(self, prompt: str, model: str, timeout: int) -> tuple[str, int, str | None]:
+    def _run_api(
+        self, prompt: str, model: str, timeout: int
+    ) -> tuple[str, int, str | None]:
         try:
             from openai import OpenAI
         except ImportError:
-            return "", 1, "openai package not installed; run: pip install caliper[openai]"
+            return (
+                "",
+                1,
+                "openai package not installed; run: pip install caliper[openai]",
+            )
 
         try:
             client = OpenAI()

--- a/caliper/harness/pi.py
+++ b/caliper/harness/pi.py
@@ -122,7 +122,8 @@ class PiHarness(HarnessBackend):
         cmd = [
             pi,
             "--print",
-            "--mode", "json",
+            "--mode",
+            "json",
             "--no-session",
             # Trust the project-local skill file for this run; without it pi
             # blocks on an interactive trust prompt when a skill is loaded.
@@ -153,7 +154,11 @@ class PiHarness(HarnessBackend):
                 env=env,
                 cwd=isolated_home,
             )
-            return result.stdout.strip(), result.returncode, result.stderr.strip() or None
+            return (
+                result.stdout.strip(),
+                result.returncode,
+                result.stderr.strip() or None,
+            )
         except subprocess.TimeoutExpired:
             return "", 124, "timeout"
         except OSError as exc:

--- a/caliper/judge/openai_api_judge.py
+++ b/caliper/judge/openai_api_judge.py
@@ -20,7 +20,11 @@ def evaluate_with_openai_api(
     try:
         from openai import OpenAI
     except ImportError:
-        return False, "openai package not installed; run: pip install caliper[openai]", True
+        return (
+            False,
+            "openai package not installed; run: pip install caliper[openai]",
+            True,
+        )
 
     user_msg = _USER_TMPL.format(
         expect=expect,

--- a/caliper/main.py
+++ b/caliper/main.py
@@ -20,8 +20,12 @@ app.command("new", help="Create a new evaluation spec (interactive wizard)")(new
 app.command("report", help="Render saved evaluation results")(report_cmd)
 app.command("list", help="List evaluation specs and past runs")(list_cmd_fn)
 app.command("validate", help="Validate an evaluation spec file")(validate_cmd)
-app.command("install-skill", help="Install the bundled evaluate-skill agent skill")(install_skill_cmd)
-app.command("update-cli", help="Check or update Codex and Claude Code CLIs")(update_cli_cmd)
+app.command("install-skill", help="Install the bundled evaluate-skill agent skill")(
+    install_skill_cmd
+)
+app.command("update-cli", help="Check or update Codex and Claude Code CLIs")(
+    update_cli_cmd
+)
 
 
 def main() -> None:

--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -50,8 +50,12 @@ _OUTCOME_GLYPH = {
 }
 
 
-def print_banner(spec_name: str, k: int, backend: str, model: str | None = None) -> None:
-    target = f"[cyan]{backend}[/cyan]" + (f" [dim]{_SEP} {model}[/dim]" if model else "")
+def print_banner(
+    spec_name: str, k: int, backend: str, model: str | None = None
+) -> None:
+    target = f"[cyan]{backend}[/cyan]" + (
+        f" [dim]{_SEP} {model}[/dim]" if model else ""
+    )
     console.print(
         Panel(
             f"{_BANNER}  {_SEP}  [bold]{spec_name}[/bold]  {_SEP}  k=[cyan]{k}[/cyan]  {_SEP}  {target}",
@@ -106,7 +110,11 @@ def update_progress(
     elif terminal and unusable:
         status = f"[bold yellow]{_UNUSABLE}{unusable}[/bold yellow]"
     elif terminal:
-        status = f"[bold green]{_CHECK}[/bold green]" if passed == k else f"[bold red]{_CROSS}[/bold red]"
+        status = (
+            f"[bold green]{_CHECK}[/bold green]"
+            if passed == k
+            else f"[bold red]{_CROSS}[/bold red]"
+        )
     else:
         status = f"[dim]{completed}/{k}[/dim]"
     rendered_completed = k if finished and completed < k else completed
@@ -129,7 +137,9 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
     )
     console.print()
 
-    table = Table(box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False)
+    table = Table(
+        box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False
+    )
     table.add_column("ID", style="dim", no_wrap=True)
     table.add_column("Task")
     table.add_column(f"k ({k})", justify="center")
@@ -189,7 +199,13 @@ def _print_aggregate(results: RunResults) -> None:
 
     def score_bar(score: float, width: int = 20) -> str:
         filled = round(score * width)
-        return "[green]" + _BAR_FULL * filled + "[/green][dim]" + _BAR_EMPTY * (width - filled) + "[/dim]"
+        return (
+            "[green]"
+            + _BAR_FULL * filled
+            + "[/green][dim]"
+            + _BAR_EMPTY * (width - filled)
+            + "[/dim]"
+        )
 
     console.print(
         f" [bold]With skill[/bold]    [cyan]{agg.avg_pass_at_k * 100:.1f}%[/cyan]  {score_bar(agg.avg_pass_at_k)}"
@@ -253,7 +269,11 @@ def _print_task_detail(tr: TaskResult, k: int) -> None:
         )
     for attempt in tr.attempts:
         prefix = _OUTCOME_GLYPH.get(attempt.outcome, f"[red]{_CROSS}[/red]")
-        label = "" if attempt.outcome.is_usable else f"  [yellow]{attempt.outcome.value}[/yellow]"
+        label = (
+            ""
+            if attempt.outcome.is_usable
+            else f"  [yellow]{attempt.outcome.value}[/yellow]"
+        )
         lines.append(
             f"  Attempt {attempt.attempt}  {prefix}{label}  ({attempt.duration_seconds:.1f}s)"
         )

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -65,16 +65,38 @@ def run(
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures_with = {
             pool.submit(
-                _run_task, task, harness, judge, cheat, spec, spec_path,
-                k, timeout, True, on_attempt_done, on_task_done, fail_fast_unusable,
+                _run_task,
+                task,
+                harness,
+                judge,
+                cheat,
+                spec,
+                spec_path,
+                k,
+                timeout,
+                True,
+                on_attempt_done,
+                on_task_done,
+                fail_fast_unusable,
             ): task
             for task in spec.tasks
         }
         futures_without = (
             {
                 pool.submit(
-                    _run_task, task, harness, judge, cheat, spec, spec_path,
-                    k, timeout, False, on_attempt_done, on_task_done, fail_fast_unusable,
+                    _run_task,
+                    task,
+                    harness,
+                    judge,
+                    cheat,
+                    spec,
+                    spec_path,
+                    k,
+                    timeout,
+                    False,
+                    on_attempt_done,
+                    on_task_done,
+                    fail_fast_unusable,
                 ): task
                 for task in spec.tasks
             }
@@ -142,8 +164,16 @@ def _run_task(
     consecutive_fail_fast_triggers = 0
     for attempt_num in range(1, k + 1):
         record = _run_attempt(
-            task, attempt_num, harness, judge, cheat,
-            spec, spec_path, timeout, with_skill, on_attempt_done,
+            task,
+            attempt_num,
+            harness,
+            judge,
+            cheat,
+            spec,
+            spec_path,
+            timeout,
+            with_skill,
+            on_attempt_done,
         )
         attempts.append(record)
         if record.outcome in _FAIL_FAST_OUTCOMES:
@@ -188,8 +218,7 @@ def _run_attempt(
     try:
         _run_shell(task.setup)
         resolved_extra_path = [
-            str((spec_path.parent / p).resolve())
-            for p in spec.sandbox.extra_path
+            str((spec_path.parent / p).resolve()) for p in spec.sandbox.extra_path
         ]
         skill_path = _resolve_skill_path(spec, spec_path) if with_skill else None
         if skill_path:
@@ -219,7 +248,9 @@ def _run_attempt(
             or looks_like_infra_failure(infra_text)
         ):
             outcome = classify_outcome(attempt_result, [], None)
-            evidence = attempt_result.error or f"harness exited {attempt_result.exit_code}"
+            evidence = (
+                attempt_result.error or f"harness exited {attempt_result.exit_code}"
+            )
             return _finish(
                 AttemptRecord(
                     attempt=attempt,
@@ -281,7 +312,9 @@ def _finish(
 ) -> AttemptRecord:
     if on_attempt_done:
         on_attempt_done(
-            AttemptEvent(task_id=task.id, attempt=record.attempt, outcome=record.outcome)
+            AttemptEvent(
+                task_id=task.id, attempt=record.attempt, outcome=record.outcome
+            )
         )
     return record
 

--- a/caliper/schema/spec.py
+++ b/caliper/schema/spec.py
@@ -53,7 +53,9 @@ class TaskSpec(BaseModel):
     @model_validator(mode="after")
     def require_at_least_one_check(self) -> "TaskSpec":
         if not self.expect and not self.assert_script:
-            raise ValueError(f"Task '{self.name}' must have at least one of: expect, assert")
+            raise ValueError(
+                f"Task '{self.name}' must have at least one of: expect, assert"
+            )
         return self
 
 

--- a/caliper/scoring.py
+++ b/caliper/scoring.py
@@ -10,7 +10,9 @@ def pass_at_k(successes: int, k: int) -> float:
     return 1.0 - (1.0 - p) ** k
 
 
-def aggregate_scores(task_pass_counts: dict[str, tuple[str, int, int, int]]) -> AggregateScore:
+def aggregate_scores(
+    task_pass_counts: dict[str, tuple[str, int, int, int]],
+) -> AggregateScore:
     """
     task_pass_counts: {task_id: (task_name, successes, usable, k)}
 
@@ -22,7 +24,13 @@ def aggregate_scores(task_pass_counts: dict[str, tuple[str, int, int, int]]) -> 
     for task_id, (task_name, successes, usable, k) in task_pass_counts.items():
         score = pass_at_k(successes, usable) if usable > 0 else None
         per_task.append(
-            TaskScore(task_id=task_id, task_name=task_name, k=k, successes=successes, score=score)
+            TaskScore(
+                task_id=task_id,
+                task_name=task_name,
+                k=k,
+                successes=successes,
+                score=score,
+            )
         )
 
     scored = [t.score for t in per_task if t.score is not None]
@@ -30,7 +38,9 @@ def aggregate_scores(task_pass_counts: dict[str, tuple[str, int, int, int]]) -> 
     return AggregateScore(avg_pass_at_k=avg, per_task=per_task)
 
 
-def compute_delta(with_skill: AggregateScore, without_skill: AggregateScore) -> DeltaReport:
+def compute_delta(
+    with_skill: AggregateScore, without_skill: AggregateScore
+) -> DeltaReport:
     return DeltaReport(
         with_skill=with_skill,
         without_skill=without_skill,

--- a/caliper/wizard.py
+++ b/caliper/wizard.py
@@ -8,7 +8,14 @@ from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
 from rich.rule import Rule
 
-from caliper.schema.spec import EvalSpec, JudgeConfig, SandboxConfig, SkillConfig, TaskSpec, normalize_backend
+from caliper.schema.spec import (
+    EvalSpec,
+    JudgeConfig,
+    SandboxConfig,
+    SkillConfig,
+    TaskSpec,
+    normalize_backend,
+)
 
 console = Console()
 
@@ -26,11 +33,14 @@ def run_wizard(
 
     # ── Step 1: Skill ─────────────────────────────────────────────────────────
     console.print(Rule("[bold]Step 1 — Skill[/bold]", style="cyan"))
-    skill_p = Prompt.ask(
-        "  Path to skill file",
-        default=skill_path or "",
-        show_default=bool(skill_path),
-    ).strip() or None
+    skill_p = (
+        Prompt.ask(
+            "  Path to skill file",
+            default=skill_path or "",
+            show_default=bool(skill_path),
+        ).strip()
+        or None
+    )
 
     backend_choice = Prompt.ask(
         "  Backend",
@@ -54,13 +64,17 @@ def run_wizard(
 
     # ── Step 3: Tasks ─────────────────────────────────────────────────────────
     console.print(Rule("[bold]Step 3 — Tasks[/bold]", style="cyan"))
-    console.print("  [dim]Add tasks one by one. Leave task name empty to finish.[/dim]\n")
+    console.print(
+        "  [dim]Add tasks one by one. Leave task name empty to finish.[/dim]\n"
+    )
 
     tasks: list[TaskSpec] = []
     task_num = 1
 
     while True:
-        task_name = Prompt.ask(f"  Task {task_num} name (empty to finish)", default="").strip()
+        task_name = Prompt.ask(
+            f"  Task {task_num} name (empty to finish)", default=""
+        ).strip()
         if not task_name:
             if not tasks:
                 console.print("  [yellow]At least one task is required.[/yellow]")
@@ -80,10 +94,13 @@ def run_wizard(
             prompt_lines.append(line)
         prompt_text = "\n".join(prompt_lines)
 
-        expect = Prompt.ask(
-            "  Expectation [dim](what does success look like?)[/dim]",
-            default="",
-        ).strip() or None
+        expect = (
+            Prompt.ask(
+                "  Expectation [dim](what does success look like?)[/dim]",
+                default="",
+            ).strip()
+            or None
+        )
 
         assert_val: str | None = None
         if Confirm.ask("  Add an assert script?", default=False):
@@ -156,4 +173,6 @@ def _to_yaml(spec: EvalSpec) -> str:
     for task in data.get("tasks", []):
         if "assert_script" in task:
             task["assert"] = task.pop("assert_script")
-    return yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    return yaml.dump(
+        data, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 [project.optional-dependencies]
 openai = ["openai>=1.0"]
 codex = ["openai>=1.0"]
-dev = ["pytest", "ruff"]
+dev = ["pytest", "ruff==0.13.0", "pre-commit"]
 
 [project.scripts]
 caliper = "caliper.main:app"
@@ -51,3 +51,7 @@ Skills = "https://clawhub.ai/edonadei/evaluate-skill"
 
 [tool.hatch.build.targets.wheel]
 packages = ["caliper"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"

--- a/tests/test_claude_harness.py
+++ b/tests/test_claude_harness.py
@@ -9,7 +9,9 @@ from caliper.harness.base import HarnessConfigurationError
 from caliper.harness.claude_code import ClaudeCodeHarness
 
 
-def test_claude_harness_accepts_runner_contract_with_extra_path(monkeypatch, tmp_path) -> None:
+def test_claude_harness_accepts_runner_contract_with_extra_path(
+    monkeypatch, tmp_path
+) -> None:
     skill = tmp_path / "review.md"
     skill.write_text("Review the code.")
     run_calls = []
@@ -45,7 +47,9 @@ def test_claude_harness_accepts_runner_contract_with_extra_path(monkeypatch, tmp
     assert result.exit_code == 0
     assert result.final_output == "done"
 
-    cmd, kwargs = next((cmd, kwargs) for cmd, kwargs in run_calls if cmd[:2] == ["claude", "-p"])
+    cmd, kwargs = next(
+        (cmd, kwargs) for cmd, kwargs in run_calls if cmd[:2] == ["claude", "-p"]
+    )
     assert cmd[:2] == ["claude", "-p"]
     assert cmd[2] == "/review the diff"
     assert "--dangerously-skip-permissions" in cmd
@@ -54,7 +58,9 @@ def test_claude_harness_accepts_runner_contract_with_extra_path(monkeypatch, tmp
     assert not list((tmp_path / "home" / ".claude" / "commands").glob("*.md"))
 
 
-def test_claude_harness_reports_cli_startup_crash_before_auth(monkeypatch, tmp_path) -> None:
+def test_claude_harness_reports_cli_startup_crash_before_auth(
+    monkeypatch, tmp_path
+) -> None:
     def fake_run(cmd, **kwargs):
         stderr = "\n".join(
             [

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -22,7 +22,9 @@ def test_codex_cli_receives_injected_skill_on_stdin(monkeypatch, tmp_path) -> No
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
         if cmd == ["codex.cmd", "--version"]:
-            return subprocess.CompletedProcess(cmd, 0, stdout="codex-cli 0.132.0\n", stderr="")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="codex-cli 0.132.0\n", stderr=""
+            )
         assert cmd[:2] == ["codex.cmd", "exec"]
         assert cmd[-1] == "-"
         assert kwargs["input"].startswith("[Skill context]\nUse caliper carefully.")
@@ -31,7 +33,9 @@ def test_codex_cli_receives_injected_skill_on_stdin(monkeypatch, tmp_path) -> No
         return subprocess.CompletedProcess(cmd, 0, stdout="VALID\n", stderr="")
 
     monkeypatch.setattr("caliper.harness.codex.shutil.which", fake_which)
-    monkeypatch.setattr("caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
     monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
 
     result = CodexHarness().run(
@@ -61,11 +65,15 @@ def test_codex_cli_omits_model_when_unspecified(monkeypatch, tmp_path) -> None:
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
         if cmd == ["codex", "--version"]:
-            return subprocess.CompletedProcess(cmd, 0, stdout="codex-cli 0.132.0\n", stderr="")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="codex-cli 0.132.0\n", stderr=""
+            )
         return subprocess.CompletedProcess(cmd, 0, stdout="OK\n", stderr="")
 
     monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex")
-    monkeypatch.setattr("caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
     monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
 
     result = CodexHarness().run(
@@ -86,7 +94,9 @@ def test_codex_cli_omits_model_when_unspecified(monkeypatch, tmp_path) -> None:
 def test_codex_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
     def fake_run(cmd, **kwargs):
         if cmd == ["codex", "--version"]:
-            return subprocess.CompletedProcess(cmd, 0, stdout="codex-cli 0.132.0\n", stderr="")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="codex-cli 0.132.0\n", stderr=""
+            )
         events = [
             {"type": "thread.started", "thread_id": "thread-1"},
             {"type": "turn.started"},
@@ -122,7 +132,9 @@ def test_codex_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex")
-    monkeypatch.setattr("caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
     monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
 
     result = CodexHarness().run(
@@ -152,7 +164,9 @@ def test_codex_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
 def test_codex_json_stream_keeps_unknown_tool_items(monkeypatch, tmp_path) -> None:
     def fake_run(cmd, **kwargs):
         if cmd == ["codex", "--version"]:
-            return subprocess.CompletedProcess(cmd, 0, stdout="codex-cli 0.132.0\n", stderr="")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="codex-cli 0.132.0\n", stderr=""
+            )
         events = [
             {
                 "type": "item.completed",
@@ -173,7 +187,9 @@ def test_codex_json_stream_keeps_unknown_tool_items(monkeypatch, tmp_path) -> No
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex")
-    monkeypatch.setattr("caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
     monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
 
     result = CodexHarness().run(
@@ -209,12 +225,12 @@ def test_codex_config_copy_strips_top_level_model(monkeypatch, tmp_path) -> None
     real_codex_home.mkdir(parents=True)
     (real_codex_home / "auth.json").write_text("{}")
     (real_codex_home / "config.toml").write_text(
-        '\n'.join(
+        "\n".join(
             [
                 'model = "gpt-5.5"',
                 'model_reasoning_effort = "medium"',
                 "",
-                '[profiles.keep]',
+                "[profiles.keep]",
                 'model = "profile-model"',
             ]
         )
@@ -235,7 +251,9 @@ def test_codex_config_copy_strips_top_level_model(monkeypatch, tmp_path) -> None
 
 def test_codex_fails_clearly_when_cli_is_not_runnable(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex.exe")
-    monkeypatch.setattr("caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
 
     def fake_run(cmd, **kwargs):
         raise OSError("access denied")
@@ -256,21 +274,27 @@ def test_codex_fails_clearly_when_cli_is_not_runnable(monkeypatch, tmp_path) -> 
     assert "does not fall back to the OpenAI API" in str(exc.value)
 
 
-def test_codex_fails_clearly_when_cli_requires_newer_version(monkeypatch, tmp_path) -> None:
+def test_codex_fails_clearly_when_cli_requires_newer_version(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex")
-    monkeypatch.setattr("caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
 
     def fake_run(cmd, **kwargs):
         if cmd == ["codex", "--version"]:
-            return subprocess.CompletedProcess(cmd, 0, stdout="codex-cli 0.46.0\n", stderr="")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="codex-cli 0.46.0\n", stderr=""
+            )
         return subprocess.CompletedProcess(
             cmd,
             1,
             stdout="",
             stderr=(
                 "ERROR: unexpected status 400 Bad Request: "
-                "{\"detail\":\"The 'gpt-5.4-mini' model requires a newer version "
-                "of Codex. Please upgrade to the latest app or CLI and try again.\"}"
+                '{"detail":"The \'gpt-5.4-mini\' model requires a newer version '
+                'of Codex. Please upgrade to the latest app or CLI and try again."}'
             ),
         )
 

--- a/tests/test_codex_judge.py
+++ b/tests/test_codex_judge.py
@@ -22,13 +22,15 @@ def test_eval_judge_expect_only_calls_llm(monkeypatch, tmp_path) -> None:
         calls.append((expect, model, cwd))
         return True, "Codex accepted the transcript.", False
 
-    monkeypatch.setattr("caliper.judge.script_assert.EvalJudge._llm_evaluate",
-                        lambda self, task, transcript, spec_dir: fake_eval(
-                            expect=task.expect,
-                            transcript=transcript,
-                            model=self._config.model,
-                            cwd=spec_dir,
-                        ))
+    monkeypatch.setattr(
+        "caliper.judge.script_assert.EvalJudge._llm_evaluate",
+        lambda self, task, transcript, spec_dir: fake_eval(
+            expect=task.expect,
+            transcript=transcript,
+            model=self._config.model,
+            cwd=spec_dir,
+        ),
+    )
 
     judge = EvalJudge(JudgeConfig(backend="codex", model="test-model"))
     result = judge.evaluate(
@@ -60,7 +62,9 @@ def test_eval_judge_assert_only_runs_script_no_llm(tmp_path) -> None:
 def test_eval_judge_assert_failure_makes_overall_fail(tmp_path) -> None:
     judge = EvalJudge(JudgeConfig(backend="codex"))
     result = judge.evaluate(
-        task=TaskSpec(id="t3", name="t", prompt="p", assert_script="assert False, 'nope'"),
+        task=TaskSpec(
+            id="t3", name="t", prompt="p", assert_script="assert False, 'nope'"
+        ),
         transcript=[],
         final_output="",
         spec_dir=str(tmp_path),
@@ -118,7 +122,9 @@ def test_errored_autorater_dropped_when_assert_passes(monkeypatch, tmp_path) -> 
     assert result.autorater_passed is None
 
 
-def test_errored_autorater_does_not_override_failing_assert(monkeypatch, tmp_path) -> None:
+def test_errored_autorater_does_not_override_failing_assert(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setattr(
         "caliper.judge.script_assert.EvalJudge._llm_evaluate", _errored_llm
     )
@@ -158,11 +164,24 @@ def test_codex_judge_uses_output_last_message(monkeypatch, tmp_path) -> None:
         calls.append((cmd, kwargs))
         output_path = cmd[cmd.index("--output-last-message") + 1]
         with open(output_path, "w") as f:
-            json.dump({"mode": "verdict", "passed": True, "reasoning": "The transcript matches."}, f)
-        return subprocess.CompletedProcess(cmd, 0, stdout="noisy session log", stderr="")
+            json.dump(
+                {
+                    "mode": "verdict",
+                    "passed": True,
+                    "reasoning": "The transcript matches.",
+                },
+                f,
+            )
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="noisy session log", stderr=""
+        )
 
-    monkeypatch.setattr("caliper.judge.codex_judge.shutil.which", lambda _name: "codex.cmd")
-    monkeypatch.setattr("caliper.judge.codex_judge.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.judge.codex_judge.shutil.which", lambda _name: "codex.cmd"
+    )
+    monkeypatch.setattr(
+        "caliper.judge.codex_judge.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
     monkeypatch.setattr("caliper.judge.codex_judge.subprocess.run", fake_run)
 
     passed, reasoning, errored = evaluate_with_codex(
@@ -183,7 +202,9 @@ def test_codex_judge_uses_output_last_message(monkeypatch, tmp_path) -> None:
     assert kwargs["cwd"] == str(tmp_path)
 
 
-def test_eval_judge_uses_codex_for_expect_when_configured(monkeypatch, tmp_path) -> None:
+def test_eval_judge_uses_codex_for_expect_when_configured(
+    monkeypatch, tmp_path
+) -> None:
     calls = []
 
     def fake_eval(*, expect, transcript, model, cwd, timeout=60):

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -30,7 +30,9 @@ def test_install_skill_codex_writes_expected_path(tmp_path) -> None:
 
 
 def test_install_skill_claude_code_writes_expected_path(tmp_path) -> None:
-    result = runner.invoke(app, ["install-skill", "claude-code"], env={"HOME": str(tmp_path)})
+    result = runner.invoke(
+        app, ["install-skill", "claude-code"], env={"HOME": str(tmp_path)}
+    )
 
     destination = tmp_path / ".claude" / "commands" / "evaluate-skill.md"
     assert result.exit_code == 0, result.output

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -61,12 +61,16 @@ def test_classify_infra_error_on_rate_limit_signal_despite_zero_exit() -> None:
 
 
 def test_classify_timeout() -> None:
-    out = classify_outcome(_harness(exit_code=124, error="timeout", timed_out=True), [], None)
+    out = classify_outcome(
+        _harness(exit_code=124, error="timeout", timed_out=True), [], None
+    )
     assert out is Outcome.TIMEOUT
 
 
 def test_classify_cheat() -> None:
-    assert classify_outcome(_harness(), ["/forbidden/answers.txt"], None) is Outcome.CHEAT
+    assert (
+        classify_outcome(_harness(), ["/forbidden/answers.txt"], None) is Outcome.CHEAT
+    )
 
 
 def test_precedence_timeout_beats_infra() -> None:

--- a/tests/test_pi_harness.py
+++ b/tests/test_pi_harness.py
@@ -101,7 +101,12 @@ def test_pi_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
                 "toolCallId": "toolu_1",
                 "toolName": "write",
                 "result": {
-                    "content": [{"type": "text", "text": "Successfully wrote 5 bytes to notes.txt"}]
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Successfully wrote 5 bytes to notes.txt",
+                        }
+                    ]
                 },
                 "isError": False,
             },

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -5,7 +5,13 @@ from datetime import datetime, timezone
 
 from rich.console import Console
 
-from caliper.reporter import _OUTPUT_TRUNCATE_AT, _format_output, make_progress, print_results, update_progress
+from caliper.reporter import (
+    _OUTPUT_TRUNCATE_AT,
+    _format_output,
+    make_progress,
+    print_results,
+    update_progress,
+)
 from caliper.schema.results import (
     AggregateScore,
     AttemptRecord,
@@ -200,7 +206,12 @@ def test_only_failed_tasks_shown_in_mixed_results() -> None:
     results = _make_results(
         [
             _make_task("task-001", passed=True, output="pass output"),
-            _make_task("task-002", passed=False, output="fail output", assert_evidence="file not found"),
+            _make_task(
+                "task-002",
+                passed=False,
+                output="fail output",
+                assert_evidence="file not found",
+            ),
         ]
     )
     out = _render(results)
@@ -241,9 +252,7 @@ def test_verbose_shows_all_tasks() -> None:
 
 def test_long_output_truncated_in_rendered_output() -> None:
     long_output = "z" * (_OUTPUT_TRUNCATE_AT + 200)
-    results = _make_results(
-        [_make_task("task-001", passed=False, output=long_output)]
-    )
+    results = _make_results([_make_task("task-001", passed=False, output=long_output)])
     out = _render(results)
     assert "truncated" in out
     # Rich wraps long lines; count total z's to verify the tail was included
@@ -251,9 +260,7 @@ def test_long_output_truncated_in_rendered_output() -> None:
 
 
 def test_empty_output_renders_no_output_marker() -> None:
-    results = _make_results(
-        [_make_task("task-001", passed=False, output="")]
-    )
+    results = _make_results([_make_task("task-001", passed=False, output="")])
     out = _render(results)
     assert "no output" in out
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -291,9 +291,7 @@ def test_stage_excludes_cheat_surfaces(tmp_path) -> None:
     home = tmp_path / "home"
     home.mkdir()
 
-    _stage_skill_directory(
-        str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"]
-    )
+    _stage_skill_directory(str(skill_dir / "SKILL.md"), str(home), [r"secret\.txt$"])
 
     assert not (home / ".caliper").exists()
     assert not (home / "my-skill.eval.yaml").exists()

--- a/tests/test_update_cli.py
+++ b/tests/test_update_cli.py
@@ -23,7 +23,9 @@ def test_update_cli_check_prints_versions(monkeypatch, tmp_path) -> None:
 
     def fake_run(cmd, **kwargs):
         if cmd == [str(codex), "--version"]:
-            return subprocess.CompletedProcess(cmd, 0, stdout="codex-cli 0.132.0\n", stderr="")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="codex-cli 0.132.0\n", stderr=""
+            )
         if cmd == ["npm", "view", "@openai/codex", "version"]:
             return subprocess.CompletedProcess(cmd, 0, stdout="0.133.0\n", stderr="")
         if cmd == ["npm", "view", "@anthropic-ai/claude-code", "version"]:
@@ -31,7 +33,9 @@ def test_update_cli_check_prints_versions(monkeypatch, tmp_path) -> None:
         raise AssertionError(cmd)
 
     monkeypatch.setattr("caliper.commands.update_cli.shutil.which", fake_which)
-    monkeypatch.setattr("caliper.commands.update_cli.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.commands.update_cli.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
     monkeypatch.setattr("caliper.commands.update_cli.subprocess.run", fake_run)
 
     result = runner.invoke(app, ["update-cli", "codex", "--check"])
@@ -65,11 +69,15 @@ def test_update_cli_updates_with_npm_when_confirmed(monkeypatch, tmp_path) -> No
         if cmd == ["npm", "install", "-g", "@openai/codex"]:
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
         if cmd == [str(codex), "--version"]:
-            return subprocess.CompletedProcess(cmd, 0, stdout="codex-cli 0.133.0\n", stderr="")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="codex-cli 0.133.0\n", stderr=""
+            )
         raise AssertionError(cmd)
 
     monkeypatch.setattr("caliper.commands.update_cli.shutil.which", fake_which)
-    monkeypatch.setattr("caliper.commands.update_cli.CODEX_APP_CLI", tmp_path / "missing-codex")
+    monkeypatch.setattr(
+        "caliper.commands.update_cli.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
     monkeypatch.setattr("caliper.commands.update_cli.subprocess.run", fake_run)
 
     result = runner.invoke(app, ["update-cli", "codex", "--yes"])


### PR DESCRIPTION
Closes #30.

Adopts **`ruff==0.13.0`** as the single formatting and linting authority so style is deterministic and never resurfaces as review churn (follow-up to #29, where a `ruff format` run reflowed unrelated lines and had to be hand-reverted).

## What's in here

- **Pin the formatter** — `ruff==0.13.0` and `pre-commit` added to the `dev` extras; explicit `[tool.ruff]` config (`line-length = 88`, `target-version = "py310"`).
- **Format the world** — one-time `ruff format .` reflow (28 files). No behavioral changes; all 95 tests still pass.
- **CI gate** — `.github/workflows/lint.yml` runs `ruff format --check .` and `ruff check .` on every `pull_request` and on `push` to `main` (single Python 3.12 job).
- **Pre-commit hook** — `.pre-commit-config.yaml` (ruff mirror pinned to `v0.13.0`) runs `ruff-format` + `ruff check --fix` locally; CI stays check-only.
- **Docs** — new `CONTRIBUTING.md` (source of truth: pinned version, commands, `pre-commit install`, "don't hand-format unrelated lines"), an agent rule in `CLAUDE.md`, and a pointer from `README.md`.

## Follow-up (manual, done alongside this PR)

`lint` is being added as a **required status check** on `main` via branch protection. `CONTRIBUTING.md` documents the `gh api` command to re-apply it if protection is ever reset.

## Acceptance criteria

- [x] `ruff format --check .` and `ruff check .` pass cleanly on this branch.
- [x] Both run automatically on every PR (`lint.yml`).
- [x] A pre-commit hook runs the same checks locally.
- [x] Convention documented in `CLAUDE.md` + `CONTRIBUTING.md`.