### PR TITLE
docs: relabel hero install steps to match what they do

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 Know whether your skill actually works. Write a short spec of what "good" looks like, run it _k_ times, and get a pass@k score you can track. Caliper also runs the tasks without the skill, so you can see whether it's the skill or the base agent doing the work. Works with the agent you already use: Claude Code, Codex, or Pi.
 
-**Install Caliper:**
+**Teach your agent to evaluate:**
 
 ```bash
 npx skills@latest add edonadei/caliper
 ```
 
-**Measure your skill:**
+**Or run it yourself:**
 
 ```bash
 caliper run my-skill.eval.yaml --k 3 --baseline


### PR DESCRIPTION
## What

Follow-up to #42. Fixes a misleading label in the README hero.

## Why

`npx skills@latest add edonadei/caliper` installs the **agent skills** (`evaluate-skill`, `grill-skill`), not a `caliper` binary. Labeling it **"Install Caliper"** promised something the command doesn't deliver — and the very next block is bare `caliper run`, which comes from a *different* install (`pipx install caliper-eval`). So the label pointed at the wrong artifact and the two blocks read as one sequence when they're actually two separate entry points.

## Change

- **"Install Caliper"** → **"Teach your agent to evaluate"** — describes what the npx command actually does (adds the skills to your agent) and leads with the benefit.
- **"Measure your skill"** → **"Or run it yourself"** — the "Or" frames the CLI line as an alternative path, not step 2. This mirrors the Quick start's Path A (agentic) / Path B (CLI) split directly below.