### PR TITLE
De-pin backend/model from .eval.yaml specs — make the engine a runtime axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ pipx install caliper-eval   # requires Python 3.10+
 # my-skill.eval.yaml
 skill:
   path: ./SKILL.md
-  backend: claude-code
-
-judge:
-  backend: claude-code
 
 tasks:
   # Autorater — the LLM judge reads the transcript and decides
@@ -108,6 +104,8 @@ tasks:
 ```
 
 `expect:` is graded by the judge LLM; `assert:` runs locally as Python. Use either or both.
+
+The spec never names an engine — the skill and judge default to `claude-code`, and you pick a different agent/model at run time with `--model` / `--judge-model` (see [Choosing an engine](#choosing-an-engine)).
 
 **3. Run it**
 
@@ -229,7 +227,19 @@ If an `.eval.yaml` already exists next to your skill, `grill-skill` reads the ex
 
 ---
 
-## Choosing a backend
+## Choosing an engine
+
+The engine (backend + model) is a **runtime axis, not a spec field** — the spec
+describes *what* is tested and *how* success is judged, and you pick the agent
+that runs and grades it at invocation. Both default to `claude-code`; select a
+different one with `--model` / `--judge-model`:
+
+```bash
+caliper run my-skill.eval.yaml                          # claude-code (default)
+caliper run my-skill.eval.yaml --model codex            # codex, its default model
+caliper run my-skill.eval.yaml --model codex:gpt-5-codex
+caliper run my-skill.eval.yaml --model pi --judge-model claude-code
+```
 
 | Backend | Requires | Best for |
 |---|---|---|
@@ -239,11 +249,11 @@ If an `.eval.yaml` already exists next to your skill, `grill-skill` reads the ex
 
 Caliper runs skills only through CLI agents — every backend can actually load and run a skill. There is no direct-API backend: to run against API-priced billing, configure one of these CLIs with an API key (e.g. `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) rather than selecting a separate backend.
 
-The agent backend and judge backend are independent — you can test a Codex skill with a Claude judge, or any other combination.
+The skill engine and judge engine are independent — you can test a Codex skill with a Claude judge, or any other combination, by pairing `--model` with `--judge-model`.
 
 ### Claude Code setup
 
-Install and authenticate the `claude` CLI. `backend: claude-code` uses your existing Claude Code auth — no extra configuration needed.
+Install and authenticate the `claude` CLI. `--model claude-code` uses your existing Claude Code auth — no extra configuration needed.
 
 ### Codex setup
 
@@ -252,7 +262,7 @@ npm install -g @openai/codex
 codex login
 ```
 
-`backend: codex` calls `codex exec`. If the Codex desktop app is installed, Caliper prefers the app-bundled binary over `codex` on `PATH`. Set `CODEX_CLI_PATH` to force a specific binary.
+`--model codex` calls `codex exec`. If the Codex desktop app is installed, Caliper prefers the app-bundled binary over `codex` on `PATH`. Set `CODEX_CLI_PATH` to force a specific binary.
 
 ### pi setup
 
@@ -261,7 +271,7 @@ npm install -g @earendil-works/pi-coding-agent
 pi   # then authenticate (e.g. /login for a subscription provider, or set the provider API key)
 ```
 
-`backend: pi` runs `pi --print --mode json` and loads the skill natively via pi's `--skill` flag (the agentskills.io standard). It reuses your `~/.pi/agent` auth and settings — the spec's `model:` overrides pi's configured default when set. Set `PI_CLI_PATH` to force a specific binary. Note: pi's built-in default provider is `google`, so a spec with no `model:` relies on your pi config to resolve a provider you are authenticated for.
+`--model pi` runs `pi --print --mode json` and loads the skill natively via pi's `--skill` flag (the agentskills.io standard). It reuses your `~/.pi/agent` auth and settings — the `:model` half of `--model pi:<model>` overrides pi's configured default when set. Set `PI_CLI_PATH` to force a specific binary. Note: pi's built-in default provider is `google`, so running `--model pi` with no model relies on your pi config to resolve a provider you are authenticated for.
 
 Check installed CLI versions:
 
@@ -291,12 +301,9 @@ caliper update-cli --check
 ```yaml
 skill:
   path: ./SKILL.md              # path to the skill file (optional for baseline-only runs)
-  backend: claude-code          # claude-code | codex | pi
-  model: <model-name>           # optional model override
 
-judge:
-  backend: claude-code          # claude-code | codex | pi
-  model: <model-name>           # optional model override
+# Note: there is no `backend`/`model` or `judge:` block. The engine is a runtime
+# axis — pass `--model` / `--judge-model` at run time (default: claude-code).
 
 sandbox:
   extra_path:
@@ -328,12 +335,9 @@ Each task needs at least one of `expect` or `assert`. Task IDs are assigned auto
 
 ### LLM autorater (`expect:`)
 
-The judge backend reads the full attempt transcript and decides whether the `expect` condition was met. When the backend captures tool-call traces (Claude Code, Codex), those traces are included — the judge can verify things like "the agent used tool X" without relying on the final text alone.
+The judge engine reads the full attempt transcript and decides whether the `expect` condition was met. When the backend captures tool-call traces (Claude Code, Codex, pi), those traces are included — the judge can verify things like "the agent used tool X" without relying on the final text alone.
 
-```yaml
-judge:
-  backend: claude-code
-```
+The judge engine is chosen at run time and defaults to `claude-code`; point it at a different agent with `--judge-model` (e.g. `--judge-model codex`), independently of the skill's `--model`.
 
 ### Deterministic assertions (`assert:`)
 
@@ -383,32 +387,30 @@ When both `expect` and `assert` are present, both must pass.
 | `--workers INT` | `4` | Parallel task workers |
 | `--timeout INT` | `120` | Seconds per attempt |
 | `--fail-fast INT` | `0` | Stop a task after N consecutive `infra_error`/`timeout` attempts (`0` disables) |
-| `--model TARGET` | — | Override skill backend and/or model (see below) |
-| `--judge-model TARGET` | — | Override judge backend and/or model (see below) |
+| `--model TARGET` | `claude-code` | Skill engine — backend and/or model (see below) |
+| `--judge-model TARGET` | `claude-code` | Judge engine — backend and/or model (see below) |
 | `--verbose` | off | Show per-attempt judge reasoning |
 | `--output PATH` | — | Also save results JSON to a specific path |
 
 #### `--model` and `--judge-model` syntax
 
-Both flags accept a `backend:model` compound value, a bare backend name, or a bare model name:
+The engine is not stored in the spec — these flags select it, defaulting to `claude-code` when omitted. Both accept a `backend:model` compound value, a bare backend name, or a bare model name:
 
 ```bash
-# Override backend and model together
+# Backend and model together
 caliper run my-skill.eval.yaml --model codex:gpt-5-codex
 
-# Override backend only (model stays unset / from spec)
+# Backend only (that backend's default model)
 caliper run my-skill.eval.yaml --model codex
 
-# Override model only (backend stays from spec)
+# Model only (backend stays claude-code)
 caliper run my-skill.eval.yaml --model claude-sonnet-4-6
 
