### PR TITLE
refactor: move the pre-judge skip behind the outcome seam

### DIFF
--- a/caliper/outcome.py
+++ b/caliper/outcome.py
@@ -29,6 +29,26 @@ def looks_like_infra_failure(text: str) -> bool:
     return bool(text) and bool(_INFRA_SIGNALS.search(text))
 
 
+def classify_pre_judge(harness: AttemptResult) -> Outcome | None:
+    """The terminal outcome an attempt earns from its harness result alone.
+
+    Returns ``TIMEOUT`` or ``INFRA_ERROR`` when the attempt never got a fair
+    shot, so it must skip cheat detection and the (paid) judge entirely; returns
+    ``None`` when the attempt ran cleanly enough to proceed. This is the single
+    authority on that predicate: the runner asks it to decide whether to spend a
+    judge call, and ``classify_outcome`` reuses it for the final label, so the
+    skip and the label can never disagree.
+    """
+    if harness.timed_out:
+        return Outcome.TIMEOUT
+
+    text = "\n".join(part for part in (harness.final_output, harness.error) if part)
+    if harness.exit_code != 0 or looks_like_infra_failure(text):
+        return Outcome.INFRA_ERROR
+
+    return None
+
+
 def classify_outcome(
     harness: AttemptResult,
     cheat_violations: list[str],
@@ -45,12 +65,9 @@ def classify_outcome(
     ``judge`` is ``None`` on the early-exit paths (timeout / infra / cheat) where
     the judge was never run.
     """
-    if harness.timed_out:
-        return Outcome.TIMEOUT
-
-    text = "\n".join(part for part in (harness.final_output, harness.error) if part)
-    if harness.exit_code != 0 or looks_like_infra_failure(text):
-        return Outcome.INFRA_ERROR
+    pre_judge = classify_pre_judge(harness)
+    if pre_judge is not None:
+        return pre_judge
 
     if cheat_violations:
         return Outcome.CHEAT

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -13,7 +13,7 @@ from typing import Callable
 
 from caliper.harness.base import ConversationTurn, HarnessBackend
 from caliper.judge.base import Judge
-from caliper.outcome import classify_outcome, looks_like_infra_failure
+from caliper.outcome import classify_outcome, classify_pre_judge
 from caliper.schema.results import (
     AggregateScore,
     AttemptRecord,
@@ -236,18 +236,12 @@ def _run_attempt(
             extra_path=resolved_extra_path,
         )
 
-        # Short-circuit on timeout / infrastructure noise before spending a
-        # (paid) judge call on garbage output. classify_outcome remains the sole
-        # authority on the label; this only decides whether to do the work.
-        infra_text = "\n".join(
-            part for part in (attempt_result.final_output, attempt_result.error) if part
-        )
-        if (
-            attempt_result.timed_out
-            or attempt_result.exit_code != 0
-            or looks_like_infra_failure(infra_text)
-        ):
-            outcome = classify_outcome(attempt_result, [], None)
+        # A timeout or infrastructure signal terminates the attempt before we
+        # spend a (paid) judge call on garbage output. The pre-judge classifier
+        # owns that predicate — the runner no longer re-derives it — so the skip
+        # here and the final label can never drift apart.
+        pre_judge_outcome = classify_pre_judge(attempt_result)
+        if pre_judge_outcome is not None:
             evidence = (
                 attempt_result.error or f"harness exited {attempt_result.exit_code}"
             )
@@ -256,7 +250,7 @@ def _run_attempt(
                     attempt=attempt,
                     output=attempt_result.final_output,
                     duration_seconds=attempt_result.duration_seconds,
-                    outcome=outcome,
+                    outcome=pre_judge_outcome,
                     assert_evidence=evidence,
                 ),
                 task,

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from caliper.harness.base import AttemptResult
 from caliper.judge.base import JudgeResult
-from caliper.outcome import classify_outcome, looks_like_infra_failure
+from caliper.outcome import (
+    classify_outcome,
+    classify_pre_judge,
+    looks_like_infra_failure,
+)
 from caliper.schema.results import Outcome
 
 
@@ -82,6 +86,39 @@ def test_precedence_timeout_beats_infra() -> None:
 def test_precedence_infra_beats_cheat_and_judge() -> None:
     h = _harness(exit_code=1)
     assert classify_outcome(h, ["/x"], _judge(passed=True)) is Outcome.INFRA_ERROR
+
+
+# --- classify_pre_judge: the skip predicate the runner shares -------------
+
+
+def test_pre_judge_none_on_clean_attempt() -> None:
+    # Ran cleanly: no skip, proceed to cheat detection and judging.
+    assert classify_pre_judge(_harness()) is None
+
+
+def test_pre_judge_timeout() -> None:
+    assert classify_pre_judge(_harness(timed_out=True)) is Outcome.TIMEOUT
+
+
+def test_pre_judge_infra_on_nonzero_exit() -> None:
+    assert classify_pre_judge(_harness(exit_code=1)) is Outcome.INFRA_ERROR
+
+
+def test_pre_judge_infra_on_signal_despite_zero_exit() -> None:
+    h = _harness(exit_code=0, final_output="Spending cap reached resets 4:30am")
+    assert classify_pre_judge(h) is Outcome.INFRA_ERROR
+
+
+def test_pre_judge_ignores_cheat_and_judge_states() -> None:
+    # Cheat is not a pre-judge concern: it needs the transcript scan that runs
+    # after this predicate, so a clean-exit attempt returns None here.
+    assert classify_pre_judge(_harness()) is None
+
+
+def test_classify_outcome_reuses_pre_judge_predicate() -> None:
+    # The final label agrees with the skip decision on every early-exit path.
+    for h in (_harness(timed_out=True), _harness(exit_code=1)):
+        assert classify_outcome(h, [], None) is classify_pre_judge(h)
 
 
 # --- looks_like_infra_failure --------------------------------------------


### PR DESCRIPTION
## What

Architecture-review candidate 3. The runner re-derived `classify_outcome`'s timeout/infra front half inline to decide whether to skip a (paid) judge call:

```python
if attempt_result.timed_out or attempt_result.exit_code != 0 or looks_like_infra_failure(infra_text):
```

So the predicate for "this attempt is unusable before judging" lived in **two** places that had to stay in sync by hand — the runner's own comment admitted it ("classify_outcome remains the sole authority on the label; this only decides whether to do the work"). That quietly undercut ADR-0001, which makes `classify_outcome` the single seam for labelling an attempt.

## How

Extract `classify_pre_judge(harness) -> Outcome | None`:

- returns `TIMEOUT` / `INFRA_ERROR` when the attempt never got a fair shot (skip cheat detection + the judge),
- returns `None` when it ran cleanly enough to proceed.

`classify_outcome` now calls it for its front half, and the runner asks it directly instead of restating the predicate. One authority for the skip decision *and* the final label, so they can't drift.

## Result

- `runner.py`: the inline `infra_text` + three-way `if` collapses to `pre_judge_outcome = classify_pre_judge(...)`; the redundant re-call of `classify_outcome` on the skip path is gone, and `looks_like_infra_failure` is no longer imported there.
- `outcome.py`: +1 small pure function; the precedence chain (timeout → infra → cheat → judge_error → verdict) is unchanged, just expressed once.

## Behaviour

No change. Precedence and the paid-judge skip are preserved; existing runner/outcome tests stay green, plus 6 new unit tests pin `classify_pre_judge` and assert it agrees with `classify_outcome` on every early-exit path.

## Tests

`ruff format --check .`, `ruff check .`, full `pytest`: **107 passed**.