### PR TITLE
docs: emphasize dead-simple CLI in README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Two commands to know whether your skill actually works. Install it, run it _k_ times, and get a pass@k score you can track — with proof the skill beats the base agent underneath. Works with the agent you already use: Claude Code, Codex, or Pi.
 
-**Install the skills:**
+**Install Caliper:**
 
 ```bash
 npx skills@latest add edonadei/caliper

--- a/README.md
+++ b/README.md
@@ -4,13 +4,21 @@
 [![Python](https://img.shields.io/pypi/pyversions/caliper-eval.svg)](https://pypi.org/project/caliper-eval/)
 [![Skills](https://skills.sh/b/edonadei/caliper)](https://skills.sh/edonadei/caliper)
 
-Run your skill _k_ times, get a pass@k score you can track and compare, and prove the skill beats the base agent. Works with the agent you already use — Claude Code, Codex, or Pi.
+Two commands to know whether your skill actually works. Install it, run it _k_ times, and get a pass@k score you can track — with proof the skill beats the base agent underneath. Works with the agent you already use: Claude Code, Codex, or Pi.
+
+**Install the skills:**
 
 ```bash
 npx skills@latest add edonadei/caliper
 ```
 
-Run each task with and without the skill, and Caliper shows you the difference:
+**Measure a skill:**
+
+```bash
+caliper run my-skill.eval.yaml --k 3 --baseline
+```
+
+That's the whole loop. Caliper runs each task with and without the skill, and shows you the difference:
 
 ```text
 ID      Task                              k (3)   pass@k

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/caliper-eval.svg)](https://pypi.org/project/caliper-eval/)
 [![Skills](https://skills.sh/b/edonadei/caliper)](https://skills.sh/edonadei/caliper)
 
-Know whether your skill actually works. Write a short spec of what "good" looks like, run it _k_ times, and get a pass@k score you can track — with proof the skill beats the base agent underneath. Works with the agent you already use: Claude Code, Codex, or Pi.
+Know whether your skill actually works. Write a short spec of what "good" looks like, run it _k_ times, and get a pass@k score you can track. Caliper also runs the tasks without the skill, so you can see whether it's the skill or the base agent doing the work. Works with the agent you already use: Claude Code, Codex, or Pi.
 
 **Install Caliper:**
 
@@ -18,7 +18,7 @@ npx skills@latest add edonadei/caliper
 caliper run my-skill.eval.yaml --k 3 --baseline
 ```
 
-That command reads a spec — a few lines of YAML describing what "working" means, which you hand-write or have `/grill-skill` generate for you. Caliper runs each task with and without the skill, and shows you the difference:
+That command reads a spec: a few lines of YAML describing what "working" means, which you hand-write or have `/grill-skill` generate for you. Caliper runs each task with and without the skill, then shows you the difference:
 
 ```text
 ID      Task                              k (3)   pass@k

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/caliper-eval.svg)](https://pypi.org/project/caliper-eval/)
 [![Skills](https://skills.sh/b/edonadei/caliper)](https://skills.sh/edonadei/caliper)
 
-Two commands to know whether your skill actually works. Install it, run it _k_ times, and get a pass@k score you can track — with proof the skill beats the base agent underneath. Works with the agent you already use: Claude Code, Codex, or Pi.
+Know whether your skill actually works. Write a short spec of what "good" looks like, run it _k_ times, and get a pass@k score you can track — with proof the skill beats the base agent underneath. Works with the agent you already use: Claude Code, Codex, or Pi.
 
 **Install Caliper:**
 
@@ -12,13 +12,13 @@ Two commands to know whether your skill actually works. Install it, run it _k_ t
 npx skills@latest add edonadei/caliper
 ```
 
-**Measure a skill:**
+**Measure your skill:**
 
 ```bash
 caliper run my-skill.eval.yaml --k 3 --baseline
 ```
 
-That's the whole loop. Caliper runs each task with and without the skill, and shows you the difference:
+That command reads a spec — a few lines of YAML describing what "working" means, which you hand-write or have `/grill-skill` generate for you. Caliper runs each task with and without the skill, and shows you the difference:
 
 ```text
 ID      Task                              k (3)   pass@k


### PR DESCRIPTION
## What

Reworks the README hero to make the *dead-simple* nature of Caliper the headline, rather than something the reader has to infer.

## Why

The old hero jumped from the install line straight to a results table — the reader never saw the single command that produced it, so the simplicity was implied, not shown.

## Changes

- **New lead:** "Two commands to know whether your skill actually works." Quantifies the effort up front — a count is proof where "simple" is just a claim.
- **Install / Measure labels** with the `caliper run my-skill.eval.yaml --k 3 --baseline` one-liner surfaced right in the hero, so the whole loop is visible above the fold.
- **"That's the whole loop."** closes the pattern so there's no hidden step 3.
- Keeps the `npx skills` installer first, as before.

## Note on the two paths

`npx skills add` is Path A (agentic) and bare `caliper run` is Path B (`pipx install caliper-eval`). The hero frames them as two *tastes* of simplicity ("Install the skills" / "Measure a skill") rather than a strict do-these-in-order sequence, to avoid implying `caliper` is on PATH straight after the npx install.