-# Override judge independently
+# Select the judge engine independently
 caliper run my-skill.eval.yaml --model codex --judge-model claude-code:claude-haiku-4-5-20251001
 ```
 
-Accepted backends: `claude-code`, `codex`, `pi` (alias: `claude` → `claude-code`).
-
-The spec file is never modified — overrides apply only to the current run.
+Accepted backends: `claude-code`, `codex`, `pi` (alias: `claude` → `claude-code`). The actual engine used is recorded in each saved run's `RunMeta`, so results stay traceable even though the spec doesn't pin it.
 
 ---
 

--- a/caliper/commands/new.py
+++ b/caliper/commands/new.py
@@ -15,15 +15,8 @@ def new_cmd(
     skill: Annotated[
         Optional[str], typer.Option("--skill", help="Pre-populate skill path")
     ] = None,
-    backend: Annotated[
-        str,
-        typer.Option(
-            "--backend",
-            help="Pre-populate backend (claude-code, codex, pi)",
-        ),
-    ] = "claude-code",
     output: Annotated[
         Optional[Path], typer.Option("--out", help="Output path for .eval.yaml")
     ] = None,
 ) -> None:
-    run_wizard(name=name, output=output, skill_path=skill, backend=backend)
+    run_wizard(name=name, output=output, skill_path=skill)

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -19,7 +19,7 @@ from caliper.reporter import (
 )
 from caliper.runner import run, AttemptEvent
 from caliper.schema.results import Outcome, TaskResult
-from caliper.schema.spec import load_spec, parse_target, spec_name
+from caliper.schema.spec import DEFAULT_BACKEND, load_spec, parse_target, spec_name
 
 console = Console()
 
@@ -66,25 +66,26 @@ def run_cmd(
         console.print(f"[bold red]Invalid spec:[/bold red] {exc}")
         raise typer.Exit(1)
 
+    # The engine is a runtime axis, not a spec field (ADR 0004): resolve it here
+    # from the flags, defaulting to claude-code. The resolved (backend, model)
+    # is what gets recorded in RunMeta.
+    backend, skill_model = DEFAULT_BACKEND, None
     if model:
-        backend_override, model_override = parse_target(model)
-        if backend_override:
-            spec.skill.backend = backend_override
-        if model_override:
-            spec.skill.model = model_override
+        b, m = parse_target(model)
+        backend = b or backend
+        skill_model = m
 
+    judge_backend, judge_model_name = DEFAULT_BACKEND, None
     if judge_model:
-        j_backend, j_model = parse_target(judge_model)
-        if j_backend:
-            spec.judge.backend = j_backend
-        if j_model:
-            spec.judge.model = j_model
+        jb, jm = parse_target(judge_model)
+        judge_backend = jb or judge_backend
+        judge_model_name = jm
 
     name = spec_name(spec_file)
-    print_banner(name, k, spec.skill.backend, spec.skill.model)
+    print_banner(name, k, backend, skill_model)
 
-    harness = get_harness(spec.skill.backend, spec.skill.model)
-    judge = EvalJudge(spec.judge)
+    harness = get_harness(backend, skill_model)
+    judge = EvalJudge(judge_backend, judge_model_name)
 
     task_names = [t.name for t in spec.tasks]
     progress, task_ids = make_progress(task_names, k)
@@ -142,6 +143,8 @@ def run_cmd(
                 spec_path=spec_file,
                 harness=harness,
                 judge=judge,
+                backend=backend,
+                model=skill_model,
                 k=k,
                 workers=workers,
                 timeout=timeout,

--- a/caliper/commands/validate.py
+++ b/caliper/commands/validate.py
@@ -43,15 +43,14 @@ def validate_cmd(
 
     name = spec_name(spec_file)
     n_tasks = len(spec.tasks)
-    backend = spec.skill.backend
+    skill_path = spec.skill.path or "(bare agent — no skill)"
 
     console.print(
         Panel(
             f"[bold]{name}[/bold]\n"
-            f"  backend  [cyan]{backend}[/cyan]\n"
+            f"  skill    [cyan]{skill_path}[/cyan]\n"
             f"  tasks    [cyan]{n_tasks}[/cyan]\n"
-            f"  judge    [cyan]{spec.judge.backend}[/cyan]"
-            + (f" / [dim]{spec.judge.model}[/dim]" if spec.judge.model else ""),
+            "  engine   [dim]chosen at run time (--model / --judge-model)[/dim]",
             title=f"[bold green]{CHECK} Spec is valid[/bold green]",
             border_style="green",
         )

--- a/caliper/harness/codex.py
+++ b/caliper/harness/codex.py
@@ -32,7 +32,7 @@ class CodexHarness(CliHarness):
             raise HarnessConfigurationError(
                 "Codex CLI is not available for the `codex` backend.\n\n"
                 "Caliper runs skills only through CLI agents. Install and "
-                "authenticate the Codex CLI to use `backend: codex`. For API "
+                "authenticate the Codex CLI to run with `--model codex`. For API "
                 "billing, configure the Codex CLI with an API key rather than "
                 "selecting a separate backend."
             )
@@ -218,10 +218,11 @@ class CodexHarness(CliHarness):
             return (
                 "Codex CLI cannot run the requested model with this account or "
                 "installed version.\n\n"
-                "Caliper uses `codex exec` for `backend: codex`. The Codex CLI "
+                "Caliper uses `codex exec` for `--model codex`. The Codex CLI "
                 "returned:\n"
                 f"  {summary}\n\n"
-                "Omit `model` to use the Codex CLI default, upgrade the Codex app "
+                "Pass `--model codex` (no model) to use the Codex CLI default, "
+                "upgrade the Codex app "
                 "or CLI, or choose a model supported by the installed Codex CLI "
                 "and account, then retry the eval."
             )
@@ -241,7 +242,7 @@ class CodexHarness(CliHarness):
             return (
                 "Codex CLI cannot run with the current subscription/authentication "
                 "configuration.\n\n"
-                "Caliper uses `codex exec` for `backend: codex` and does not fall "
+                "Caliper uses `codex exec` for `--model codex` and does not fall "
                 "back to the OpenAI API. The Codex CLI returned:\n"
                 f"  {text}\n\n"
                 "Run `codex login` and verify `codex exec` works in your normal "

--- a/caliper/harness/pi.py
+++ b/caliper/harness/pi.py
@@ -216,14 +216,14 @@ class PiHarness(CliHarness):
                 "pi cannot run with the current provider/credential "
                 "configuration.\n\n"
                 "Caliper copies your `~/.pi/agent` auth and settings verbatim "
-                "and passes `--model` only when the spec sets one. The pi CLI "
+                "and passes a model to pi only when you select one. The pi CLI "
                 "returned:\n"
                 f"  {text}\n\n"
-                "pi's built-in default provider is `google`, so a spec with no "
-                "`model:` (and no Google credentials) can fail here. Set a "
-                "`model:`/provider you are authenticated for in the spec, or "
-                "configure pi's default provider with `pi` directly, then rerun "
-                "caliper."
+                "pi's built-in default provider is `google`, so running "
+                "`--model pi` with no model (and no Google credentials) can fail "
+                "here. Pass `--model pi:<model>` for a provider you are "
+                "authenticated for, or configure pi's default provider with `pi` "
+                "directly, then rerun caliper."
             )
 
         auth_markers = (

--- a/caliper/judge/pi_judge.py
+++ b/caliper/judge/pi_judge.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from caliper.harness.base import ConversationTurn
+from caliper.judge.script_assert import (
+    _SYSTEM,
+    _USER_TMPL,
+    _format_transcript,
+    _parse_rich_response,
+)
+
+
+def evaluate_with_pi(
+    *,
+    expect: str,
+    transcript: list[ConversationTurn],
+    model: str | None,
+    spec_dir: str,
+    timeout: int = 60,
+) -> tuple[bool, str, bool]:
+    user_msg = _USER_TMPL.format(
+        expect=expect,
+        transcript=_format_transcript(transcript),
+    )
+    prompt = f"{_SYSTEM}\n\n{user_msg}"
+    raw, error = _run_pi(prompt, model, spec_dir, timeout)
+    if error:
+        return False, error, True
+    return _parse_rich_response(raw, spec_dir)
+
+
+def _run_pi(
+    prompt: str, model: str | None, cwd: str, timeout: int
+) -> tuple[str, str | None]:
+    pi = _pi_command()
+    if not pi:
+        return "", "pi CLI not found"
+
+    cmd = [pi, "--print", "--mode", "json", "--no-session", "--approve"]
+    if model:
+        cmd += ["--model", model]
+    cmd.append(prompt)
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=dict(os.environ),
+            cwd=cwd,
+            # --print reads stdin for trust confirmations otherwise and hangs.
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        return "", "Judge timed out."
+    except OSError as exc:
+        return "", f"pi judge failed: {exc}"
+
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip()
+        return "", f"pi judge exited {proc.returncode}: {detail[:200]}"
+
+    return _final_assistant_message(proc.stdout), None
+
+
+def _final_assistant_message(stdout: str) -> str:
+    """Extract the last assistant message from pi's JSON event stream."""
+    final = ""
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or event.get("type") != "message_end":
+            continue
+        message = event.get("message")
+        if isinstance(message, dict) and message.get("role") == "assistant":
+            text = _flatten_text(message.get("content"))
+            if text:
+                final = text
+    return _strip_markdown_fence(final)
+
+
+def _flatten_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        return "".join(parts).strip()
+    return ""
+
+
+def _strip_markdown_fence(raw: str) -> str:
+    raw = raw.strip()
+    if not raw.startswith("```"):
+        return raw
+    lines = raw.splitlines()
+    return "\n".join(line for line in lines if not line.startswith("```")).strip()
+
+
+def _pi_command() -> str | None:
+    configured = os.environ.get("PI_CLI_PATH")
+    if configured and Path(configured).exists():
+        return configured
+    return shutil.which("pi")

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -8,8 +8,7 @@ from pathlib import Path
 
 from caliper.harness.base import ConversationTurn
 from caliper.judge.base import Judge, JudgeResult
