### PR TITLE
refactor: collapse harness backends onto a deep CliHarness template

### DIFF
--- a/caliper/harness/__init__.py
+++ b/caliper/harness/__init__.py
@@ -1,4 +1,9 @@
-from caliper.harness.base import AttemptResult, ConversationTurn, HarnessBackend
+from caliper.harness.base import (
+    AttemptResult,
+    CliHarness,
+    ConversationTurn,
+    HarnessBackend,
+)
 from caliper.harness.claude_code import ClaudeCodeHarness
 from caliper.schema.spec import normalize_backend
 
@@ -23,6 +28,7 @@ __all__ = [
     "AttemptResult",
     "ConversationTurn",
     "HarnessBackend",
+    "CliHarness",
     "ClaudeCodeHarness",
     "get_harness",
 ]

--- a/caliper/harness/base.py
+++ b/caliper/harness/base.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from typing import Callable
 
 
 class HarnessConfigurationError(RuntimeError):
@@ -31,7 +35,56 @@ class AttemptResult:
     cheat_evidence: list[str] = field(default_factory=list)
 
 
+@dataclass
+class RunContext:
+    """Everything one attempt needs, plus a scratch dict for backend hooks.
+
+    Created fresh per ``run`` call and threaded through the hooks, so a backend
+    can stash per-attempt state (credentials seen, per-attempt config dir) in
+    ``extras`` without touching instance state — the harness object is shared
+    across the runner's worker threads.
+    """
+
+    task_id: str
+    attempt: int
+    prompt: str
+    skill_path: str | None
+    model: str | None
+    timeout: int
+    isolated_home: str
+    extra_path: list[str]
+    extras: dict = field(default_factory=dict)
+
+
+@dataclass
+class ProcessResult:
+    """The normalized outcome of spawning a CLI agent once."""
+
+    stdout: str
+    stderr: str
+    returncode: int
+    timed_out: bool
+
+    @property
+    def error(self) -> str | None:
+        """The default ``AttemptResult.error``: a timeout marker, else stderr."""
+        if self.timed_out:
+            return "timeout"
+        return self.stderr or None
+
+
 class HarnessBackend(ABC):
+    """The narrow seam the runner depends on: run one attempt, report a name.
+
+    Deliberately small — a test double or a future non-CLI backend only has to
+    satisfy these two members. The shared CLI-agent lifecycle lives in
+    :class:`CliHarness`, not here.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
     @abstractmethod
     def run(
         self,
@@ -46,6 +99,183 @@ class HarnessBackend(ABC):
         extra_path: list[str] | None = None,
     ) -> AttemptResult: ...
 
-    @property
+
+class CliHarness(HarnessBackend):
+    """Deep base owning the CLI-agent run lifecycle; backends fill in what varies.
+
+    ``run`` is a template method: it prepares the isolated home, builds the
+    command and environment, spawns the CLI agent once (timing it and handling
+    timeouts uniformly), raises on a diagnosed misconfiguration, parses the
+    stream, and assembles the ``AttemptResult``. A backend only implements the
+    parts that genuinely differ between CLI agents — the command, the
+    environment, and how to read that agent's stream.
+    """
+
+    def run(
+        self,
+        task_id: str,
+        attempt: int,
+        prompt: str,
+        *,
+        skill_path: str | None,
+        model: str | None,
+        timeout: int,
+        isolated_home: str,
+        extra_path: list[str] | None = None,
+    ) -> AttemptResult:
+        ctx = RunContext(
+            task_id=task_id,
+            attempt=attempt,
+            prompt=prompt,
+            skill_path=skill_path,
+            model=model or self._model,
+            timeout=timeout,
+            isolated_home=isolated_home,
+            extra_path=list(extra_path or []),
+        )
+
+        self._ensure_ready(ctx)
+        self._prepare(ctx)
+        cmd, stdin, cleanup = self._command(ctx)
+        env = self._environment(ctx)
+
+        start = time.monotonic()
+        try:
+            proc = self._execute(
+                cmd, env=env, cwd=ctx.isolated_home, timeout=ctx.timeout, stdin=stdin
+            )
+        finally:
+            if cleanup is not None:
+                cleanup()
+        duration = time.monotonic() - start
+
+        transcript, final_output = self._parse_stream(proc.stdout)
+
+        diagnostic = self._diagnose(proc, final_output)
+        if diagnostic:
+            raise HarnessConfigurationError(diagnostic)
+
+        transcript, final_output = self._fallback(transcript, final_output, proc)
+
+        return AttemptResult(
+            task_id=ctx.task_id,
+            attempt=ctx.attempt,
+            transcript=transcript,
+            final_output=final_output,
+            exit_code=proc.returncode,
+            duration_seconds=duration,
+            error=self._error_field(proc, final_output),
+            timed_out=proc.timed_out,
+        )
+
+    # --- hooks a backend implements ---------------------------------------
+
+    _model: str | None = None
+
+    def _ensure_ready(self, ctx: RunContext) -> None:
+        """Raise ``HarnessConfigurationError`` if the CLI can't run. Default: skip."""
+
+    def _prepare(self, ctx: RunContext) -> None:
+        """Seed the isolated home with auth/config before the agent runs."""
+
     @abstractmethod
