### PR TITLE
caliper compare <A> <B>: per-task diff of two saved runs (the ablation primitive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ When both `expect` and `assert` are present, both must pass.
 | `caliper validate <spec>` | Validate a spec file |
 | `caliper list [spec]` | List specs and saved runs |
 | `caliper report <spec-or-result>` | Re-render saved results |
+| `caliper compare <A> <B>` | Diff two saved runs of the same eval, task by task |
 | `caliper install-skill <backend>` | Install the bundled evaluate-skill into Claude Code or Codex |
 | `caliper update-cli [backend]` | Check or update installed agent CLI versions |
 
@@ -420,6 +421,70 @@ caliper run my-skill.eval.yaml --model claude-api:claude-sonnet-4-6 --judge-mode
 Accepted backends: `claude-code`, `codex`, `pi`, `claude-api`, `openai-api` (aliases: `claude`, `anthropic`, `openai`).
 
 The spec file is never modified — overrides apply only to the current run.
+
+---
+
+## Comparing two runs (`caliper compare`)
+
+An **ablation** compares two runs of the *same* eval — a full skill vs. a
+shortened variant, or the same skill over time. `caliper compare <A> <B>` diffs
+two already-saved runs task by task, so you don't hand-write a JSON script to
+answer "did this change regress?".
+
+```bash
+# Latest run of each spec (a bare spec name resolves to its latest run)
+caliper compare commit-simple-full commit-simple-short
+
+# Pin specific runs by pointing at their results JSON
+caliper compare .caliper/results/demo/2026-07-01T10-00-00Z.json \
+                .caliper/results/demo/2026-07-02T09-00-00Z.json
+
+# Machine-readable diff for a ship / no-ship decision
+caliper compare A B --format json
+```
+
+Each positional (`A`, `B`) is addressed exactly like `report`'s argument: a spec
+name (→ its latest run) or a path to a results JSON. There are no `--run-a/-b`
+flags — pin a historical run by naming its JSON path.
+
+```
+──────────────────── CALIPER  —  compare  —  commit-simple ─────────────────────
+    A 2026-07-01T10-00-00Z (claude-code)   ·   B 2026-07-02T09-00-00Z (claude-code)   ·   k=5
+
+╭──────────────────┬──────────┬──────────┬────────┬─────────┬─────────╮
+│ Task             │ A pass@k │ B pass@k │      Δ │ A strip │ B strip │
+├──────────────────┼──────────┼──────────┼────────┼─────────┼─────────┤
+│ commits cleanly  │   100.0% │   100.0% │      — │ ✓✓✓✓✓   │ ✓✓✓✓✓   │
+│ handles conflict │    80.0% │    40.0% │ -40.0% │ ✓✓✓✓✗   │ ✓✗✓✗✗   │
+│ pushes upstream  │    80.0% │        — │      — │ ✓✓✓✓✗   │ ⊘⊘⊘⊘⊘   │
+╰──────────────────┴──────────┴──────────┴────────┴─────────┴─────────╯
+
+ A 90.0%   B 70.0%   Δ (matched) -20.0% ↓
+ ⚠ 1 regression: handles conflict
+ ⊘ 1 unmeasured (excluded from Δ): pushes upstream
+ unmatched — only in A: flaky task   only in B: new task
+```
+
+How the diff reads:
+
+- **Tasks are matched by name.** `task_id` is only positional, so name is the
+  stable identity — reordered tasks still line up. A task present in only one
+  run is listed as **unmatched** and left out of the delta.
+- **`Δ` is `b − a`.** A negative Δ renders red and flags the task as a
+  **regression** (any-below rule: B below A by any amount).
+- **pass@k excludes unusable attempts.** The strips reuse the run report's
+  glyphs; `⊘` marks an unusable attempt (rate-limit / timeout / judge error).
+  A task with *no* usable attempts on a side shows `—` (unmeasured) and is never
+  counted as a regression — infra noise can't fake a loss.
+- **The headline `Δ (matched)`** averages each side over only the tasks measured
+  on **both** sides, so it is strictly like-for-like.
+- **Guards** for a `k` mismatch or different spec names print as warnings in the
+  header *and* in `--format json` (`k_mismatch`, `spec_mismatch`, `warnings`), so
+  an agent driving `compare` sees them too.
+
+The `--format json` output serializes the full comparison (per-task scores,
+deltas, `regression`/`has_regression` flags, unmatched task lists, and the
+warnings) for scripting.
 
 ---
 

--- a/caliper/commands/_addressing.py
+++ b/caliper/commands/_addressing.py
@@ -1,0 +1,33 @@
+"""Shared run addressing for commands that load a saved run (``report``, ``compare``).
+
+A run reference is either a direct path to a results JSON, or a spec name that
+resolves to ``.caliper/results/<name>/`` — the latest run, or a specific one via
+``--run <timestamp>``. Both commands resolve their positional arguments the same
+way through :func:`resolve_run_path`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_run_path(spec_or_file: str, run: str | None = None) -> Path | None:
+    """Resolve a run reference to a results-JSON path, or ``None`` if not found."""
+    p = Path(spec_or_file)
+
+    # Direct JSON path.
+    if p.suffix == ".json" and p.exists():
+        return p
+
+    # Spec name -> look in .caliper/results/<name>/
+    results_dir = Path(".caliper") / "results" / spec_or_file
+    if not results_dir.exists():
+        return None
+
+    if run:
+        candidate = results_dir / f"{run}.json"
+        return candidate if candidate.exists() else None
+
+    # Latest = lexicographically last (ISO timestamps sort correctly).
+    files = sorted(results_dir.glob("*.json"))
+    return files[-1] if files else None

--- a/caliper/commands/compare.py
+++ b/caliper/commands/compare.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from caliper.commands._addressing import resolve_run_path
+from caliper.compare import diff_runs
+from caliper.reporter import comparison_to_json, print_comparison
+from caliper.schema.results import RunResults
+
+console = Console()
+
+
+def _load_run(ref: str) -> RunResults:
+    path = resolve_run_path(ref)
+    if path is None:
+        console.print(f"[bold red]Error:[/bold red] No results found for {ref!r}")
+        raise typer.Exit(1)
+    try:
+        return RunResults.model_validate_json(path.read_text())
+    except Exception as exc:
+        console.print(f"[bold red]Error parsing results ({ref}):[/bold red] {exc}")
+        raise typer.Exit(1)
+
+
+def compare_cmd(
+    a: Annotated[
+        str,
+        typer.Argument(help="Run A: spec name (latest run) or path to results JSON"),
+    ],
+    b: Annotated[
+        str,
+        typer.Argument(help="Run B: spec name (latest run) or path to results JSON"),
+    ],
+    fmt: Annotated[
+        str, typer.Option("--format", "-f", help="Output format: table | json")
+    ] = "table",
+) -> None:
+    comparison = diff_runs(_load_run(a), _load_run(b))
+
+    if fmt == "json":
+        console.print_json(comparison_to_json(comparison))
+    else:
+        print_comparison(comparison)

--- a/caliper/commands/report.py
+++ b/caliper/commands/report.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
 from rich.console import Console
 
+from caliper.commands._addressing import resolve_run_path
 from caliper.reporter import print_results, results_to_json
 from caliper.schema.results import RunResults
 
@@ -24,7 +24,7 @@ def report_cmd(
     ] = "table",
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
-    results_path = _resolve_path(spec_or_file, run)
+    results_path = resolve_run_path(spec_or_file, run)
     if results_path is None:
         console.print(
             f"[bold red]Error:[/bold red] No results found for {spec_or_file!r}"
@@ -41,24 +41,3 @@ def report_cmd(
         console.print_json(results_to_json(results))
     else:
         print_results(results, verbose=verbose)
-
-
-def _resolve_path(spec_or_file: str, run: str | None) -> Path | None:
-    p = Path(spec_or_file)
-
-    # Direct JSON path
-    if p.suffix == ".json" and p.exists():
-        return p
-
-    # Spec name → look in .caliper/results/<name>/
-    results_dir = Path(".caliper") / "results" / spec_or_file
-    if not results_dir.exists():
-        return None
-
-    if run:
-        candidate = results_dir / f"{run}.json"
-        return candidate if candidate.exists() else None
-
-    # Latest = lexicographically last (ISO timestamps sort correctly)
-    files = sorted(results_dir.glob("*.json"))
-    return files[-1] if files else None

--- a/caliper/compare.py
+++ b/caliper/compare.py
@@ -1,0 +1,112 @@
+"""Pure comparison of two saved runs — the ablation reporting primitive.
+
+``diff_runs(a, b)`` is the whole of ``caliper compare``'s logic; the CLI command
+and ``--format json`` are thin shells over it. See CONTEXT.md (Run comparison,
+Task identity, Regression) for the domain terms.
+"""
+
+from __future__ import annotations
+
+from caliper.schema.results import (
+    RunComparison,
+    RunResults,
+    TaskComparison,
+    TaskResult,
+)
+
+
+def _group_by_name(results: RunResults) -> dict[str, list[TaskResult]]:
+    """Tasks keyed by their stable identity, ``task_name``, preserving order.
+
+    ``task_id`` is only positional (see CONTEXT.md → Task identity), so it is not
+    an identity across runs; duplicate names are disambiguated positionally by
+    the order they appear here.
+    """
+    grouped: dict[str, list[TaskResult]] = {}
+    for tr in results.task_results:
+        grouped.setdefault(tr.task_name, []).append(tr)
+    return grouped
+
+
+def _compare_task(name: str, a: TaskResult, b: TaskResult) -> TaskComparison:
+    a_score = a.pass_at_k
+    b_score = b.pass_at_k
+    both_measured = a_score is not None and b_score is not None
+    return TaskComparison(
+        task_name=name,
+        a_score=a_score,
+        b_score=b_score,
+        delta=(b_score - a_score) if both_measured else None,
+        # Any-below rule; an unmeasured side is unknown, never a regression.
+        regression=both_measured and b_score < a_score,
+        a_outcomes=[att.outcome for att in a.attempts],
+        b_outcomes=[att.outcome for att in b.attempts],
+    )
+
+
+def diff_runs(a: RunResults, b: RunResults) -> RunComparison:
+    """Diff two already-saved runs of (nominally) the same eval, A vs B.
+
+    Matches tasks by ``task_name``; tasks present on only one side are surfaced
+    as unmatched. The headline aggregate is computed over the *fully-comparable*
+    set — tasks measured on both sides — so the delta is strictly like-for-like.
+    """
+    a_by_name = _group_by_name(a)
+    b_by_name = _group_by_name(b)
+
+    matched: list[TaskComparison] = []
+    unmatched_a: list[str] = []
+
+    # Walk A's order; pair each name positionally against B's tasks of that name.
+    for name, a_tasks in a_by_name.items():
+        b_tasks = b_by_name.get(name, [])
+        pairs = min(len(a_tasks), len(b_tasks))
+        for i in range(pairs):
+            matched.append(_compare_task(name, a_tasks[i], b_tasks[i]))
+        # A-side tasks with no B counterpart (name absent or fewer in B).
+        unmatched_a.extend(name for _ in a_tasks[pairs:])
+
+    # B-side leftovers: names absent from A, plus surplus duplicates of a shared name.
+    unmatched_b: list[str] = []
+    for name, b_tasks in b_by_name.items():
+        matched_count = min(len(a_by_name.get(name, [])), len(b_tasks))
+        unmatched_b.extend(name for _ in b_tasks[matched_count:])
+
+    # Headline aggregate over tasks measured on both sides only.
+    comparable = [
+        tc for tc in matched if tc.a_score is not None and tc.b_score is not None
+    ]
+    a_avg = (
+        sum(tc.a_score for tc in comparable) / len(comparable) if comparable else 0.0
+    )
+    b_avg = (
+        sum(tc.b_score for tc in comparable) / len(comparable) if comparable else 0.0
+    )
+
+    spec_mismatch = a.run.spec != b.run.spec
+    k_mismatch = a.run.k != b.run.k
+    warnings: list[str] = []
+    if spec_mismatch:
+        warnings.append(
+            f"comparing different specs: {a.run.spec} vs {b.run.spec} "
+            f"— verify this is intentional"
+        )
+    if k_mismatch:
+        warnings.append(
+            f"A ran k={a.run.k}, B ran k={b.run.k} — pass@k not directly comparable"
+        )
+
+    return RunComparison(
+        a=a.run,
+        b=b.run,
+        matched=matched,
+        unmatched_a=unmatched_a,
+        unmatched_b=unmatched_b,
+        a_matched_avg=a_avg,
+        b_matched_avg=b_avg,
+        aggregate_delta=b_avg - a_avg,
+        has_regression=any(tc.regression for tc in matched),
+        k_mismatch=k_mismatch,
+        spec_mismatch=spec_mismatch,
+        warnings=warnings,
+    )

--- a/caliper/main.py
+++ b/caliper/main.py
@@ -3,6 +3,7 @@ import typer
 from caliper.commands.run import run_cmd
 from caliper.commands.new import new_cmd
 from caliper.commands.report import report_cmd
+from caliper.commands.compare import compare_cmd
 from caliper.commands.list_cmd import list_cmd_fn
 from caliper.commands.validate import validate_cmd
 from caliper.commands.install_skill import install_skill_cmd
@@ -18,6 +19,9 @@ app = typer.Typer(
 app.command("run", help="Run an evaluation spec")(run_cmd)
 app.command("new", help="Create a new evaluation spec (interactive wizard)")(new_cmd)
 app.command("report", help="Render saved evaluation results")(report_cmd)
+app.command("compare", help="Diff two saved runs of the same eval (A vs B)")(
+    compare_cmd
+)
 app.command("list", help="List evaluation specs and past runs")(list_cmd_fn)
 app.command("validate", help="Validate an evaluation spec file")(validate_cmd)
 app.command("install-skill", help="Install the bundled evaluate-skill agent skill")(

--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -15,7 +15,13 @@ from rich.table import Table
 from rich.table import Column
 from rich.text import Text
 
-from caliper.schema.results import Outcome, RunResults, TaskResult
+from caliper.schema.results import (
+    Outcome,
+    RunComparison,
+    RunResults,
+    TaskComparison,
+    TaskResult,
+)
 
 console = Console()
 
@@ -295,8 +301,136 @@ def _print_task_detail(tr: TaskResult, k: int) -> None:
     )
 
 
+# Per-outcome (glyph, style) for building the side-by-side attempt strips as
+# rich Text, so colour survives regardless of markup mode.
+_OUTCOME_STYLE = {
+    Outcome.PASS: (_CHECK, "green"),
+    Outcome.TASK_FAIL: (_CROSS, "red"),
+    Outcome.CHEAT: (_WARN, "yellow"),
+    Outcome.INFRA_ERROR: (_UNUSABLE, "yellow"),
+    Outcome.TIMEOUT: (_UNUSABLE, "yellow"),
+    Outcome.JUDGE_ERROR: (_UNUSABLE, "yellow"),
+}
+
+
+def _fmt_score(score: float | None) -> str:
+    return _RULE if score is None else f"{score * 100:.1f}%"
+
+
+def _outcome_strip(outcomes: list[Outcome]) -> Text:
+    strip = Text()
+    for oc in outcomes:
+        glyph, style = _OUTCOME_STYLE.get(oc, (_CROSS, "red"))
+        strip.append(glyph, style=style)
+    return strip
+
+
+def _delta_cell(tc: TaskComparison) -> Text:
+    # Unmeasured (None) and no-change (0.0) both read as "—"; JSON keeps them
+    # distinct. Only a real move shows a signed number.
+    if tc.delta is None or tc.delta == 0:
+        return Text(_RULE, style="dim")
+    sign = "+" if tc.delta > 0 else ""
+    style = "red" if tc.regression else "green"
+    return Text(f"{sign}{tc.delta * 100:.1f}%", style=style)
+
+
+def print_comparison(comp: RunComparison) -> None:
+    """Render a two-run diff. A thin shell over ``diff_runs`` — no logic here."""
+    a_ts = comp.a.timestamp.strftime("%Y-%m-%dT%H-%M-%SZ")
+    b_ts = comp.b.timestamp.strftime("%Y-%m-%dT%H-%M-%SZ")
+
+    console.print()
+    console.rule(
+        f"{_BANNER}  {_RULE}  compare  {_RULE}  [bold]{comp.a.spec}[/bold]",
+        style="cyan",
+    )
+    console.print(
+        f"    [bold]A[/bold] {a_ts} ([cyan]{comp.a.backend}[/cyan])   {_SEP}"
+        f"   [bold]B[/bold] {b_ts} ([cyan]{comp.b.backend}[/cyan])   {_SEP}"
+        f"   k=[cyan]{comp.a.k}[/cyan]"
+        + (f"/[cyan]{comp.b.k}[/cyan]" if comp.k_mismatch else "")
+    )
+    for warning in comp.warnings:
+        console.print(f" [bold yellow]{_WARN}[/bold yellow] [yellow]{warning}[/yellow]")
+    console.print()
+
+    table = Table(
+        box=box.ROUNDED, show_header=True, header_style="bold cyan", expand=False
+    )
+    table.add_column("Task")
+    table.add_column("A pass@k", justify="right")
+    table.add_column("B pass@k", justify="right")
+    table.add_column(f"{_delta_symbol()}", justify="right")
+    table.add_column("A strip")
+    table.add_column("B strip")
+
+    for tc in comp.matched:
+        unmeasured = tc.a_score is None or tc.b_score is None
+        name = Text(tc.task_name, style="dim" if unmeasured else "")
+        a_pk = Text(_fmt_score(tc.a_score), style="dim" if unmeasured else "")
+        b_pk = Text(_fmt_score(tc.b_score), style="dim" if unmeasured else "")
+        table.add_row(
+            name,
+            a_pk,
+            b_pk,
+            _delta_cell(tc),
+            _outcome_strip(tc.a_outcomes),
+            _outcome_strip(tc.b_outcomes),
+        )
+
+    console.print(table)
+    console.print()
+    _print_comparison_summary(comp)
+
+
+def _delta_symbol() -> str:
+    return "Δ" if _UNICODE else "delta"
+
+
+def _print_comparison_summary(comp: RunComparison) -> None:
+    arrow = _UP if comp.aggregate_delta >= 0 else _DOWN
+    sign = "+" if comp.aggregate_delta >= 0 else ""
+    color = "green" if comp.aggregate_delta >= 0 else "red"
+    console.print(
+        f" [bold]A[/bold] [cyan]{comp.a_matched_avg * 100:.1f}%[/cyan]   "
+        f"[bold]B[/bold] [cyan]{comp.b_matched_avg * 100:.1f}%[/cyan]   "
+        f"[bold]{_delta_symbol()} (matched)[/bold] "
+        f"[{color}]{sign}{comp.aggregate_delta * 100:.1f}%[/{color}] {arrow}"
+    )
+
+    regressions = [tc.task_name for tc in comp.matched if tc.regression]
+    if regressions:
+        console.print(
+            f" [bold yellow]{_WARN}[/bold yellow] [yellow]{len(regressions)} "
+            f"regression{'s' if len(regressions) > 1 else ''}:[/yellow] "
+            f"{', '.join(regressions)}"
+        )
+
+    unmeasured = [
+        tc.task_name for tc in comp.matched if tc.a_score is None or tc.b_score is None
+    ]
+    if unmeasured:
+        console.print(
+            f" [yellow]{_UNUSABLE}[/yellow] [dim]{len(unmeasured)} unmeasured "
+            f"(excluded from {_delta_symbol()}): {', '.join(unmeasured)}[/dim]"
+        )
+
+    if comp.unmatched_a or comp.unmatched_b:
+        only_a = ", ".join(comp.unmatched_a) or "—"
+        only_b = ", ".join(comp.unmatched_b) or "—"
+        console.print(
+            f" [dim]unmatched — only in A: {only_a}   only in B: {only_b}[/dim]"
+        )
+    console.print()
+
+
 def results_to_json(results: RunResults) -> str:
     return results.model_dump_json(indent=2)
+
+
+def comparison_to_json(comp: RunComparison) -> str:
+    return comp.model_dump_json(indent=2)
 
 
 def save_results(results: RunResults, spec_path: str) -> str:

--- a/caliper/resources/evaluate_skill/REFERENCE.md
+++ b/caliper/resources/evaluate_skill/REFERENCE.md
@@ -38,6 +38,19 @@ caliper report my-skill-eval --run 2026-05-12T14-23-01Z  # specific run
 caliper report results.json --format json
 ```
 
+### Compare two runs (ablation)
+Diff two already-saved runs of the same eval — full vs. shortened skill, or the
+same skill over time. Tasks are matched by name; `Δ = b − a`; a negative Δ flags
+a regression; a side with no usable attempts shows `—` (unmeasured, never a
+regression); the headline `Δ (matched)` averages only tasks measured on both
+sides. Each argument is addressed like `report` (spec name → latest run, or a
+results-JSON path); pin a historical run by naming its path.
+```bash
+caliper compare full-eval short-eval          # latest run of each spec
+caliper compare a.json b.json                 # pin specific runs
+caliper compare full-eval short-eval --format json   # for a ship/no-ship gate
+```
+
 ## Spec format (.eval.yaml)
 
 ```yaml

--- a/caliper/schema/results.py
+++ b/caliper/schema/results.py
@@ -107,3 +107,46 @@ class RunResults(BaseModel):
     aggregate: AggregateScore
     baseline: AggregateScore | None = None
     delta: DeltaReport | None = None
+
+
+class TaskComparison(BaseModel):
+    """One matched task diffed across two runs (A vs B).
+
+    ``a_score``/``b_score`` are the stored per-task ``pass_at_k`` (``None`` when
+    every attempt was unusable — the task was never fairly measured). ``delta``
+    is ``b - a`` only when both sides were measured, else ``None`` (never faked
+    as 0). ``regression`` fires on the any-below rule: B below A, both measured.
+    """
+
+    task_name: str
+    a_score: float | None
+    b_score: float | None
+    delta: float | None
+    regression: bool
+    a_outcomes: list[Outcome]
+    b_outcomes: list[Outcome]
+
+
+class RunComparison(BaseModel):
+    """The pure result of ``diff_runs(a, b)`` — the whole ``compare`` contract.
+
+    Rendering (table) and ``--format json`` are thin shells over this value.
+    Usable/unusable counts are intentionally *not* stored: they are derivable
+    from ``a_outcomes``/``b_outcomes`` (see docs/adr/0001-attempt-outcome-taxonomy.md).
+    """
+
+    a: RunMeta
+    b: RunMeta
+    matched: list[TaskComparison]
+    unmatched_a: list[str]
+    unmatched_b: list[str]
+    # Aggregate over the fully-comparable set (tasks measured on *both* sides).
+    a_matched_avg: float
+    b_matched_avg: float
+    aggregate_delta: float
+    has_regression: bool
+    k_mismatch: bool
+    spec_mismatch: bool
+    # Human-readable guards, mirrored into both the table header and JSON so an
+    # agent on --format json sees the exact warning a human sees.
+    warnings: list[str]

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -38,6 +38,19 @@ caliper report my-skill-eval --run 2026-05-12T14-23-01Z  # specific run
 caliper report results.json --format json
 ```
 
+### Compare two runs (ablation)
+Diff two already-saved runs of the same eval — full vs. shortened skill, or the
+same skill over time. Tasks are matched by name; `Δ = b − a`; a negative Δ flags
+a regression; a side with no usable attempts shows `—` (unmeasured, never a
+regression); the headline `Δ (matched)` averages only tasks measured on both
+sides. Each argument is addressed like `report` (spec name → latest run, or a
+results-JSON path); pin a historical run by naming its path.
+```bash
+caliper compare full-eval short-eval          # latest run of each spec
+caliper compare a.json b.json                 # pin specific runs
+caliper compare full-eval short-eval --format json   # for a ship/no-ship gate
+```
+
 ## Spec format (.eval.yaml)
 
 ```yaml

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -23,7 +23,16 @@ caliper run path/to/spec.eval.yaml --judge-model claude-api:claude-haiku-4-5-202
 # Browse past results
 caliper list
 caliper report path/to/spec.eval.yaml
+
+# Compare two saved runs of the same eval (ablation: full vs. shortened, or over time)
+caliper compare full-eval short-eval           # spec name -> latest run, or a results-JSON path
+caliper compare a.json b.json --format json     # per-task Δ, regression flags, for scripting
 ```
+
+`caliper compare <A> <B>` diffs two already-saved runs task by task: tasks are
+matched by name, `Δ = b − a`, a negative Δ flags a regression (any-below), and a
+side with no usable attempts shows `—` (unmeasured, never a regression) so
+infra/judge noise can't fake a loss.
 
 ## Inspecting failures
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from caliper.compare import diff_runs
+from caliper.schema.results import (
+    AggregateScore,
+    AttemptRecord,
+    Outcome,
+    RunMeta,
+    RunResults,
+    SkillSnapshot,
+    TaskResult,
+    TaskScore,
+)
+from caliper.scoring import pass_at_k
+
+
+def _attempt(i: int, outcome: Outcome) -> AttemptRecord:
+    return AttemptRecord(attempt=i, output="", duration_seconds=1.0, outcome=outcome)
+
+
+def _task(name: str, outcomes: list[Outcome], task_id: str = "task-000") -> TaskResult:
+    usable = sum(1 for o in outcomes if o.is_usable)
+    successes = sum(1 for o in outcomes if o == Outcome.PASS)
+    score = pass_at_k(successes, usable) if usable > 0 else None
+    return TaskResult(
+        task_id=task_id,
+        task_name=name,
+        attempts=[_attempt(i + 1, o) for i, o in enumerate(outcomes)],
+        successes=successes,
+        unusable=len(outcomes) - usable,
+        pass_at_k=score,
+    )
+
+
+def _run(tasks: list[TaskResult], *, spec: str = "demo", k: int = 5) -> RunResults:
+    per_task = [
+        TaskScore(
+            task_id=t.task_id,
+            task_name=t.task_name,
+            k=k,
+            successes=t.successes,
+            score=t.pass_at_k,
+        )
+        for t in tasks
+    ]
+    scored = [t.pass_at_k for t in tasks if t.pass_at_k is not None]
+    return RunResults(
+        run=RunMeta(
+            spec=spec,
+            timestamp=datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc),
+            k=k,
+            backend="claude-code",
+        ),
+        skill_snapshot=SkillSnapshot(path="/fake/SKILL.md"),
+        task_results=tasks,
+        aggregate=AggregateScore(
+            avg_pass_at_k=sum(scored) / len(scored) if scored else 0.0,
+            per_task=per_task,
+        ),
+    )
+
+
+P, F, INF = Outcome.PASS, Outcome.TASK_FAIL, Outcome.INFRA_ERROR
+
+
+# --------------------------------------------------------------------------
+# Identical runs
+# --------------------------------------------------------------------------
+
+
+def test_identical_runs_have_zero_deltas_and_no_regression() -> None:
+    def tasks() -> list[TaskResult]:
+        return [_task("alpha", [P, P, F, P, F]), _task("beta", [P, P, P, P, P])]
+
+    comp = diff_runs(_run(tasks()), _run(tasks()))
+
+    assert not comp.has_regression
+    assert all(tc.delta == 0.0 for tc in comp.matched)
+    assert all(not tc.regression for tc in comp.matched)
+    assert comp.aggregate_delta == 0.0
+    assert comp.unmatched_a == [] and comp.unmatched_b == []
+
+
+# --------------------------------------------------------------------------
+# A single regression
+# --------------------------------------------------------------------------
+
+
+def test_single_task_regression_flags_only_that_task() -> None:
+    a = _run([_task("alpha", [P, P, P, P, P]), _task("beta", [P, P, P, P, F])])
+    b = _run([_task("alpha", [P, P, P, P, P]), _task("beta", [P, F, F, F, F])])
+
+    comp = diff_runs(a, b)
+    by_name = {tc.task_name: tc for tc in comp.matched}
+
+    assert comp.has_regression
+    assert not by_name["alpha"].regression
+    assert by_name["alpha"].delta == 0.0
+    assert by_name["beta"].regression
+    assert by_name["beta"].delta is not None and by_name["beta"].delta < 0
+    assert comp.aggregate_delta < 0
+
+
+def test_improvement_is_not_flagged_as_regression() -> None:
+    a = _run([_task("alpha", [P, F, F, F, F])])
+    b = _run([_task("alpha", [P, P, P, P, F])])
+
+    comp = diff_runs(a, b)
+    assert not comp.has_regression
+    assert comp.matched[0].delta is not None and comp.matched[0].delta > 0
+
+
+# --------------------------------------------------------------------------
+# Mismatched task sets
+# --------------------------------------------------------------------------
+
+
+def test_unmatched_tasks_are_reported_and_excluded_from_aggregate() -> None:
+    a = _run([_task("alpha", [P, P, P, P, P]), _task("only_a", [F, F, F, F, F])])
+    b = _run([_task("alpha", [P, P, P, P, P]), _task("only_b", [P, P, P, P, P])])
+
+    comp = diff_runs(a, b)
+
+    assert [tc.task_name for tc in comp.matched] == ["alpha"]
+    assert comp.unmatched_a == ["only_a"]
+    assert comp.unmatched_b == ["only_b"]
+    # Aggregate is over the fully-comparable set (alpha only), not the extras.
+    assert comp.a_matched_avg == 1.0
+    assert comp.b_matched_avg == 1.0
+
+
+def test_matching_is_by_name_not_positional_id() -> None:
+    # B reorders the tasks; positional ids differ but names must still line up.
+    a = _run([_task("alpha", [P, P, P, P, P]), _task("beta", [F, F, F, F, F])])
+    b = _run([_task("beta", [F, F, F, F, F]), _task("alpha", [P, P, P, P, P])])
+
+    comp = diff_runs(a, b)
+    by_name = {tc.task_name: tc for tc in comp.matched}
+
+    assert set(by_name) == {"alpha", "beta"}
+    assert by_name["alpha"].delta == 0.0
+    assert by_name["beta"].delta == 0.0
+    assert comp.unmatched_a == [] and comp.unmatched_b == []
+
+
+# --------------------------------------------------------------------------
+# Outcome-aware: infra noise must not fake a regression
+# --------------------------------------------------------------------------
+
+
+def test_lower_raw_score_from_unusable_attempts_is_not_a_regression() -> None:
+    # A: 4/5 pass. B: same 4 usable passes but its "misses" are infra_errors,
+    # excluded from the denominator -> B's pass@k is *higher*, not a regression.
+    a = _run([_task("alpha", [P, P, P, P, F])])
+    b = _run([_task("alpha", [P, P, P, P, INF])])
+
+    comp = diff_runs(a, b)
+    tc = comp.matched[0]
+    assert not tc.regression
+    assert tc.b_score == pass_at_k(4, 4)  # over 4 usable, not 5
+    assert tc.a_score == pass_at_k(4, 5)
+
+
+def test_fully_unusable_side_is_unmeasured_never_a_regression() -> None:
+    a = _run([_task("alpha", [P, P, P, P, F])])
+    b = _run([_task("alpha", [INF, INF, INF, INF, INF])])
+
+    comp = diff_runs(a, b)
+    tc = comp.matched[0]
+
+    assert tc.b_score is None
+    assert tc.delta is None
+    assert not tc.regression
+    assert not comp.has_regression
+    # An unmeasured side is excluded from the comparable aggregate.
+    assert comp.a_matched_avg == 0.0 and comp.b_matched_avg == 0.0
+
+
+# --------------------------------------------------------------------------
+# Guards
+# --------------------------------------------------------------------------
+
+
+def test_spec_and_k_mismatch_raise_warnings() -> None:
+    a = _run([_task("alpha", [P, P, P, P, P])], spec="full", k=5)
+    b = _run([_task("alpha", [P, P, P])], spec="short", k=3)
+
+    comp = diff_runs(a, b)
+
+    assert comp.spec_mismatch
+    assert comp.k_mismatch
+    assert any("different specs" in w for w in comp.warnings)
+    assert any("k=5" in w and "k=3" in w for w in comp.warnings)
+
+
+def test_matching_specs_and_k_produce_no_warnings() -> None:
+    a = _run([_task("alpha", [P, P, P, P, P])])
+    b = _run([_task("alpha", [P, P, P, P, P])])
+
+    comp = diff_runs(a, b)
+    assert not comp.spec_mismatch
+    assert not comp.k_mismatch
+    assert comp.warnings == []


### PR DESCRIPTION
Closes #23.

## What

Adds `caliper compare <A> <B>` — the ablation reporting primitive. It diffs two **already-saved** runs of the same eval task by task (control vs. candidate, or the same skill over time), so "did this change regress?" is a one-liner instead of a throwaway `python -c "import json…"` script.

```
──────────────────── CALIPER  —  compare  —  commit-simple ─────────────────────
    A 2026-07-01T10-00-00Z (claude-code)   ·   B 2026-07-02T09-00-00Z (claude-code)   ·   k=5
╭──────────────────┬──────────┬──────────┬───────┬─────────┬─────────╮
│ Task             │ A pass@k │ B pass@k │     Δ │ A strip │ B strip │
├──────────────────┼──────────┼──────────┼───────┼─────────┼─────────┤
│ commits cleanly  │   100.0% │   100.0% │     — │ ✓✓✓✓✓   │ ✓✓✓✓✓   │
│ handles conflict │   100.0% │    92.2% │ -7.7% │ ✓✓✓✓✗   │ ✓✗✓✗✗   │
│ pushes upstream  │   100.0% │        — │     — │ ✓✓✓✓✗   │ ⊘⊘⊘⊘⊘   │
╰──────────────────┴──────────┴──────────┴───────┴─────────┴─────────╯
 A 99.6%   B 97.1%   Δ (matched) -2.6% ↓
 ⚠ 1 regression: handles conflict
 ⊘ 2 unmeasured (excluded from Δ): pushes upstream, verifies remote
 unmatched — only in A: flaky task   only in B: new task
```

## Design (grilled up front)

- **Pure core.** All logic lives in `diff_runs(a, b) -> RunComparison`; the CLI command and `--format json` are thin shells over it. Tests assert on the model, not table formatting.
- **Match by `task_name`.** `task_id` is only positional (`load_spec` assigns `task-NNN` by order), so name is the stable identity — reordered tasks still line up. One-sided tasks are surfaced as unmatched and excluded from the delta.
- **Raw stored `pass_at_k`** per side (agrees with `report`, excludes unusable attempts via the outcome taxonomy). `Δ = b − a`; **any-below** regression flag (`b < a`).
- **Noise can't fake a loss.** A side with no usable attempts is *unmeasured* (`—`), never a regression. The headline `Δ (matched)` averages only tasks measured on **both** sides — strictly like-for-like.
- **Guards for agents.** A `k` mismatch or different spec names surface as warnings in the header **and** in JSON (`k_mismatch`, `spec_mismatch`, `warnings`), since `--format json` is agent-facing.
- **Addressing reuse.** Each positional resolves exactly like `report`'s argument (spec name → latest run, or a results-JSON path); `report`'s resolver was lifted into a shared `resolve_run_path`. No new `--run-a/-b` flags.
- **No `AggregateScore` schema change** — usable/unusable stay derived (no drift).

## Scope / follow-ups

Out of scope (tracked separately): stable content-derived task ids (#32) and an optional non-inferiority `--margin` for the regression flag (#33). Compare consumes the attempt-outcome taxonomy (#22) but doesn't define it, and doesn't produce runs (that's #17).

## Tests & docs

- New `tests/test_compare.py`: identical runs, single regression, unmatched sets, name-not-position matching, unusable-attempt cases, and the guards. Full suite: 104 pass, ruff clean.
- Docs updated in all four required locations (README + both REFERENCE.md copies + grill-skill REFERENCE); packaged-SKILL sync check passes.