-from caliper.schema.spec import normalize_backend
-from caliper.schema.spec import JudgeConfig, TaskSpec
+from caliper.schema.spec import DEFAULT_BACKEND, normalize_backend, TaskSpec
 
 _SYSTEM = """\
 You are an evaluation judge for an AI assistant. You will be shown a conversation \
@@ -131,8 +130,12 @@ class EvalJudge(Judge):
 
     strategy = "script"
 
-    def __init__(self, config: JudgeConfig) -> None:
-        self._config = config
+    def __init__(
+        self, backend: str = DEFAULT_BACKEND, model: str | None = None
+    ) -> None:
+        # The judge engine is a runtime axis, resolved from --judge-model (ADR 0004).
+        self._backend = backend
+        self._model = model
 
     def evaluate(
         self,
@@ -186,14 +189,14 @@ class EvalJudge(Judge):
     def _llm_evaluate(
         self, task: TaskSpec, transcript: list[ConversationTurn], spec_dir: str
     ) -> tuple[bool, str, bool]:
-        match normalize_backend(self._config.backend):
+        match normalize_backend(self._backend):
             case "codex":
                 from caliper.judge.codex_judge import evaluate_with_codex
 
                 return evaluate_with_codex(
                     expect=task.expect,
                     transcript=transcript,
-                    model=self._config.model,
+                    model=self._model,
                     cwd=spec_dir,
                 )
             case "claude-code":
@@ -202,8 +205,17 @@ class EvalJudge(Judge):
                 return evaluate_with_claude_code(
                     expect=task.expect,
                     transcript=transcript,
-                    model=self._config.model,
+                    model=self._model,
+                    spec_dir=spec_dir,
+                )
+            case "pi":
+                from caliper.judge.pi_judge import evaluate_with_pi
+
+                return evaluate_with_pi(
+                    expect=task.expect,
+                    transcript=transcript,
+                    model=self._model,
                     spec_dir=spec_dir,
                 )
             case _:
-                return False, f"Unknown judge backend: {self._config.backend!r}", True
+                return False, f"Unknown judge backend: {self._backend!r}", True

--- a/caliper/resources/evaluate_skill/REFERENCE.md
+++ b/caliper/resources/evaluate_skill/REFERENCE.md
@@ -8,10 +8,10 @@ caliper run path/to/spec.eval.yaml --k 3
 caliper run path/to/spec.eval.yaml --k 3 --baseline      # include no-skill delta
 caliper run path/to/spec.eval.yaml --verbose             # show per-attempt reasoning
 
-# Override backend and/or model at run time (no spec edit needed)
+# Choose the engine at run time — it is not stored in the spec (default: claude-code)
 caliper run path/to/spec.eval.yaml --model codex:gpt-5-codex
-caliper run path/to/spec.eval.yaml --model codex
-caliper run path/to/spec.eval.yaml --model claude-sonnet-4-6   # model only, keep spec backend
+caliper run path/to/spec.eval.yaml --model codex                # backend only, its default model
+caliper run path/to/spec.eval.yaml --model claude-sonnet-4-6    # model only, backend stays claude-code
 caliper run path/to/spec.eval.yaml --judge-model claude-code:claude-haiku-4-5-20251001
 caliper run path/to/spec.eval.yaml --model codex --judge-model claude-code:claude-haiku-4-5-20251001
 ```
@@ -19,9 +19,8 @@ caliper run path/to/spec.eval.yaml --model codex --judge-model claude-code:claud
 ### Create a new evaluation spec (interactive wizard)
 ```bash
 caliper new my-skill-eval
-caliper new --skill ~/.claude/commands/review.md --backend claude-code
-caliper new --skill ./SKILL.md --backend codex
-caliper new --skill ./SKILL.md --backend pi
+caliper new --skill ~/.claude/commands/review.md
+caliper new --skill ./SKILL.md
 ```
 
 ### Validate a spec file
@@ -53,15 +52,14 @@ caliper compare full-eval short-eval --format json   # for a ship/no-ship gate
 
 ## Spec format (.eval.yaml)
 
+The spec carries no engine — no `backend`/`model` and no `judge:` block. Backend
+and model for both the skill and the judge are chosen at run time via `--model` /
+`--judge-model` (default `claude-code`); a spec that still pins these keys fails
+validation with a message pointing at the flags.
+
 ```yaml
 skill:
   path: ./SKILL.md
-  backend: claude-code     # claude-code | codex | pi
-  model: claude-sonnet-4-6 # optional
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001  # optional; cheaper is fine for judging
 
 sandbox:
   forbidden_files:
@@ -89,27 +87,18 @@ tasks:
     assert: ./assertions/check_report.py
 ```
 
-For a Codex-backed eval, use:
+The same spec runs on any engine. To run it on Codex, pass the backend at run
+time — the spec is unchanged:
 
-```yaml
-skill:
-  path: ./SKILL.md
-  backend: codex
-
-judge:
-  backend: codex
+```bash
+caliper run path/to/spec.eval.yaml --model codex --judge-model codex
 ```
 
-For a pi-backed eval (loads the skill natively via pi's `--skill` flag):
+For pi (loads the skill natively via pi's `--skill` flag), the `:model` half
+overrides pi's configured default:
 
-```yaml
-skill:
-  path: ./SKILL.md
-  backend: pi
-  model: claude-sonnet-4-6  # optional; overrides pi's configured default
-
-judge:
-  backend: pi
+```bash
+caliper run path/to/spec.eval.yaml --model pi:claude-sonnet-4-6 --judge-model pi
 ```
 
 ## Key concepts
@@ -121,8 +110,9 @@ judge:
 - **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
 - **isolation** — each attempt runs in a fresh temp HOME with no session history
-- **`--model TARGET`** — override skill backend/model at run time; accepts `backend:model`, bare backend (`codex`), or bare model name
-- **`--judge-model TARGET`** — same syntax, overrides the judge backend/model independently
+- **engine as a runtime axis** — backend + model are not spec fields; they are chosen per run and recorded in `RunMeta`, so the same spec can target any agent and never ages when a model goes stale
+- **`--model TARGET`** — select the skill engine at run time (default `claude-code`); accepts `backend:model`, bare backend (`codex`), or bare model name
+- **`--judge-model TARGET`** — same syntax, selects the judge engine independently
 
 ## Results storage
 

--- a/caliper/resources/evaluate_skill/SKILL.md
+++ b/caliper/resources/evaluate_skill/SKILL.md
@@ -16,18 +16,15 @@ The `caliper` CLI must be on `PATH`. This skill can be copied into an agent with
 pipx install caliper-eval
 ```
 
-Backends for the skill-under-test (`skill.backend`) and the judge (`judge.backend`) are chosen independently — from `claude-code`, `codex`, `pi`. Every backend is a CLI agent that uses its own subscription/auth; there is no direct-API backend (for API billing, configure a CLI with an API key). Full per-backend detail and every command: [REFERENCE.md](REFERENCE.md).
+The engine (backend + model) is not part of the spec — it is chosen at run time with `--model` (skill) and `--judge-model` (judge), independently, from `claude-code`, `codex`, `pi`, defaulting to `claude-code`. Every backend is a CLI agent that uses its own subscription/auth; there is no direct-API backend (for API billing, configure a CLI with an API key). Full per-backend detail and every command: [REFERENCE.md](REFERENCE.md).
 
 ## Spec shape
 
-An `.eval.yaml` names the skill, the judge, and a list of tasks. Keep `skill.path` relative to the spec file (usually `./SKILL.md`):
+An `.eval.yaml` names the skill and a list of tasks. Keep `skill.path` relative to the spec file (usually `./SKILL.md`):
 
 ```yaml
 skill:
   path: ./SKILL.md      # relative to the spec file
-  backend: codex        # claude-code | codex | pi
-judge:
-  backend: codex        # independent of skill.backend
 tasks:
   - name: What success looks like
     prompt: <prompt sent to the skill under test>
@@ -36,7 +33,7 @@ tasks:
       assert ...
 ```
 
-Add `model:` under `skill`/`judge` only when the user asks for a specific model. The full format (setup/cleanup, external assert scripts, sandbox) is in [REFERENCE.md](REFERENCE.md).
+The spec has no `backend`/`model` or `judge:` block; pick the engine when you run, e.g. `caliper run <spec> --model codex --judge-model codex`. The full format (setup/cleanup, external assert scripts, sandbox) is in [REFERENCE.md](REFERENCE.md).
 
 ## Bundled references
 

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -25,7 +25,7 @@ from caliper.schema.results import (
     SkillSnapshot,
     TaskResult,
 )
-from caliper.schema.spec import EvalSpec, TaskSpec, spec_name
+from caliper.schema.spec import DEFAULT_BACKEND, EvalSpec, TaskSpec, spec_name
 from caliper.scoring import aggregate_scores, compute_delta, pass_at_k
 
 _FAIL_FAST_OUTCOMES = {Outcome.INFRA_ERROR, Outcome.TIMEOUT}
@@ -43,6 +43,8 @@ def run(
     spec_path: Path,
     harness: HarnessBackend,
     judge: Judge,
+    backend: str = DEFAULT_BACKEND,
+    model: str | None = None,
     k: int = 3,
     workers: int = 4,
     timeout: int = 120,
@@ -135,8 +137,8 @@ def run(
             spec=spec_name(spec_path),
             timestamp=datetime.now(tz=timezone.utc),
             k=k,
-            backend=spec.skill.backend,
-            model=spec.skill.model,
+            backend=backend,
+            model=model,
         ),
         skill_snapshot=skill_snapshot,
         task_results=task_results_with,
@@ -230,7 +232,9 @@ def _run_attempt(
             attempt=attempt,
             prompt=task.prompt,
             skill_path=skill_path,
-            model=spec.skill.model,
+            # None → the harness uses the model it was constructed with; the
+            # engine is resolved once at the run seam (ADR 0004), not per spec.
+            model=None,
             timeout=timeout,
             isolated_home=tmp_dir,
             extra_path=resolved_extra_path,

--- a/caliper/schema/spec.py
+++ b/caliper/schema/spec.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 BackendName = Literal["claude-code", "codex", "pi"]
 
 _VALID_BACKENDS: frozenset[str] = frozenset({"claude-code", "codex", "pi"})
+
+# The engine (backend + model) is a runtime axis, not a spec field: it is chosen
+# at invocation via --model / --judge-model and defaults to this. A saved run
+# still records the actual engine in RunMeta, so de-pinning costs no
+# reproducibility. See docs/adr/0004-engine-is-a-runtime-axis-not-a-spec-field.md.
+DEFAULT_BACKEND: str = "claude-code"
 
 
 def normalize_backend(value: str) -> str:
@@ -56,24 +62,9 @@ class TaskSpec(BaseModel):
 
 
 class SkillConfig(BaseModel):
+    # `path` is the only spec-level skill fact; the engine that runs it is a
+    # runtime axis (see DEFAULT_BACKEND). Omit `path` to test the bare agent.
     path: str | None = None
-    backend: BackendName = "claude-code"
-    model: str | None = None
-
-    @field_validator("backend", mode="before")
-    @classmethod
-    def normalize_backend_name(cls, value: str) -> str:
-        return normalize_backend(value)
-
-
-class JudgeConfig(BaseModel):
-    backend: BackendName = "claude-code"
-    model: str | None = None
-
-    @field_validator("backend", mode="before")
-    @classmethod
-    def normalize_backend_name(cls, value: str) -> str:
-        return normalize_backend(value)
 
 
 class SandboxConfig(BaseModel):
@@ -83,17 +74,50 @@ class SandboxConfig(BaseModel):
 
 class EvalSpec(BaseModel):
     skill: SkillConfig
-    judge: JudgeConfig = Field(default_factory=JudgeConfig)
     sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
     tasks: list[TaskSpec]
 
     model_config = ConfigDict(extra="forbid")
 
 
+# Keys removed in ADR 0004, mapped to the runtime flag that replaced them. Caught
+# before generic validation so the error explains *where the engine went*, not
+# just that an unknown key is present.
+_REMOVED_KEYS: dict[str, str] = {
+    "skill.backend": "--model",
+    "skill.model": "--model",
+    "judge": "--judge-model",
+}
+
+
+def _reject_removed_keys(raw: dict) -> None:
+    offenders: list[str] = []
+    skill = raw.get("skill")
+    if isinstance(skill, dict):
+        offenders += [f"skill.{k}" for k in ("backend", "model") if k in skill]
+    if "judge" in raw:
+        offenders.append("judge")
+    if not offenders:
+        return
+    lines = [
+        f"  - {key} (engine now comes from {_REMOVED_KEYS[key]})" for key in offenders
+    ]
+    raise ValueError(
+        "backend/model are no longer spec fields — the engine is chosen at "
+        "runtime (default: "
+        f"{DEFAULT_BACKEND}). Delete these key(s) from the spec:\n"
+        + "\n".join(lines)
+        + "\nPass the engine when you run: "
+        "caliper run <spec> --model codex:gpt-5-codex --judge-model claude-code"
+    )
+
+
 def load_spec(path: Path) -> EvalSpec:
     import yaml
 
     raw = yaml.safe_load(path.read_text())
+    if isinstance(raw, dict):
+        _reject_removed_keys(raw)
     for i, task in enumerate(raw.get("tasks", []), 1):
         task["id"] = f"task-{i:03d}"
     return EvalSpec.model_validate(raw)

--- a/caliper/schema/spec.py
+++ b/caliper/schema/spec.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-
-BackendName = Literal["claude-code", "codex", "pi"]
 
 _VALID_BACKENDS: frozenset[str] = frozenset({"claude-code", "codex", "pi"})
 

--- a/caliper/wizard.py
+++ b/caliper/wizard.py
@@ -10,11 +10,9 @@ from rich.rule import Rule
 
 from caliper.schema.spec import (
     EvalSpec,
-    JudgeConfig,
     SandboxConfig,
     SkillConfig,
     TaskSpec,
-    normalize_backend,
 )
 
 console = Console()
@@ -26,12 +24,13 @@ def run_wizard(
     name: str | None = None,
     output: Path | None = None,
     skill_path: str | None = None,
-    backend: str = "claude-code",
 ) -> Path:
     console.print(Panel(_BANNER, border_style="cyan", padding=(0, 2)))
     console.print()
 
     # ── Step 1: Skill ─────────────────────────────────────────────────────────
+    # The wizard authors *specs* only. The engine (backend/model) is a runtime
+    # axis chosen at `caliper run` time, so it is never written here (ADR 0004).
     console.print(Rule("[bold]Step 1 — Skill[/bold]", style="cyan"))
     skill_p = (
         Prompt.ask(
@@ -42,28 +41,10 @@ def run_wizard(
         or None
     )
 
-    backend_choice = Prompt.ask(
-        "  Backend",
-        choices=["claude-code", "codex", "pi"],
-        default=normalize_backend(backend),
-    )
-    model = Prompt.ask("  Model override", default="").strip() or None
-
     console.print()
 
-    # ── Step 2: Judge ─────────────────────────────────────────────────────────
-    console.print(Rule("[bold]Step 2 — Judge[/bold]", style="cyan"))
-    judge_backend = Prompt.ask(
-        "  Judge backend",
-        choices=["claude-code", "codex", "pi"],
-        default="claude-code",
-    )
-    judge_model = Prompt.ask("  Judge model override", default="").strip() or None
-
-    console.print()
-
-    # ── Step 3: Tasks ─────────────────────────────────────────────────────────
-    console.print(Rule("[bold]Step 3 — Tasks[/bold]", style="cyan"))
+    # ── Step 2: Tasks ─────────────────────────────────────────────────────────
+    console.print(Rule("[bold]Step 2 — Tasks[/bold]", style="cyan"))
     console.print(
         "  [dim]Add tasks one by one. Leave task name empty to finish.[/dim]\n"
     )
@@ -139,16 +120,15 @@ def run_wizard(
 
     console.print()
 
-    # ── Step 4: Output path ───────────────────────────────────────────────────
-    console.print(Rule("[bold]Step 4 — Save[/bold]", style="cyan"))
+    # ── Step 3: Output path ───────────────────────────────────────────────────
+    console.print(Rule("[bold]Step 3 — Save[/bold]", style="cyan"))
     default_name = (name or "my-eval") + ".eval.yaml"
     if output is None:
         out_str = Prompt.ask("  Save spec to", default=default_name).strip()
         output = Path(out_str)
 
     spec = EvalSpec(
-        skill=SkillConfig(path=skill_p, backend=backend_choice, model=model),
-        judge=JudgeConfig(backend=judge_backend, model=judge_model),
+        skill=SkillConfig(path=skill_p),
         sandbox=SandboxConfig(forbidden_files=[".*\\.eval\\.yaml$", "./.caliper/.*"]),
         tasks=tasks,
     )
@@ -159,7 +139,9 @@ def run_wizard(
         Panel(
             f"Spec written to [bold cyan]{output}[/bold cyan]\n"
             f"Validate with: [dim]caliper validate {output}[/dim]\n"
-            f"Run with:      [dim]caliper run {output}[/dim]",
+            f"Run with:      [dim]caliper run {output}[/dim]\n"
+            "Pick an engine at run time (default claude-code), e.g.:\n"
+            f"               [dim]caliper run {output} --model codex:gpt-5-codex[/dim]",
             title="[bold green]✓ Done[/bold green]",
             border_style="green",
         )

--- a/examples/starter-pack/01-false-success/false-success.eval.yaml
+++ b/examples/starter-pack/01-false-success/false-success.eval.yaml
@@ -16,23 +16,19 @@ skill:
   # 👉 EDIT 1: point this at your own SKILL.md (or delete `path:` to test the
   #            bare agent with no skill).
   path: ./SKILL.md
-  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi
-  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
+  # The engine (backend + model) is NOT a spec field — it's a runtime axis.
+  # Pick it when you run, e.g. `--model codex:gpt-5-codex` (default: claude-code).
 
 tasks:
-  # 👉 EDIT 3: rename this task — it becomes the row label in your results.
+  # 👉 EDIT 2: rename this task — it becomes the row label in your results.
   - name: Actually writes the note it claims to have saved
-    # 👉 EDIT 4: the output path below appears in setup, cleanup, prompt, expect,
+    # 👉 EDIT 3: the output path below appears in setup, cleanup, prompt, expect,
     #            and assert — change it in every one. The setup/cleanup lines
     #            start clean so a leftover file from a previous run can't fake a
     #            pass — exactly the false success this template catches.
     setup: rm -f /tmp/caliper-note.txt
     cleanup: rm -f /tmp/caliper-note.txt
-    # 👉 EDIT 5: replace this prompt with a real request for your own agent.
+    # 👉 EDIT 4: replace this prompt with a real request for your own agent.
     prompt: "Save the note 'ship the release on Friday' to /tmp/caliper-note.txt"
 
     # The self-report check: did the agent SAY it did the right thing?

--- a/examples/starter-pack/02-tool-misuse/tool-misuse.eval.yaml
+++ b/examples/starter-pack/02-tool-misuse/tool-misuse.eval.yaml
@@ -16,12 +16,8 @@
 skill:
   # 👉 EDIT 1: point this at your own SKILL.md.
   path: ./SKILL.md
-  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi
-  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
+  # The engine (backend + model) is NOT a spec field — it's a runtime axis.
+  # Pick it when you run, e.g. `--model codex:gpt-5-codex` (default: claude-code).
 
 sandbox:
   # Puts the fake `notify` CLI on PATH inside each attempt. When testing your
@@ -30,13 +26,13 @@ sandbox:
     - ./bin
 
 tasks:
-  # 👉 EDIT 3: rename this task — it becomes the row label in your results.
+  # 👉 EDIT 2: rename this task — it becomes the row label in your results.
   - name: Sends the alert to the required ops channel
     # setup/cleanup clear the wrapper's argument log between attempts. When you
     # switch to your own tool, point these (and the assert) at your real signal.
     setup: rm -f /tmp/caliper-notify-args.log
     cleanup: rm -f /tmp/caliper-notify-args.log
-    # 👉 EDIT 4: replace with a real request that should trigger your tool.
+    # 👉 EDIT 3: replace with a real request that should trigger your tool.
     #            (Name the tool so the agent reaches for it — the skill's job is
     #            to enforce the *right arguments*, which is what we assert on.)
     prompt: >

--- a/examples/starter-pack/03-runaway-loops/runaway-loops.eval.yaml
+++ b/examples/starter-pack/03-runaway-loops/runaway-loops.eval.yaml
@@ -18,23 +18,19 @@
 skill:
   # 👉 EDIT 1: point this at your own SKILL.md.
   path: ./SKILL.md
-  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi
-  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
+  # The engine (backend + model) is NOT a spec field — it's a runtime axis.
+  # Pick it when you run, e.g. `--model codex:gpt-5-codex` (default: claude-code).
 
 sandbox:
   extra_path:
     - ./bin
 
 tasks:
-  # 👉 EDIT 3: rename this task — it becomes the row label in your results.
+  # 👉 EDIT 2: rename this task — it becomes the row label in your results.
   - name: Stops retrying within the budget instead of looping forever
     setup: rm -f /tmp/caliper-fetch-calls.log
     cleanup: rm -f /tmp/caliper-fetch-calls.log
-    # 👉 EDIT 4: replace with a real request that exercises your retry path.
+    # 👉 EDIT 3: replace with a real request that exercises your retry path.
     prompt: >
       Run the command `flaky-fetch metrics` to fetch the latest metrics, then
       tell me what happened.
@@ -46,7 +42,7 @@ tasks:
       unavailable, so a correct answer reports the failure.)
 
     # The budget check: count the calls. This is what catches a runaway loop —
-    # 👉 EDIT 5 (optional): raise/lower the budget to match your own tool.
+    # 👉 EDIT 4 (optional): raise/lower the budget to match your own tool.
     assert: |
       from pathlib import Path
 

--- a/examples/starter-pack/04-prompt-regression/prompt-regression.eval.yaml
+++ b/examples/starter-pack/04-prompt-regression/prompt-regression.eval.yaml
@@ -19,14 +19,10 @@
 skill:
   # 👉 EDIT 1: point this at your own SKILL.md.
   path: ./SKILL.md
-  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi
-  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
+  # The engine (backend + model) is NOT a spec field — it's a runtime axis.
+  # Pick it when you run, e.g. `--model codex:gpt-5-codex` (default: claude-code).
 
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
-
-# 👉 EDIT 3: replace these four cases with the fixed set that matters for your
+# 👉 EDIT 2: replace these four cases with the fixed set that matters for your
 #            skill. Keep them simple and unambiguous — they are your tripwire.
 tasks:
   - name: Basic two-word title

--- a/examples/starter-pack/05-context-boundary/context-boundary.eval.yaml
+++ b/examples/starter-pack/05-context-boundary/context-boundary.eval.yaml
@@ -16,12 +16,8 @@
 skill:
   # 👉 EDIT 1: point this at your own SKILL.md.
   path: ./SKILL.md
-  backend: claude-code             # 👉 EDIT 2: claude-code | codex | pi
-  model: claude-haiku-4-5-20251001 # optional — delete to use your agent's default model
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
+  # The engine (backend + model) is NOT a spec field — it's a runtime axis.
+  # Pick it when you run, e.g. `--model codex:gpt-5-codex` (default: claude-code).
 
 tasks:
   - name: Excludes stale transcript claim when ADR supersedes it

--- a/examples/starter-pack/README.md
+++ b/examples/starter-pack/README.md
@@ -13,9 +13,10 @@ Install the CLI and make sure your agent backend is authenticated:
 pipx install caliper-eval        # or: pip install caliper-eval
 ```
 
-The templates default to the `claude-code` backend. If you use a different
-agent, change the `backend:` line in any template (see
-[Choosing a backend](../../README.md#choosing-a-backend)).
+The engine (agent + model) isn't written in the templates — it's chosen when you
+run. Everything defaults to `claude-code`; to use a different agent, pass
+`--model` (e.g. `--model codex:gpt-5-codex`) — see
+[Choosing an engine](../../README.md#choosing-an-engine).
 
 Two terms you'll see in every template:
 
@@ -121,9 +122,12 @@ side-effect path, which can appear in `setup`, `cleanup`, `prompt`, and
 
 1. **`skill.path`** — point it at your own `SKILL.md` (or delete it to test the
    bare agent with no skill).
-2. **`skill.backend`** — your agent: `claude-code`, `codex`, or `pi`.
-3. **`tasks[].prompt`** (and the matching `expect:`/`assert:`) — describe a real
+2. **`tasks[].prompt`** (and the matching `expect:`/`assert:`) — describe a real
    request and what a correct result looks like for *your* skill.
+
+The agent itself isn't in the template — pass it at run time with `--model`
+(`claude-code`, `codex`, `pi`, or a `backend:model` pair); it defaults to
+`claude-code`.
 
 For templates 2 and 3, the fake tool under `bin/` is a stand-in so the example
 runs without any external service. When you switch to your own agent, delete the

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -8,10 +8,10 @@ caliper run path/to/spec.eval.yaml --k 3
 caliper run path/to/spec.eval.yaml --k 3 --baseline      # include no-skill delta
 caliper run path/to/spec.eval.yaml --verbose             # show per-attempt reasoning
 
-# Override backend and/or model at run time (no spec edit needed)
+# Choose the engine at run time — it is not stored in the spec (default: claude-code)
 caliper run path/to/spec.eval.yaml --model codex:gpt-5-codex
-caliper run path/to/spec.eval.yaml --model codex
-caliper run path/to/spec.eval.yaml --model claude-sonnet-4-6   # model only, keep spec backend
+caliper run path/to/spec.eval.yaml --model codex                # backend only, its default model
+caliper run path/to/spec.eval.yaml --model claude-sonnet-4-6    # model only, backend stays claude-code
 caliper run path/to/spec.eval.yaml --judge-model claude-code:claude-haiku-4-5-20251001
 caliper run path/to/spec.eval.yaml --model codex --judge-model claude-code:claude-haiku-4-5-20251001
 ```
@@ -19,9 +19,8 @@ caliper run path/to/spec.eval.yaml --model codex --judge-model claude-code:claud
 ### Create a new evaluation spec (interactive wizard)
 ```bash
 caliper new my-skill-eval
-caliper new --skill ~/.claude/commands/review.md --backend claude-code
-caliper new --skill ./SKILL.md --backend codex
-caliper new --skill ./SKILL.md --backend pi
+caliper new --skill ~/.claude/commands/review.md
+caliper new --skill ./SKILL.md
 ```
 
 ### Validate a spec file
@@ -53,15 +52,14 @@ caliper compare full-eval short-eval --format json   # for a ship/no-ship gate
 
 ## Spec format (.eval.yaml)
 
+The spec carries no engine — no `backend`/`model` and no `judge:` block. Backend
+and model for both the skill and the judge are chosen at run time via `--model` /
+`--judge-model` (default `claude-code`); a spec that still pins these keys fails
+validation with a message pointing at the flags.
+
 ```yaml
 skill:
   path: ./SKILL.md
-  backend: claude-code     # claude-code | codex | pi
-  model: claude-sonnet-4-6 # optional
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001  # optional; cheaper is fine for judging
 
 sandbox:
   forbidden_files:
@@ -89,27 +87,18 @@ tasks:
     assert: ./assertions/check_report.py
 ```
 
-For a Codex-backed eval, use:
+The same spec runs on any engine. To run it on Codex, pass the backend at run
+time — the spec is unchanged:
 
-```yaml
-skill:
-  path: ./SKILL.md
-  backend: codex
-
-judge:
-  backend: codex
+```bash
+caliper run path/to/spec.eval.yaml --model codex --judge-model codex
 ```
 
-For a pi-backed eval (loads the skill natively via pi's `--skill` flag):
+For pi (loads the skill natively via pi's `--skill` flag), the `:model` half
+overrides pi's configured default:
 
-```yaml
-skill:
-  path: ./SKILL.md
-  backend: pi
-  model: claude-sonnet-4-6  # optional; overrides pi's configured default
-
-judge:
-  backend: pi
+```bash
+caliper run path/to/spec.eval.yaml --model pi:claude-sonnet-4-6 --judge-model pi
 ```
 
 ## Key concepts
@@ -121,8 +110,9 @@ judge:
 - **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
 - **isolation** — each attempt runs in a fresh temp HOME with no session history
-- **`--model TARGET`** — override skill backend/model at run time; accepts `backend:model`, bare backend (`codex`), or bare model name
-- **`--judge-model TARGET`** — same syntax, overrides the judge backend/model independently
+- **engine as a runtime axis** — backend + model are not spec fields; they are chosen per run and recorded in `RunMeta`, so the same spec can target any agent and never ages when a model goes stale
+- **`--model TARGET`** — select the skill engine at run time (default `claude-code`); accepts `backend:model`, bare backend (`codex`), or bare model name
+- **`--judge-model TARGET`** — same syntax, selects the judge engine independently
 
 ## Results storage
 

--- a/skills/evaluate-skill/SKILL.md
+++ b/skills/evaluate-skill/SKILL.md
@@ -16,18 +16,15 @@ The `caliper` CLI must be on `PATH`. This skill can be copied into an agent with
 pipx install caliper-eval
 ```
 
-Backends for the skill-under-test (`skill.backend`) and the judge (`judge.backend`) are chosen independently — from `claude-code`, `codex`, `pi`. Every backend is a CLI agent that uses its own subscription/auth; there is no direct-API backend (for API billing, configure a CLI with an API key). Full per-backend detail and every command: [REFERENCE.md](REFERENCE.md).
+The engine (backend + model) is not part of the spec — it is chosen at run time with `--model` (skill) and `--judge-model` (judge), independently, from `claude-code`, `codex`, `pi`, defaulting to `claude-code`. Every backend is a CLI agent that uses its own subscription/auth; there is no direct-API backend (for API billing, configure a CLI with an API key). Full per-backend detail and every command: [REFERENCE.md](REFERENCE.md).
 
 ## Spec shape
 
-An `.eval.yaml` names the skill, the judge, and a list of tasks. Keep `skill.path` relative to the spec file (usually `./SKILL.md`):
+An `.eval.yaml` names the skill and a list of tasks. Keep `skill.path` relative to the spec file (usually `./SKILL.md`):
 
 ```yaml
 skill:
   path: ./SKILL.md      # relative to the spec file
-  backend: codex        # claude-code | codex | pi
-judge:
-  backend: codex        # independent of skill.backend
 tasks:
   - name: What success looks like
     prompt: <prompt sent to the skill under test>
@@ -36,7 +33,7 @@ tasks:
       assert ...
 ```
 
-Add `model:` under `skill`/`judge` only when the user asks for a specific model. The full format (setup/cleanup, external assert scripts, sandbox) is in [REFERENCE.md](REFERENCE.md).
+The spec has no `backend`/`model` or `judge:` block; pick the engine when you run, e.g. `caliper run <spec> --model codex --judge-model codex`. The full format (setup/cleanup, external assert scripts, sandbox) is in [REFERENCE.md](REFERENCE.md).
 
 ## Bundled references
 

--- a/skills/evaluate-skill/evaluate-skill.eval.yaml
+++ b/skills/evaluate-skill/evaluate-skill.eval.yaml
@@ -1,23 +1,19 @@
 skill:
   path: ./SKILL.md
-  backend: codex
 
-judge:
-  backend: codex
+# The engine (backend + model) is a runtime axis, not a spec field — run this
+# eval with `--model codex --judge-model codex` (or any other engine).
 
 sandbox:
   forbidden_files:
     - "./.caliper/.*"
 
 tasks:
-  - name: Validates a Codex-backed spec and reports it as valid
+  - name: Validates a well-formed spec and reports it as valid
     setup: |
       cat > /tmp/caliper-test-valid.eval.yaml << 'EOF'
       skill:
         path: ./SKILL.md
-        backend: codex
-      judge:
-        backend: codex
       tasks:
         - name: Test arithmetic
           prompt: What is 2 + 2?
@@ -29,7 +25,7 @@ tasks:
       and tell me whether it is valid.
     expect: >
       The agent runs caliper validate on /tmp/caliper-test-valid.eval.yaml and
-      reports that the Codex-backed spec is valid with no errors.
+      reports that the spec is valid with no errors.
     assert: |
       import subprocess
 
@@ -43,7 +39,7 @@ tasks:
     setup: |
       cat > /tmp/caliper-test-invalid.eval.yaml << 'EOF'
       skill:
-        backend: claude-code
+        path: ./SKILL.md
       tasks:
         - name: Broken task
           prompt: do something
@@ -57,18 +53,20 @@ tasks:
       describing that the task is missing both expect and assert fields. The
       agent does not edit the invalid spec file.
 
-  - name: Creates a Codex CLI eval spec file on request
+  - name: Creates an engineless eval spec and defers the engine to run time
     cleanup: rm -f /tmp/caliper-created.eval.yaml
     prompt: >
       Create an evaluation spec file at /tmp/caliper-created.eval.yaml for a
-      Codex CLI skill at ./SKILL.md. Use codex as both the skill backend and
-      judge backend. Include one task named "Answers
-      arithmetic", with prompt "What is 2 + 2?" and expectation "The assistant
-      answers 4."
+      skill at ./SKILL.md that I intend to run on the Codex CLI. Include one task
+      named "Answers arithmetic", with prompt "What is 2 + 2?" and expectation
+      "The assistant answers 4." Then tell me how to run it against Codex.
     expect: >
-      A valid .eval.yaml file is written at /tmp/caliper-created.eval.yaml. It
-      uses codex for both skill.backend and judge.backend and includes the
-      requested task.
+      A valid .eval.yaml file is written at /tmp/caliper-created.eval.yaml with
+      skill.path ./SKILL.md and the requested task. The spec does NOT pin a
+      backend or model (no skill.backend/model, no judge block) because the
+      engine is a runtime axis, and the agent tells the user to select Codex at
+      run time with `caliper run ... --model codex` (optionally
+      `--judge-model codex`).
     assert: |
       import os
       import yaml
@@ -77,29 +75,30 @@ tasks:
       assert os.path.exists(path), "Spec file was not created"
       with open(path) as f:
           spec = yaml.safe_load(f)
-      assert spec["skill"]["backend"] == "codex", "skill backend should be codex"
       assert spec["skill"]["path"] == "./SKILL.md", "skill path should be ./SKILL.md"
-      assert "model" not in spec["skill"], "skill model should be omitted unless requested"
-      assert spec["judge"]["backend"] == "codex", "judge backend should be codex"
-      assert "model" not in spec["judge"], "judge model should be omitted unless requested"
+      assert "backend" not in spec["skill"], "engine is a runtime axis: no skill.backend"
+      assert "model" not in spec["skill"], "engine is a runtime axis: no skill.model"
+      assert "judge" not in spec, "engine is a runtime axis: no judge block belongs in the spec"
       assert len(spec.get("tasks", [])) == 1, "Expected exactly one task"
       task = spec["tasks"][0]
       assert task["name"] == "Answers arithmetic", "Unexpected task name"
       assert task["prompt"] == "What is 2 + 2?", "Unexpected prompt"
       assert task["expect"] == "The assistant answers 4.", "Unexpected expectation"
 
-  - name: Explains mixed Claude Code and Codex backend support
+  - name: Explains independent skill and judge engines are selected at run time
     cleanup: rm -f /tmp/caliper-mixed-backend.eval.yaml
     prompt: >
       Create an evaluation spec file at /tmp/caliper-mixed-backend.eval.yaml
-      that evaluates a Claude Code skill at ~/.claude/commands/review.md with
-      skill.backend set to claude-code, but judges it with Codex. Include one
-      task named "Reviews staged changes", prompt "/review the staged changes",
-      and expectation "The review reports at least one actionable issue."
+      that evaluates a Claude Code skill at ~/.claude/commands/review.md but is
+      judged by Codex. Include one task named "Reviews staged changes", prompt
+      "/review the staged changes", and expectation "The review reports at least
+      one actionable issue." Then tell me the exact command to run it that way.
     expect: >
-      The agent creates a valid spec with skill.backend set to claude-code and
-      judge.backend set to codex, showing that Caliper supports independent
-      agent and judge backends.
+      The agent writes a valid engineless spec (skill.path
+      ~/.claude/commands/review.md, no backend/model, no judge block) and
+      explains that the skill and judge engines are chosen independently at run
+      time — e.g. `caliper run ... --model claude-code --judge-model codex` —
+      because Caliper treats the engine as a runtime axis, not a spec field.
     assert: |
       import os
       import yaml
@@ -108,8 +107,9 @@ tasks:
       assert os.path.exists(path), "Spec file was not created"
       with open(path) as f:
           spec = yaml.safe_load(f)
-      assert spec["skill"]["backend"] == "claude-code", "skill backend should be claude-code"
-      assert spec["judge"]["backend"] == "codex", "judge backend should be codex"
+      assert spec["skill"]["path"] == "~/.claude/commands/review.md", "Unexpected skill path"
+      assert "backend" not in spec["skill"], "engine is a runtime axis: no skill.backend"
+      assert "judge" not in spec, "engine is a runtime axis: no judge block belongs in the spec"
       assert spec["tasks"][0]["name"] == "Reviews staged changes", "Unexpected task name"
 
   - name: Lists available evaluations gracefully

--- a/skills/evaluate-skill/references/evals/claude-code-smoke/claude-code-smoke.eval.yaml
+++ b/skills/evaluate-skill/references/evals/claude-code-smoke/claude-code-smoke.eval.yaml
@@ -1,11 +1,5 @@
 skill:
   path: ./SKILL.md
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
 
 sandbox:
   forbidden_files:

--- a/skills/evaluate-skill/references/evals/commit-simple/commit-simple.eval.yaml
+++ b/skills/evaluate-skill/references/evals/commit-simple/commit-simple.eval.yaml
@@ -1,11 +1,5 @@
 skill:
   path: ./SKILL.md
-  backend: claude-code
-  model: claude-sonnet-4-6
-
-judge:
-  backend: claude-code
-  model: claude-sonnet-4-6
 
 tasks:
   - name: Conventional commit on a feature branch

--- a/skills/evaluate-skill/references/evals/screenshot/screenshot.eval.yaml
+++ b/skills/evaluate-skill/references/evals/screenshot/screenshot.eval.yaml
@@ -1,9 +1,5 @@
 skill:
   path: ./SKILL.md
-  backend: codex
-
-judge:
-  backend: codex
 
 sandbox:
   forbidden_files:

--- a/skills/evaluate-skill/references/evals/summarize/summarize.eval.yaml
+++ b/skills/evaluate-skill/references/evals/summarize/summarize.eval.yaml
@@ -1,11 +1,5 @@
 skill:
   path: ./SKILL.md
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
-
-judge:
-  backend: claude-code
-  model: claude-sonnet-4-6
 
 sandbox:
   extra_path:

--- a/skills/evaluate-skill/references/evals/tdd/tdd.eval.yaml
+++ b/skills/evaluate-skill/references/evals/tdd/tdd.eval.yaml
@@ -1,11 +1,5 @@
 skill:
   path: ./SKILL.md
-  backend: claude
-  model: claude-sonnet-4-6
-
-judge:
-  backend: claude
-  model: claude-sonnet-4-6
 
 tasks:
   - name: Writes failing test before implementing new function

--- a/skills/evaluate-skill/references/examples/simple.eval.yaml
+++ b/skills/evaluate-skill/references/examples/simple.eval.yaml
@@ -1,11 +1,5 @@
 skill:
   path: ~/.claude/commands/review.md
-  backend: claude
-  model: claude-sonnet-4-6
-
-judge:
-  backend: claude
-  model: claude-haiku-4-5-20251001
 
 sandbox:
   forbidden_files:

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -15,7 +15,7 @@ caliper run path/to/spec.eval.yaml --k 3
 # Baseline run — before committing, proves the skill makes a difference
 caliper run path/to/spec.eval.yaml --k 3 --baseline
 
-# Run against a different backend or model without editing the spec
+# Choose the engine at run time — it is not stored in the spec (default: claude-code)
 caliper run path/to/spec.eval.yaml --model codex:gpt-5-codex
 caliper run path/to/spec.eval.yaml --model codex
 caliper run path/to/spec.eval.yaml --judge-model claude-code:claude-haiku-4-5-20251001
@@ -55,15 +55,14 @@ caliper report path/to/spec.eval.yaml --verbose
 caliper report path/to/spec.eval.yaml --run 2026-06-21T14-53-12Z --verbose
 ```
 
-## Spec skeleton (claude-code backend)
+## Spec skeleton
+
+The spec carries no engine — pick the backend/model at run time with `--model` /
+`--judge-model` (default `claude-code`).
 
 ```yaml
 skill:
   path: ./SKILL.md
-  backend: claude-code
-
-judge:
-  backend: claude-code
 
 sandbox:
   forbidden_files:
@@ -125,4 +124,4 @@ Add `assert:` when the outcome is a fact that an LLM judge might guess wrong:
 | `codex` | Codex CLI | For Codex-targeted skills |
 | `pi` | pi CLI (authenticated) | For pi / agentskills.io skills; native `--skill` loading |
 
-Skill backend and judge backend are independent. Every backend is a CLI agent; for API billing, configure a CLI with an API key rather than selecting a separate backend.
+The skill engine (`--model`) and judge engine (`--judge-model`) are chosen independently at run time. Every backend is a CLI agent; for API billing, configure a CLI with an API key rather than selecting a separate backend.

--- a/skills/grill-skill/grill-skill.eval.yaml
+++ b/skills/grill-skill/grill-skill.eval.yaml
@@ -1,9 +1,8 @@
 skill:
   path: ./SKILL.md
-  backend: claude-code
 
-judge:
-  backend: claude-code
+# The engine (backend + model) is a runtime axis, not a spec field — this eval
+# runs on whatever `--model` / `--judge-model` select (default claude-code).
 
 # No explicit sandbox.forbidden_files: caliper already auto-forbids the eval
 # spec and .caliper/ by absolute path. Listing "./.caliper/.*" here caused a
@@ -73,9 +72,6 @@ tasks:
       cat > /tmp/grill-existing/summarize.eval.yaml << 'EOF'
       skill:
         path: ./SKILL.md
-        backend: claude-code
-      judge:
-        backend: claude-code
       tasks:
         - name: Summarizes a short text file
           prompt: Summarize /tmp/notes.txt
@@ -128,21 +124,20 @@ tasks:
       a COMPLETE, valid caliper eval spec for the
       skill at /tmp/grill-serialize/SKILL.md, and write it to
       /tmp/grill-serialize/hello-file.eval.yaml (do not run it — just create the
-      file). The spec must include the top-level skill block (skill.path
-      ./SKILL.md and backend claude-code) and judge block (backend claude-code),
-      plus exactly 3 tasks: a happy path where the prompt asks the agent to
-      write the greeting file and the expect is that /tmp/hello.txt contains
-      "hello world"; an edge case where the user specifies a custom greeting;
-      and an adversarial case where the user asks to overwrite a protected
-      system file.
+      file). The spec must have a top-level skill block with skill.path
+      ./SKILL.md (and NO backend/model or judge block — the engine is a runtime
+      axis, chosen with --model at run time), plus exactly 3 tasks: a happy path
+      where the prompt asks the agent to write the greeting file and the expect
+      is that /tmp/hello.txt contains "hello world"; an edge case where the user
+      specifies a custom greeting; and an adversarial case where the user asks
+      to overwrite a protected system file.
     expect: >
       A valid, runnable .eval.yaml is written at
       /tmp/grill-serialize/hello-file.eval.yaml: it has a top-level skill block
-      (path ./SKILL.md, a backend), a judge block with a backend, and exactly 3
-      tasks covering a happy path, an edge case, and an adversarial case.
+      (path ./SKILL.md, no backend/model, no judge block) and exactly 3 tasks
+      covering a happy path, an edge case, and an adversarial case.
     assert: |
       import yaml
-      def be(n): return n if isinstance(n, str) else (n or {}).get("backend")
       def pa(n): return n if isinstance(n, str) else (n or {}).get("path")
 
       path = "/tmp/grill-serialize/hello-file.eval.yaml"
@@ -156,8 +151,11 @@ tasks:
       assert isinstance(spec, dict), "spec is not a mapping"
       assert pa(spec.get("skill")) in ("./SKILL.md", "SKILL.md"), \
           f"skill.path should be ./SKILL.md, got {pa(spec.get('skill'))!r}"
-      assert be(spec.get("skill")), "skill.backend is required"
-      assert be(spec.get("judge")), "judge.backend is required"
+      skill = spec.get("skill") or {}
+      if isinstance(skill, dict):
+          assert "backend" not in skill and "model" not in skill, \
+              "engine is a runtime axis: skill must not pin backend/model"
+      assert "judge" not in spec, "engine is a runtime axis: no judge block belongs in the spec"
       tasks = spec.get("tasks", [])
       assert len(tasks) == 3, f"Expected 3 tasks, got {len(tasks)}"
       for task in tasks:

--- a/tests/claude-code-smoke.eval.yaml
+++ b/tests/claude-code-smoke.eval.yaml
@@ -1,10 +1,7 @@
-skill:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
+# End-to-end smoke eval for the `claude-code` backend (the default engine).
+# The engine is a runtime axis, not a spec field — pick it when you run:
+#   caliper run tests/claude-code-smoke.eval.yaml --model claude-code:claude-haiku-4-5-20251001
+skill: {}
 
 tasks:
   - name: Write hello to a file

--- a/tests/codex-smoke.eval.yaml
+++ b/tests/codex-smoke.eval.yaml
@@ -1,9 +1,7 @@
-skill:
-  backend: codex
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
+# End-to-end smoke eval for the `codex` backend.
+# The engine is a runtime axis, not a spec field — pick it when you run:
+#   caliper run tests/codex-smoke.eval.yaml --model codex
+skill: {}
 
 tasks:
   - name: Write hello to a file

--- a/tests/pi-smoke.eval.yaml
+++ b/tests/pi-smoke.eval.yaml
@@ -1,9 +1,7 @@
-skill:
-  backend: pi
-
-judge:
-  backend: claude-code
-  model: claude-haiku-4-5-20251001
+# End-to-end smoke eval for the `pi` backend.
+# The engine is a runtime axis, not a spec field — pick it when you run:
+#   caliper run tests/pi-smoke.eval.yaml --model pi
+skill: {}
 
 tasks:
   - name: Write hello to a file

--- a/tests/test_claude_judge.py
+++ b/tests/test_claude_judge.py
@@ -4,7 +4,7 @@ import subprocess
 
 from caliper.harness.base import ConversationTurn
 from caliper.judge.script_assert import EvalJudge
-from caliper.schema.spec import JudgeConfig, TaskSpec
+from caliper.schema.spec import TaskSpec
 
 
 def test_eval_judge_claude_code_invokes_claude_cli(monkeypatch, tmp_path) -> None:
@@ -21,7 +21,7 @@ def test_eval_judge_claude_code_invokes_claude_cli(monkeypatch, tmp_path) -> Non
 
     monkeypatch.setattr("caliper.judge.claude_code_judge.subprocess.run", fake_run)
 
-    result = EvalJudge(JudgeConfig(backend="claude", model="claude-test")).evaluate(
+    result = EvalJudge(backend="claude", model="claude-test").evaluate(
         task=TaskSpec(
             id="task-001",
             name="Claude judge",

--- a/tests/test_codex_judge.py
+++ b/tests/test_codex_judge.py
@@ -6,12 +6,12 @@ import subprocess
 from caliper.harness.base import ConversationTurn
 from caliper.judge.codex_judge import _extract_codex_error, evaluate_with_codex
 from caliper.judge.script_assert import EvalJudge
-from caliper.schema.spec import JudgeConfig, TaskSpec
+from caliper.schema.spec import TaskSpec
 
 
 def test_eval_judge_always_returns_eval_judge_instance() -> None:
     for backend in ("codex", "claude-code", "pi"):
-        judge = EvalJudge(JudgeConfig(backend=backend))
+        judge = EvalJudge(backend=backend)
         assert isinstance(judge, EvalJudge)
 
 
@@ -27,12 +27,12 @@ def test_eval_judge_expect_only_calls_llm(monkeypatch, tmp_path) -> None:
         lambda self, task, transcript, spec_dir: fake_eval(
             expect=task.expect,
             transcript=transcript,
-            model=self._config.model,
+            model=self._model,
             cwd=spec_dir,
         ),
     )
 
-    judge = EvalJudge(JudgeConfig(backend="codex", model="test-model"))
+    judge = EvalJudge(backend="codex", model="test-model")
     result = judge.evaluate(
         task=TaskSpec(id="t1", name="t", prompt="p", expect="should say hello"),
         transcript=[ConversationTurn(role="assistant", content="hello")],
@@ -46,7 +46,7 @@ def test_eval_judge_expect_only_calls_llm(monkeypatch, tmp_path) -> None:
 
 
 def test_eval_judge_assert_only_runs_script_no_llm(tmp_path) -> None:
-    judge = EvalJudge(JudgeConfig(backend="codex"))
+    judge = EvalJudge(backend="codex")
     result = judge.evaluate(
         task=TaskSpec(id="t2", name="t", prompt="p", assert_script="assert 1 == 1"),
         transcript=[],
@@ -60,7 +60,7 @@ def test_eval_judge_assert_only_runs_script_no_llm(tmp_path) -> None:
 
 
 def test_eval_judge_assert_failure_makes_overall_fail(tmp_path) -> None:
-    judge = EvalJudge(JudgeConfig(backend="codex"))
+    judge = EvalJudge(backend="codex")
     result = judge.evaluate(
         task=TaskSpec(
             id="t3", name="t", prompt="p", assert_script="assert False, 'nope'"
@@ -80,7 +80,7 @@ def test_eval_judge_both_checks_must_pass(monkeypatch, tmp_path) -> None:
         lambda self, task, transcript, spec_dir: (True, "LLM says yes", False),
     )
 
-    judge = EvalJudge(JudgeConfig(backend="codex"))
+    judge = EvalJudge(backend="codex")
     result = judge.evaluate(
         task=TaskSpec(
             id="t4",
@@ -108,7 +108,7 @@ def test_errored_autorater_dropped_when_assert_passes(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(
         "caliper.judge.script_assert.EvalJudge._llm_evaluate", _errored_llm
     )
-    judge = EvalJudge(JudgeConfig(backend="codex"))
+    judge = EvalJudge(backend="codex")
     result = judge.evaluate(
         task=TaskSpec(
             id="t", name="t", prompt="p", expect="x", assert_script="assert True"
@@ -128,7 +128,7 @@ def test_errored_autorater_does_not_override_failing_assert(
     monkeypatch.setattr(
         "caliper.judge.script_assert.EvalJudge._llm_evaluate", _errored_llm
     )
-    judge = EvalJudge(JudgeConfig(backend="codex"))
+    judge = EvalJudge(backend="codex")
     result = judge.evaluate(
         task=TaskSpec(
             id="t", name="t", prompt="p", expect="x", assert_script="assert False"
@@ -146,7 +146,7 @@ def test_judge_error_when_only_check_errors(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         "caliper.judge.script_assert.EvalJudge._llm_evaluate", _errored_llm
     )
-    judge = EvalJudge(JudgeConfig(backend="codex"))
+    judge = EvalJudge(backend="codex")
     result = judge.evaluate(
         task=TaskSpec(id="t", name="t", prompt="p", expect="x"),
         transcript=[],
@@ -213,7 +213,7 @@ def test_eval_judge_uses_codex_for_expect_when_configured(
 
     monkeypatch.setattr("caliper.judge.codex_judge.evaluate_with_codex", fake_eval)
 
-    judge = EvalJudge(JudgeConfig(backend="codex", model="test-model"))
+    judge = EvalJudge(backend="codex", model="test-model")
     result = judge.evaluate(
         task=TaskSpec(
             id="task-001",

--- a/tests/test_load_spec.py
+++ b/tests/test_load_spec.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from caliper.schema.spec import load_spec
+
+
+def _write(tmp_path, text: str):
+    p = tmp_path / "s.eval.yaml"
+    p.write_text(text)
+    return p
+
+
+_TASK = "tasks:\n  - name: t\n    prompt: p\n    assert: assert True\n"
+
+
+def test_load_spec_accepts_engineless_spec(tmp_path) -> None:
+    spec = load_spec(_write(tmp_path, "skill:\n  path: ./SKILL.md\n" + _TASK))
+    assert spec.skill.path == "./SKILL.md"
+    assert spec.tasks[0].id == "task-001"
+
+
+def test_load_spec_accepts_bare_agent(tmp_path) -> None:
+    spec = load_spec(_write(tmp_path, "skill: {}\n" + _TASK))
+    assert spec.skill.path is None
+
+
+@pytest.mark.parametrize(
+    "removed, needle",
+    [
+        ("skill:\n  path: ./SKILL.md\n  backend: codex\n", "skill.backend"),
+        ("skill:\n  path: ./SKILL.md\n  model: claude-sonnet-4-6\n", "skill.model"),
+        ("skill:\n  path: ./SKILL.md\njudge:\n  backend: codex\n", "judge"),
+    ],
+)
+def test_load_spec_rejects_removed_engine_keys(tmp_path, removed, needle) -> None:
+    with pytest.raises(ValueError) as exc:
+        load_spec(_write(tmp_path, removed + _TASK))
+    msg = str(exc.value)
+    assert needle in msg
+    # The error must point users at the runtime flags, not just say "unknown key".
+    assert "--model" in msg or "--judge-model" in msg

--- a/tests/test_pi_judge.py
+++ b/tests/test_pi_judge.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from caliper.harness.base import ConversationTurn
+from caliper.judge.pi_judge import evaluate_with_pi
+from caliper.judge.script_assert import EvalJudge
+from caliper.schema.spec import TaskSpec
+
+
+def _pi_stream(text: str) -> str:
+    """A minimal pi JSON event stream ending in an assistant message."""
+    return json.dumps(
+        {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+            },
+        }
+    )
+
+
+def test_pi_backend_is_a_valid_judge(monkeypatch, tmp_path) -> None:
+    """Regression: `--judge-model pi` must dispatch, not report 'Unknown judge backend'."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=_pi_stream('{"mode": "verdict", "passed": true, "reasoning": "ok"}'),
+            stderr="",
+        )
+
+    monkeypatch.setattr("caliper.judge.pi_judge.shutil.which", lambda _: "/usr/bin/pi")
+    monkeypatch.setattr("caliper.judge.pi_judge.subprocess.run", fake_run)
+
+    result = EvalJudge(backend="pi", model="claude-sonnet-4-6").evaluate(
+        task=TaskSpec(id="t1", name="t", prompt="p", expect="says ok"),
+        transcript=[ConversationTurn(role="assistant", content="ok")],
+        final_output="ok",
+        spec_dir=str(tmp_path),
+    )
+
+    assert result.passed is True
+    assert result.autorater_passed is True
+    # The judge model reached the CLI (backend:model form resolves through).
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-6"
+    assert "--print" in cmd and "--mode" in cmd
+
+
+def test_pi_judge_reports_cli_error_as_errored(monkeypatch, tmp_path) -> None:
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="not logged in")
+
+    monkeypatch.setattr("caliper.judge.pi_judge.shutil.which", lambda _: "/usr/bin/pi")
+    monkeypatch.setattr("caliper.judge.pi_judge.subprocess.run", fake_run)
+
+    passed, reasoning, errored = evaluate_with_pi(
+        expect="anything",
+        transcript=[],
+        model=None,
+        spec_dir=str(tmp_path),
+    )
+
+    assert passed is False
+    assert errored is True
+    assert "not logged in" in reasoning
+
+
+def test_pi_judge_missing_cli_errors(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("caliper.judge.pi_judge.shutil.which", lambda _: None)
+    monkeypatch.delenv("PI_CLI_PATH", raising=False)
+
+    passed, reasoning, errored = evaluate_with_pi(
+        expect="anything", transcript=[], model=None, spec_dir=str(tmp_path)
+    )
+
+    assert (passed, errored) == (False, True)
+    assert "pi CLI not found" in reasoning

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -26,7 +26,7 @@ def test_run_cli_forwards_options_to_run(monkeypatch, tmp_path) -> None:
     spec_file.write_text(
         """
 skill:
-  backend: codex
+  path: ./SKILL.md
 tasks:
   - name: One
     prompt: Do it
@@ -86,3 +86,71 @@ tasks:
     # Defaults flow through unchanged when the flag is omitted
     assert calls["timeout"] == 120
     assert calls["baseline"] is False
+    # Engine is resolved at the run seam and defaults to claude-code (ADR 0004)
+    assert calls["backend"] == "claude-code"
+    assert calls["model"] is None
+
+
+def test_run_cli_resolves_backend_and_judge_model_targets(
+    monkeypatch, tmp_path
+) -> None:
+    """--model and --judge-model accept a backend:model compound and split it."""
+    spec_file = tmp_path / "sample.eval.yaml"
+    spec_file.write_text(
+        "skill:\n  path: ./SKILL.md\n"
+        "tasks:\n  - name: One\n    prompt: Do it\n    assert: assert True\n"
+    )
+
+    harness_args = {}
+    judge_args = {}
+
+    def fake_run(**kwargs):
+        return RunResults(
+            run=RunMeta(
+                spec="sample",
+                timestamp=datetime(2026, 7, 3, tzinfo=timezone.utc),
+                k=kwargs["k"],
+                backend=kwargs["backend"],
+                model=kwargs["model"],
+            ),
+            skill_snapshot=SkillSnapshot(path=""),
+            task_results=[],
+            aggregate=AggregateScore(avg_pass_at_k=0.0, per_task=[]),
+        )
+
+    def fake_get_harness(backend, model):
+        harness_args["backend"], harness_args["model"] = backend, model
+        return object()
+
+    def fake_eval_judge(backend, model):
+        judge_args["backend"], judge_args["model"] = backend, model
+        return object()
+
+    monkeypatch.setattr("caliper.commands.run.get_harness", fake_get_harness)
+    monkeypatch.setattr("caliper.commands.run.EvalJudge", fake_eval_judge)
+    monkeypatch.setattr(
+        "caliper.commands.run.make_progress", lambda *a, **k: (_Progress(), {})
+    )
+    monkeypatch.setattr("caliper.commands.run.update_progress", lambda *a, **k: None)
+    monkeypatch.setattr("caliper.commands.run.print_banner", lambda *a, **k: None)
+    monkeypatch.setattr("caliper.commands.run.print_results", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "caliper.commands.run.save_results", lambda *a, **k: tmp_path / "r.json"
+    )
+    monkeypatch.setattr("caliper.commands.run.run", fake_run)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(spec_file),
+            "--model",
+            "codex:gpt-5-codex",
+            "--judge-model",
+            "pi:claude-sonnet-4-6",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert harness_args == {"backend": "codex", "model": "gpt-5-codex"}
+    assert judge_args == {"backend": "pi", "model": "claude-sonnet-4-6"}

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -127,7 +127,7 @@ class JudgeErrorThenPass(Judge):
 
 def _one_task_spec() -> EvalSpec:
     return EvalSpec(
-        skill=SkillConfig(backend="codex"),
+        skill=SkillConfig(),
         tasks=[
             TaskSpec(
                 id="task-001",
@@ -141,7 +141,7 @@ def _one_task_spec() -> EvalSpec:
 
 def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
     spec_path = tmp_path / "failing.eval.yaml"
-    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    spec_path.write_text("skill: {}\ntasks: []\n")
     judge = RecordingJudge()
     spec = _one_task_spec()
 
@@ -169,7 +169,7 @@ def test_runner_fails_attempt_when_harness_exits_nonzero(tmp_path) -> None:
 
 def test_runner_runs_all_infra_failures_by_default(tmp_path) -> None:
     spec_path = tmp_path / "failing.eval.yaml"
-    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    spec_path.write_text("skill: {}\ntasks: []\n")
     harness = InfraErrorHarness()
 
     results = run(
@@ -190,7 +190,7 @@ def test_runner_runs_all_infra_failures_by_default(tmp_path) -> None:
 
 def test_runner_fail_fast_stops_after_unusable_threshold(tmp_path) -> None:
     spec_path = tmp_path / "failing.eval.yaml"
-    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    spec_path.write_text("skill: {}\ntasks: []\n")
     harness = InfraErrorHarness()
 
     results = run(
@@ -213,7 +213,7 @@ def test_runner_fail_fast_stops_after_unusable_threshold(tmp_path) -> None:
 
 def test_runner_fail_fast_does_not_reset_streak_on_judge_error(tmp_path) -> None:
     spec_path = tmp_path / "failing.eval.yaml"
-    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    spec_path.write_text("skill: {}\ntasks: []\n")
     harness = MixedOutcomeHarness()
 
     results = run(
@@ -240,7 +240,7 @@ def test_runner_fail_fast_does_not_reset_streak_on_judge_error(tmp_path) -> None
 
 def test_runner_emits_task_done_when_fail_fast_stops_early(tmp_path) -> None:
     spec_path = tmp_path / "failing.eval.yaml"
-    spec_path.write_text("skill:\n  backend: codex\ntasks: []\n")
+    spec_path.write_text("skill: {}\ntasks: []\n")
     finished_tasks = []
 
     run(


### PR DESCRIPTION
Closes #35.

## Summary

The engine (backend + model), for both the skill-under-test and the judge, is now a **runtime axis chosen at invocation**, not a field baked into the `.eval.yaml`. A spec describes *what* is tested and *how* success is judged (`skill.path`, prompts, `expect:`/`assert:`, `sandbox`); the agent that runs and grades it comes from `--model` / `--judge-model`, defaulting to `claude-code`. The actual engine is still written into each run's `RunMeta`, so de-pinning costs no reproducibility — a pinned model name in a "spec" just aged badly and blocked pointing the same eval at a new agent.

## What changed

- **Schema** (`caliper/schema/spec.py`): removed `backend`/`model` from `SkillConfig`; deleted `JudgeConfig` and the `judge:` key; added `DEFAULT_BACKEND`. `load_spec` now hard-fails a spec that still pins `skill.backend` / `skill.model` / `judge:` with a message naming the key and pointing at the flag — a clean break in the spirit of ADR 0003.
- **Run seam** (`commands/run.py`, `runner.py`, `judge/script_assert.py`): `(backend, model)` and the judge engine are resolved from the flags via `parse_target`, defaulting to `claude-code`; `EvalJudge` takes `backend`/`model` directly. `RunMeta` unchanged.
- **Wizard** (`wizard.py`, `commands/new.py`): dropped all four engine prompts and `new --backend`; runtime engine selection is a hint in the "next steps" text.
- **Docs**: README, both `REFERENCE.md` copies, grill-skill `REFERENCE.md`, packaged `SKILL.md`, the starter-pack, and every example/smoke `.eval.yaml` updated to the engineless format.

## Two fixes found while wiring this up

- **`pi` can now be a judge.** The judge dispatcher only handled `codex`/`claude-code`, so `--judge-model pi` errored with `Unknown judge backend: 'pi'` despite the docs listing pi as valid. Added `caliper/judge/pi_judge.py` and the `pi` case.
- **`--judge-model backend:model` verified.** Already resolved correctly through `parse_target`; added a regression test rather than changing behavior.

## Migration

A spec that still pins the removed keys fails fast:

```
Invalid spec: backend/model are no longer spec fields — the engine is chosen at
runtime (default: claude-code). Delete these key(s) from the spec:
  - skill.backend (engine now comes from --model)
  - judge (engine now comes from --judge-model)
```

## Testing

- 116 tests pass; `ruff format --check` / `ruff check` clean.
- New `tests/test_load_spec.py` (accept/reject), `tests/test_pi_judge.py` (pi judge dispatch + errors), extended `tests/test_run_cli.py` (backend:model splitting for both flags).
- `tests/test_install_skill.py` green — packaged skill still in sync.