-    def name(self) -> str: ...
+    def _command(
+        self, ctx: RunContext
+    ) -> tuple[list[str], str | None, Callable[[], None] | None]:
+        """Return ``(argv, stdin_payload, cleanup)`` for the agent invocation.
+
+        ``stdin_payload`` is fed to the process's stdin when not ``None``;
+        ``cleanup`` runs after the process exits (e.g. to remove a staged file).
+        """
+
+    @abstractmethod
+    def _environment(self, ctx: RunContext) -> dict[str, str]: ...
+
+    @abstractmethod
+    def _parse_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]: ...
+
+    def _diagnose(self, proc: ProcessResult, final_output: str) -> str | None:
+        """Return a human-readable misconfiguration message, or ``None``."""
+        return None
+
+    def _fallback(
+        self,
+        transcript: list[ConversationTurn],
+        final_output: str,
+        proc: ProcessResult,
+    ) -> tuple[list[ConversationTurn], str]:
+        """Salvage raw stdout as a single turn when nothing parsed out of it."""
+        if not transcript and proc.stdout:
+            return [
+                ConversationTurn(role="assistant", content=proc.stdout)
+            ], proc.stdout
+        return transcript, final_output
+
+    def _error_field(self, proc: ProcessResult, final_output: str) -> str | None:
+        return proc.error
+
+    # --- shared machinery -------------------------------------------------
+
+    def _execute(
+        self,
+        cmd: list[str],
+        *,
+        env: dict[str, str],
+        cwd: str,
+        timeout: int,
+        stdin: str | None,
+    ) -> ProcessResult:
+        """Spawn the agent once, timing out into a 124/timeout ProcessResult."""
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=stdin,
+                stdin=subprocess.DEVNULL if stdin is None else None,
+                capture_output=True,
+                encoding="utf-8",
+                text=True,
+                timeout=timeout,
+                env=env,
+                cwd=cwd,
+            )
+        except subprocess.TimeoutExpired:
+            return ProcessResult("", "timeout", 124, True)
+        except OSError as exc:
+            return ProcessResult("", f"{self.name} CLI failed: {exc}", 1, False)
+        return ProcessResult(
+            stdout=proc.stdout.strip(),
+            stderr=(proc.stderr or "").strip(),
+            returncode=proc.returncode,
+            timed_out=False,
+        )
+
+    def _version_ok(
+        self, cli: str, *, timeout: int, args: tuple[str, ...] = ("--version",)
+    ) -> bool:
+        """True when ``cli --version`` exits 0 — the CLI is installed and runnable."""
+        try:
+            result = subprocess.run(
+                [cli, *args], capture_output=True, text=True, timeout=timeout
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return result.returncode == 0
+
+    def _capture_output(self, cmd: list[str], *, timeout: int) -> str | None:
+        """Run a helper command, returning its stripped stdout on a clean exit."""
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        out = result.stdout.strip()
+        return out if result.returncode == 0 and out else None
+
+    @staticmethod
+    def _passthrough(env: dict[str, str], keys: tuple[str, ...]) -> dict[str, str]:
+        """Copy the named vars from the parent environment when present."""
+        for key in keys:
+            if key in os.environ:
+                env[key] = os.environ[key]
+        return env

--- a/caliper/harness/claude_code.py
+++ b/caliper/harness/claude_code.py
@@ -4,17 +4,16 @@ import json
 import os
 import re
 import shutil
-import subprocess
 import sys
-import time
 import uuid
 from pathlib import Path
+from typing import Callable
 
 from caliper.harness.base import (
-    AttemptResult,
     ConversationTurn,
-    HarnessBackend,
-    HarnessConfigurationError,
+    CliHarness,
+    ProcessResult,
+    RunContext,
 )
 
 
@@ -36,7 +35,7 @@ def preferred_nvm_node_bin() -> str | None:
     return str(max(candidates, key=lambda item: item[:3])[3])
 
 
-class ClaudeCodeHarness(HarnessBackend):
+class ClaudeCodeHarness(CliHarness):
     def __init__(self, model: str | None = None) -> None:
         self._model = model
 
@@ -44,21 +43,9 @@ class ClaudeCodeHarness(HarnessBackend):
     def name(self) -> str:
         return "claude-code"
 
-    def run(
-        self,
-        task_id: str,
-        attempt: int,
-        prompt: str,
-        *,
-        skill_path: str | None,
-        model: str | None,
-        timeout: int,
-        isolated_home: str,
-        extra_path: list[str] | None = None,
-    ) -> AttemptResult:
-        home = Path(isolated_home)
-        commands_dir = home / ".claude" / "commands"
-        commands_dir.mkdir(parents=True, exist_ok=True)
+    def _prepare(self, ctx: RunContext) -> None:
+        home = Path(ctx.isolated_home)
+        (home / ".claude" / "commands").mkdir(parents=True, exist_ok=True)
 
         # Copy auth files from the real HOME so the CLI finds its credentials.
         # Without this, the isolated HOME causes claude to fall back to
@@ -82,76 +69,46 @@ class ClaudeCodeHarness(HarnessBackend):
         if sys.platform == "darwin" and not creds_dst.exists():
             self._seed_credentials_from_keychain(creds_dst)
 
-        has_file_credentials = creds_dst.exists()
+        ctx.extras["has_file_credentials"] = creds_dst.exists()
 
-        skill_file: Path | None = None
-        if skill_path:
-            skill_src = Path(skill_path).expanduser()
-            skill_name = skill_src.stem
+    def _command(
+        self, ctx: RunContext
+    ) -> tuple[list[str], str | None, Callable[[], None] | None]:
+        cleanup: Callable[[], None] | None = None
+        if ctx.skill_path:
+            commands_dir = Path(ctx.isolated_home) / ".claude" / "commands"
+            skill_src = Path(ctx.skill_path).expanduser()
             uid = uuid.uuid4().hex[:8]
-            skill_file = commands_dir / f"{skill_name}-vrd-{uid}.md"
+            skill_file = commands_dir / f"{skill_src.stem}-vrd-{uid}.md"
             skill_file.write_text(skill_src.read_text())
+            cleanup = lambda: skill_file.unlink(missing_ok=True)  # noqa: E731
 
-        env = self._build_env(isolated_home, extra_path or [], has_file_credentials)
-        cmd = self._build_cmd(prompt, model or self._model)
+        cmd = [
+            "claude",
+            "-p",
+            ctx.prompt,
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--dangerously-skip-permissions",
+        ]
+        if ctx.model:
+            cmd += ["--model", ctx.model]
+        return cmd, None, cleanup
 
-        start = time.monotonic()
-        try:
-            proc = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                env=env,
-                cwd=str(home),
-            )
-        except subprocess.TimeoutExpired:
-            return AttemptResult(
-                task_id=task_id,
-                attempt=attempt,
-                transcript=[],
-                final_output="",
-                exit_code=124,
-                duration_seconds=timeout,
-                error="timeout",
-                timed_out=True,
-            )
-        finally:
-            if skill_file and skill_file.exists():
-                skill_file.unlink()
-
-        duration = time.monotonic() - start
-        transcript, final_output = self._parse_stream(proc.stdout)
-        diagnostic = self._diagnose_configuration_error(
-            proc.returncode,
-            final_output,
-            proc.stderr,
-        )
-        if diagnostic:
-            raise HarnessConfigurationError(diagnostic)
-
-        return AttemptResult(
-            task_id=task_id,
-            attempt=attempt,
-            transcript=transcript,
-            final_output=final_output,
-            exit_code=proc.returncode,
-            duration_seconds=duration,
-            error=proc.stderr.strip()
-            if proc.returncode != 0 and not final_output
-            else None,
+    def _environment(self, ctx: RunContext) -> dict[str, str]:
+        return self._build_env(
+            ctx.isolated_home,
+            ctx.extra_path,
+            ctx.extras.get("has_file_credentials", False),
         )
 
-    def _diagnose_configuration_error(
-        self,
-        returncode: int,
-        final_output: str,
-        stderr: str,
-    ) -> str | None:
-        text = "\n".join(part for part in (final_output, stderr) if part).strip()
+    def _diagnose(self, proc: ProcessResult, final_output: str) -> str | None:
+        text = "\n".join(part for part in (final_output, proc.stderr) if part).strip()
         if not text:
             return None
 
+        returncode = proc.returncode
         lowered = text.lower()
         if returncode != 0 and self._looks_like_cli_startup_crash(text, lowered):
             summary = self._summarize_cli_crash(text)
@@ -206,6 +163,23 @@ class ClaudeCodeHarness(HarnessBackend):
 
         return None
 
+    def _fallback(
+        self,
+        transcript: list[ConversationTurn],
+        final_output: str,
+        proc: ProcessResult,
+    ) -> tuple[list[ConversationTurn], str]:
+        # Claude's stream-json stdout is never salvageable as a raw turn; its own
+        # last-assistant fallback in _parse_stream is the only fallback.
+        return transcript, final_output
+
+    def _error_field(self, proc: ProcessResult, final_output: str) -> str | None:
+        if proc.timed_out:
+            return "timeout"
+        if proc.returncode != 0 and not final_output:
+            return proc.stderr or None
+        return None
+
     def _looks_like_cli_startup_crash(self, text: str, lowered: str) -> bool:
         return (
             "typeerror:" in lowered
@@ -245,38 +219,19 @@ class ClaudeCodeHarness(HarnessBackend):
         return compact[:500]
 
     def _seed_credentials_from_keychain(self, dst: Path) -> None:
-        try:
-            result = subprocess.run(
-                [
-                    "security",
-                    "find-generic-password",
-                    "-s",
-                    "Claude Code-credentials",
-                    "-w",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                dst.write_text(result.stdout.strip())
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
-
-    def _build_cmd(self, prompt: str, model: str | None) -> list[str]:
-        cmd = [
-            "claude",
-            "-p",
-            prompt,
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "--dangerously-skip-permissions",
-        ]
-        if model:
-            cmd += ["--model", model]
-        return cmd
+        out = self._capture_output(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                "Claude Code-credentials",
+                "-w",
+            ],
+            timeout=5,
+        )
+        if out:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(out)
 
     def _build_env(
         self,

--- a/caliper/harness/codex.py
+++ b/caliper/harness/codex.py
@@ -2,23 +2,24 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
-import subprocess
 import sys
-import time
 from pathlib import Path
+from typing import Callable
 
 from caliper.harness.base import (
-    AttemptResult,
     ConversationTurn,
-    HarnessBackend,
+    CliHarness,
     HarnessConfigurationError,
+    ProcessResult,
+    RunContext,
 )
 
 CODEX_APP_CLI = Path("/Applications/Codex.app/Contents/Resources/codex")
 
 
-class CodexHarness(HarnessBackend):
+class CodexHarness(CliHarness):
     def __init__(self, model: str | None = None) -> None:
         self._model = model
 
@@ -26,22 +27,7 @@ class CodexHarness(HarnessBackend):
     def name(self) -> str:
         return "codex"
 
-    def run(
-        self,
-        task_id: str,
-        attempt: int,
-        prompt: str,
-        *,
-        skill_path: str | None,
-        model: str | None,
-        timeout: int,
-        isolated_home: str,
-        extra_path: list[str] | None = None,
-    ) -> AttemptResult:
-        full_prompt = self._inject_skill(prompt, skill_path)
-        effective_model = model or self._model
-        start = time.monotonic()
-
+    def _ensure_ready(self, ctx: RunContext) -> None:
         if not self._cli_available():
             raise HarnessConfigurationError(
                 "Codex CLI is not available for the `codex` backend.\n\n"
@@ -51,39 +37,34 @@ class CodexHarness(HarnessBackend):
                 "selecting a separate backend."
             )
 
-        self._copy_codex_config(isolated_home)
-        output, exit_code, error = self._run_cli(
-            full_prompt,
-            effective_model,
-            timeout,
-            isolated_home,
-            extra_path or [],
-        )
-        diagnostic = self._diagnose_configuration_error(exit_code, output, error)
-        if diagnostic:
-            raise HarnessConfigurationError(diagnostic)
+    def _prepare(self, ctx: RunContext) -> None:
+        self._copy_codex_config(ctx.isolated_home)
 
-        duration = time.monotonic() - start
-        transcript, final_output = self._parse_json_stream(output)
-        if not transcript and output:
-            transcript = [ConversationTurn(role="assistant", content=output)]
-            final_output = output
+    def _command(
+        self, ctx: RunContext
+    ) -> tuple[list[str], str | None, Callable[[], None] | None]:
+        full_prompt = self._inject_skill(ctx.prompt, ctx.skill_path)
+        codex = self._codex_command() or "codex"
+        cmd = [
+            codex,
+            "exec",
+            "--json",
+            "--skip-git-repo-check",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--color",
+            "never",
+            "-",
+        ]
+        if ctx.model:
+            cmd[2:2] = ["--model", ctx.model]
+        return cmd, full_prompt, None
 
-        return AttemptResult(
-            task_id=task_id,
-            attempt=attempt,
-            transcript=transcript,
-            final_output=final_output,
-            exit_code=exit_code,
-            duration_seconds=duration,
-            error=error,
-            timed_out=exit_code == 124 and error == "timeout",
-        )
+    def _environment(self, ctx: RunContext) -> dict[str, str]:
+        return self._build_env(ctx.isolated_home, ctx.extra_path)
 
     def _inject_skill(self, prompt: str, skill_path: str | None) -> str:
         if not skill_path:
             return prompt
-        import re
 
         skill_src = Path(skill_path).expanduser()
         if not skill_src.exists():
@@ -96,64 +77,9 @@ class CodexHarness(HarnessBackend):
 
     def _cli_available(self) -> bool:
         codex = self._codex_command()
-        if codex is None:
-            return False
-        try:
-            result = subprocess.run(
-                [codex, "--version"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            return False
-        return result.returncode == 0
+        return codex is not None and self._version_ok(codex, timeout=5)
 
-    def _run_cli(
-        self,
-        prompt: str,
-        model: str | None,
-        timeout: int,
-        isolated_home: str,
-        extra_path: list[str],
-    ) -> tuple[str, int, str | None]:
-        codex = self._codex_command() or "codex"
-        env = self._build_env(isolated_home, extra_path)
-        try:
-            cmd = [
-                codex,
-                "exec",
-                "--json",
-                "--skip-git-repo-check",
-                "--dangerously-bypass-approvals-and-sandbox",
-                "--color",
-                "never",
-                "-",
-            ]
-            if model:
-                cmd[2:2] = ["--model", model]
-
-            result = subprocess.run(
-                cmd,
-                input=prompt,
-                capture_output=True,
-                encoding="utf-8",
-                text=True,
-                timeout=timeout,
-                env=env,
-                cwd=isolated_home,
-            )
-            return (
-                result.stdout.strip(),
-                result.returncode,
-                result.stderr.strip() or None,
-            )
-        except subprocess.TimeoutExpired:
-            return "", 124, "timeout"
-        except OSError as exc:
-            return "", 1, f"codex CLI failed: {exc}"
-
-    def _parse_json_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]:
+    def _parse_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]:
         transcript: list[ConversationTurn] = []
         final_output = ""
 
@@ -238,10 +164,7 @@ class CodexHarness(HarnessBackend):
             "HOME": isolated_home,
             "PATH": path,
         }
-        for key in ("LANG", "LC_ALL", "TERM", "TMPDIR"):
-            if key in os.environ:
-                env[key] = os.environ[key]
-        return env
+        return self._passthrough(env, ("LANG", "LC_ALL", "TERM", "TMPDIR"))
 
     def _codex_command(self) -> str | None:
         configured = os.environ.get("CODEX_CLI_PATH")
@@ -277,16 +200,11 @@ class CodexHarness(HarnessBackend):
             filtered.append(line)
         return "\n".join(filtered) + ("\n" if config.endswith("\n") else "")
 
-    def _diagnose_configuration_error(
-        self,
-        returncode: int,
-        stdout: str,
-        stderr: str | None,
-    ) -> str | None:
-        if returncode == 0:
+    def _diagnose(self, proc: ProcessResult, final_output: str) -> str | None:
+        if proc.returncode == 0:
             return None
 
-        text = "\n".join(part for part in (stdout, stderr or "") if part).strip()
+        text = "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
         lowered = text.lower()
 
         model_markers = (

--- a/caliper/harness/pi.py
+++ b/caliper/harness/pi.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import subprocess
-import time
 from pathlib import Path
+from typing import Callable
 
 from caliper.harness.base import (
-    AttemptResult,
     ConversationTurn,
-    HarnessBackend,
+    CliHarness,
     HarnessConfigurationError,
+    ProcessResult,
+    RunContext,
 )
 
 
-class PiHarness(HarnessBackend):
+class PiHarness(CliHarness):
     """CLI-subprocess backend for the `pi` coding agent.
 
     Drives the locally installed `pi` CLI in non-interactive JSON mode and
@@ -31,21 +31,7 @@ class PiHarness(HarnessBackend):
     def name(self) -> str:
         return "pi"
 
-    def run(
-        self,
-        task_id: str,
-        attempt: int,
-        prompt: str,
-        *,
-        skill_path: str | None,
-        model: str | None,
-        timeout: int,
-        isolated_home: str,
-        extra_path: list[str] | None = None,
-    ) -> AttemptResult:
-        effective_model = model or self._model
-        start = time.monotonic()
-
+    def _ensure_ready(self, ctx: RunContext) -> None:
         if not self._cli_available():
             raise HarnessConfigurationError(
                 "pi CLI is not available for the `pi` backend.\n\n"
@@ -54,71 +40,19 @@ class PiHarness(HarnessBackend):
                 "`PI_CLI_PATH` to the pi binary, then rerun caliper."
             )
 
+    def _prepare(self, ctx: RunContext) -> None:
         # pi reads auth/settings from its config dir. We copy the real config
         # verbatim into a per-attempt directory (parallel-safe; never mutates
         # the user's real ~/.pi) and point pi at it via PI_CODING_AGENT_DIR.
         # The config's default model/provider is preserved on purpose; the
         # spec's `--model` overrides it when set. See issue #10 for why this
         # differs from codex (which strips its config default).
-        agent_dir = self._copy_pi_config(isolated_home)
+        ctx.extras["agent_dir"] = self._copy_pi_config(ctx.isolated_home)
 
-        output, exit_code, error = self._run_cli(
-            prompt,
-            effective_model,
-            skill_path,
-            timeout,
-            isolated_home,
-            agent_dir,
-            extra_path or [],
-        )
-        diagnostic = self._diagnose_configuration_error(exit_code, output, error)
-        if diagnostic:
-            raise HarnessConfigurationError(diagnostic)
-
-        duration = time.monotonic() - start
-        transcript, final_output = self._parse_json_stream(output)
-        if not transcript and output:
-            transcript = [ConversationTurn(role="assistant", content=output)]
-            final_output = output
-
-        return AttemptResult(
-            task_id=task_id,
-            attempt=attempt,
-            transcript=transcript,
-            final_output=final_output,
-            exit_code=exit_code,
-            duration_seconds=duration,
-            error=error,
-            timed_out=exit_code == 124 and error == "timeout",
-        )
-
-    def _cli_available(self) -> bool:
-        pi = self._pi_command()
-        if pi is None:
-            return False
-        try:
-            result = subprocess.run(
-                [pi, "--version"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            return False
-        return result.returncode == 0
-
-    def _run_cli(
-        self,
-        prompt: str,
-        model: str | None,
-        skill_path: str | None,
-        timeout: int,
-        isolated_home: str,
-        agent_dir: Path,
-        extra_path: list[str],
-    ) -> tuple[str, int, str | None]:
+    def _command(
+        self, ctx: RunContext
+    ) -> tuple[list[str], str | None, Callable[[], None] | None]:
         pi = self._pi_command() or "pi"
-        env = self._build_env(isolated_home, agent_dir, extra_path)
         cmd = [
             pi,
             "--print",
@@ -129,42 +63,32 @@ class PiHarness(HarnessBackend):
             # blocks on an interactive trust prompt when a skill is loaded.
             "--approve",
         ]
-        if model:
-            cmd += ["--model", model]
-        if skill_path:
+        if ctx.model:
+            cmd += ["--model", ctx.model]
+        if ctx.skill_path:
             # Prefer the staged copy in the run's cwd (siblings staged alongside,
             # cheat surfaces excluded) over the real skill dir; fall back to the
             # original path when nothing was staged (e.g. a lone command file).
-            staged = Path(isolated_home) / "SKILL.md"
-            skill_src = staged if staged.exists() else Path(skill_path).expanduser()
+            staged = Path(ctx.isolated_home) / "SKILL.md"
+            skill_src = staged if staged.exists() else Path(ctx.skill_path).expanduser()
             if skill_src.exists():
                 cmd += ["--skill", str(skill_src)]
-        cmd.append(prompt)
+        cmd.append(ctx.prompt)
+        # stdin is left as None so the template closes it (DEVNULL): in --print
+        # mode pi otherwise blocks reading stdin (e.g. for a trust confirmation)
+        # and hangs until timeout.
+        return cmd, None, None
 
-        try:
-            result = subprocess.run(
-                cmd,
-                # Close stdin: in --print mode pi otherwise blocks reading
-                # stdin (e.g. for a trust confirmation) and hangs until timeout.
-                stdin=subprocess.DEVNULL,
-                capture_output=True,
-                encoding="utf-8",
-                text=True,
-                timeout=timeout,
-                env=env,
-                cwd=isolated_home,
-            )
-            return (
-                result.stdout.strip(),
-                result.returncode,
-                result.stderr.strip() or None,
-            )
-        except subprocess.TimeoutExpired:
-            return "", 124, "timeout"
-        except OSError as exc:
-            return "", 1, f"pi CLI failed: {exc}"
+    def _environment(self, ctx: RunContext) -> dict[str, str]:
+        return self._build_env(
+            ctx.isolated_home, ctx.extras["agent_dir"], ctx.extra_path
+        )
 
-    def _parse_json_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]:
+    def _cli_available(self) -> bool:
+        pi = self._pi_command()
+        return pi is not None and self._version_ok(pi, timeout=10)
+
+    def _parse_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]:
         transcript: list[ConversationTurn] = []
         final_output = ""
 
@@ -250,10 +174,7 @@ class PiHarness(HarnessBackend):
             "PATH": path,
             "PI_CODING_AGENT_DIR": str(agent_dir),
         }
-        for key in ("LANG", "LC_ALL", "TERM", "TMPDIR"):
-            if key in os.environ:
-                env[key] = os.environ[key]
-        return env
+        return self._passthrough(env, ("LANG", "LC_ALL", "TERM", "TMPDIR"))
 
     def _pi_command(self) -> str | None:
         configured = os.environ.get("PI_CLI_PATH")
@@ -271,16 +192,11 @@ class PiHarness(HarnessBackend):
                 shutil.copy2(src, agent_dir / filename)
         return agent_dir
 
-    def _diagnose_configuration_error(
-        self,
-        returncode: int,
-        stdout: str,
-        stderr: str | None,
-    ) -> str | None:
-        if returncode == 0:
+    def _diagnose(self, proc: ProcessResult, final_output: str) -> str | None:
+        if proc.returncode == 0:
             return None
 
-        text = "\n".join(part for part in (stdout, stderr or "") if part).strip()
+        text = "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
         if not text:
             return None
         lowered = text.lower()

--- a/tests/test_claude_harness.py
+++ b/tests/test_claude_harness.py
@@ -31,7 +31,7 @@ def test_claude_harness_accepts_runner_contract_with_extra_path(
         )
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
-    monkeypatch.setattr("caliper.harness.claude_code.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     result = ClaudeCodeHarness(model="claude-test").run(
         task_id="task-001",
@@ -73,7 +73,7 @@ def test_claude_harness_reports_cli_startup_crash_before_auth(
         )
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=stderr)
 
-    monkeypatch.setattr("caliper.harness.claude_code.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     with pytest.raises(HarnessConfigurationError) as exc:
         ClaudeCodeHarness().run(

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -35,7 +35,7 @@ def test_codex_cli_receives_injected_skill_on_stdin(monkeypatch, tmp_path) -> No
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
-    monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     result = CodexHarness().run(
         task_id="task-001",
@@ -73,7 +73,7 @@ def test_codex_cli_omits_model_when_unspecified(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
-    monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     result = CodexHarness().run(
         task_id="task-001",
@@ -134,7 +134,7 @@ def test_codex_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
-    monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     result = CodexHarness().run(
         task_id="task-001",
@@ -189,7 +189,7 @@ def test_codex_json_stream_keeps_unknown_tool_items(monkeypatch, tmp_path) -> No
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
-    monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     result = CodexHarness().run(
         task_id="task-001",
@@ -257,7 +257,7 @@ def test_codex_fails_clearly_when_cli_is_not_runnable(monkeypatch, tmp_path) -> 
     def fake_run(cmd, **kwargs):
         raise OSError("access denied")
 
-    monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     with pytest.raises(HarnessConfigurationError) as exc:
         CodexHarness(model="fallback-model").run(
@@ -297,7 +297,7 @@ def test_codex_fails_clearly_when_cli_requires_newer_version(
             ),
         )
 
-    monkeypatch.setattr("caliper.harness.codex.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     with pytest.raises(HarnessConfigurationError) as exc:
         CodexHarness().run(

--- a/tests/test_pi_harness.py
+++ b/tests/test_pi_harness.py
@@ -25,7 +25,7 @@ def test_pi_cli_receives_skill_and_model_flags(monkeypatch, tmp_path) -> None:
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
-    monkeypatch.setattr("caliper.harness.pi.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     PiHarness().run(
         task_id="task-001",
@@ -65,7 +65,7 @@ def test_pi_omits_model_and_skill_when_unspecified(monkeypatch, tmp_path) -> Non
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
-    monkeypatch.setattr("caliper.harness.pi.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     PiHarness().run(
         task_id="task-001",
@@ -124,7 +124,7 @@ def test_pi_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
-    monkeypatch.setattr("caliper.harness.pi.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     result = PiHarness().run(
         task_id="task-001",
@@ -173,7 +173,7 @@ def test_pi_auth_failure_raises_configuration_error(monkeypatch, tmp_path) -> No
         )
 
     monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
-    monkeypatch.setattr("caliper.harness.pi.subprocess.run", fake_run)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
 
     with pytest.raises(HarnessConfigurationError, match="authentication"):
         PiHarness().run(


### PR DESCRIPTION
## What

Deepens the harness spine (architecture-review candidate 1). The three CLI backends — `claude-code`, `codex`, `pi` — each re-implemented the same run machinery: env building, `subprocess` + timeout handling, config staging, and `AttemptResult` assembly. `HarnessBackend` was a bare interface with no leverage; the "shared" logic was copy-pasted three times.

## How

Split the seam in two:

- **`HarnessBackend`** stays the *narrow* interface the runner depends on (`run` + `name`). Test doubles and any future non-CLI backend satisfy just those two members.
- **`CliHarness`** is a *deep* template method owning the lifecycle: prepare the isolated home → build command/env → spawn the agent once (timing it, normalising timeouts into a `124`/`timeout` `ProcessResult`) → diagnose misconfiguration → parse the stream → assemble the result.

Backends now implement only what genuinely varies per agent:

| hook | required | purpose |
|------|----------|---------|
| `_command` | ✓ | argv, stdin payload, cleanup |
| `_environment` | ✓ | env dict |
| `_parse_stream` | ✓ | that agent's JSON/stream shape |
| `_ensure_ready` / `_prepare` / `_diagnose` / `_fallback` / `_error_field` | optional | availability check, config staging, error mapping |

Per-attempt state rides on `RunContext.extras` instead of instance fields, keeping the shared harness object thread-safe under the runner's `ThreadPoolExecutor`.

All subprocess spawning routes through `CliHarness`, so harness tests patch `caliper.harness.base.subprocess.run` in one place.

## Result

- `base.py` +234, and `claude_code.py` / `codex.py` / `pi.py` shed ~490 lines of duplicated plumbing.
- Backends collapse to the three-to-five parts that truly differ — one interface, one test surface each.
- Serves the recorded direction toward a unified harness config (consistency over per-backend realism).

## Behaviour

No outward change intended: `AttemptResult` shape, diagnostic messages, and timeout semantics are preserved. Minor internal unifications (claude now closes stdin with `DEVNULL` and catches `OSError` gracefully instead of propagating) are strictly safer and covered by tests.

## Tests

`ruff format --check .`, `ruff check .`, and the full `pytest` suite (101 passed) all green. Harness tests updated only to patch the subprocess seam at its new home in `base`.