### PR TITLE
Add hermes backend and record model/judge provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If an `.eval.yaml` already exists next to your skill, `grill-skill` reads the ex
 | Term | What it is |
 |---|---|
 | **Spec** | A `.eval.yaml` file that describes the skill, judge, and tasks to run |
-| **Backend** | The CLI agent that executes the skill (`claude-code`, `codex`, `pi`) |
+| **Backend** | The CLI agent that executes the skill (`claude-code`, `codex`, `pi`, `hermes`) |
 | **Judge** | What decides pass/fail — an LLM reading the transcript (`expect:`), Python assertions (`assert:`), or both |
 | **pass@k** | Reliability score: run k times, measure how often the skill succeeds |
 | **Baseline** | Re-run the same tasks without the skill to prove the skill is doing the work |
@@ -241,6 +241,7 @@ caliper run my-skill.eval.yaml --model pi --judge-model claude-code
 | `claude-code` | Claude Code CLI installed and authenticated | Testing Claude Code slash-command skills |
 | `codex` | Codex CLI installed (`npm install -g @openai/codex`) | Testing Codex skills |
 | `pi` | pi CLI installed (`npm install -g @earendil-works/pi-coding-agent`) and authenticated | Testing pi skills (agentskills.io) |
+| `hermes` | Hermes Agent CLI installed and authenticated (Nous Research) | Testing skills on Hermes; `hermes:<provider>/<model>` selects the model |
 
 Caliper runs skills only through CLI agents — every backend can actually load and run a skill. There is no direct-API backend: to run against API-priced billing, configure one of these CLIs with an API key (e.g. `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) rather than selecting a separate backend.
 
@@ -267,6 +268,15 @@ pi   # then authenticate (e.g. /login for a subscription provider, or set the pr
 ```
 
 `--model pi` runs `pi --print --mode json` and loads the skill natively via pi's `--skill` flag (the agentskills.io standard). It reuses your `~/.pi/agent` auth and settings — the `:model` half of `--model pi:<model>` overrides pi's configured default when set. Set `PI_CLI_PATH` to force a specific binary. Note: pi's built-in default provider is `google`, so running `--model pi` with no model relies on your pi config to resolve a provider you are authenticated for.
+
+### Hermes setup
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+hermes login   # authenticate; pick a default model/provider you have credits for
+```
+
+Hermes is a stateful, always-on agent (persistent memory, a persona, auto-generated skills), so Caliper **normalizes it to a neutral agent** to keep its pass@k apples-to-apples with the other backends: every attempt runs in an isolated `HERMES_HOME` seeded with your `~/.hermes` auth/config only (never `SOUL.md`/`MEMORY.md`) and with `--ignore-rules`, and the skill-under-test is staged as the sole local skill. `--model hermes` runs `hermes -z` (oneshot) then `hermes sessions export` to recover the full tool-call trajectory; `--model hermes:<provider>/<model>` (e.g. `hermes:anthropic/claude-sonnet-4.6`) selects the model, otherwise your `~/.hermes/config.yaml` default is used — point it at a provider you have credits for. Set `HERMES_CLI_PATH` to force a specific binary. Hermes updates itself (`hermes update`), so it is not part of `caliper update-cli`.
 
 Check installed CLI versions:
 
@@ -407,7 +417,7 @@ caliper run my-skill.eval.yaml --model claude-sonnet-4-6
 caliper run my-skill.eval.yaml --model codex --judge-model claude-code:claude-haiku-4-5-20251001
 ```
 
-Accepted backends: `claude-code`, `codex`, `pi` (alias: `claude` → `claude-code`). The actual engine used is recorded in each saved run's `RunMeta`, so results stay traceable even though the spec doesn't pin it.
+Accepted backends: `claude-code`, `codex`, `pi`, `hermes` (alias: `claude` → `claude-code`). The actual engine used is recorded in each saved run's `RunMeta` — the skill `backend`/`model`, and the `judge_backend`/`judge_model` that graded it — so results stay traceable even though the spec doesn't pin it. When you don't name a model and the CLI uses its own default, `RunMeta` records the concrete model the agent resolved rather than a bare "default", wherever the backend reports it — the skill model from hermes' session export, and the `judge_model` from the `claude-code` judge's JSON output. `judge_model` stays empty for an `assert:`-only run, where no LLM judge fired.
 
 ---
 

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -145,6 +145,8 @@ def run_cmd(
                 judge=judge,
                 backend=backend,
                 model=skill_model,
+                judge_backend=judge_backend,
+                judge_model=judge_model_name,
                 k=k,
                 workers=workers,
                 timeout=timeout,

--- a/caliper/harness/__init__.py
+++ b/caliper/harness/__init__.py
@@ -20,6 +20,10 @@ def get_harness(backend: str, model: str | None = None) -> HarnessBackend:
             from caliper.harness.pi import PiHarness
 
             return PiHarness(model=model)
+        case "hermes":
+            from caliper.harness.hermes import HermesHarness
+
+            return HermesHarness(model=model)
         case _:
             raise ValueError(f"Unknown backend: {backend!r}")
 

--- a/caliper/harness/base.py
+++ b/caliper/harness/base.py
@@ -33,6 +33,11 @@ class AttemptResult:
     timed_out: bool = False
     cheated: bool = False
     cheat_evidence: list[str] = field(default_factory=list)
+    # The concrete model the agent actually resolved for this attempt, when the
+    # backend can report it (e.g. hermes echoes it in its session export). Lets a
+    # run record the real model even when none was passed and the CLI's own
+    # default was used. ``None`` when the backend cannot report it.
+    resolved_model: str | None = None
 
 
 @dataclass
@@ -166,6 +171,7 @@ class CliHarness(HarnessBackend):
             duration_seconds=duration,
             error=self._error_field(proc, final_output),
             timed_out=proc.timed_out,
+            resolved_model=self._resolved_model(proc, ctx),
         )
 
     # --- hooks a backend implements ---------------------------------------
@@ -213,6 +219,15 @@ class CliHarness(HarnessBackend):
 
     def _error_field(self, proc: ProcessResult, final_output: str) -> str | None:
         return proc.error
+
+    def _resolved_model(self, proc: ProcessResult, ctx: RunContext) -> str | None:
+        """The concrete model the agent used, if the backend can report it.
+
+        Default: the model we requested (``None`` when we let the CLI pick its
+        own default and cannot observe what it chose). A backend that surfaces
+        the resolved model in its output overrides this.
+        """
+        return ctx.model
 
     # --- shared machinery -------------------------------------------------
 

--- a/caliper/harness/hermes.py
+++ b/caliper/harness/hermes.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Callable
+
+from caliper.harness.base import (
+    ConversationTurn,
+    CliHarness,
+    HarnessConfigurationError,
+    ProcessResult,
+    RunContext,
+)
+
+# Config files copied verbatim into the isolated HERMES_HOME so the agent can
+# authenticate. Deliberately excludes SOUL.md (persona) and MEMORY.md/USER.md:
+# Hermes is a *stateful* agent, and admitting it as an apples-to-apples flat
+# backend means stripping it to a neutral agent (see
+# docs/adr/0005-hermes-backend-normalized-to-neutral-agent.md).
+_SEED_FILES = ("auth.json", "config.yaml", ".env")
+
+
+class HermesHarness(CliHarness):
+    """CLI-subprocess backend for Nous Research's `hermes` coding agent.
+
+    Hermes' non-interactive `-z/--oneshot` mode prints only the final response
+    text, so the full trajectory (tool calls + results, needed by `expect:`
+    autoraters) is recovered in a second step: after the run we `hermes sessions
+    export` the single session persisted in the isolated home, whose JSONL is a
+    standard OpenAI-style transcript. Both steps run in one shell invocation so
+    the template's single timeout covers the expensive oneshot.
+
+    Hermes is normalized to a neutral agent on every attempt: an isolated
+    ``HERMES_HOME`` seeded with auth/config only (no persona/memory) and
+    ``--ignore-rules`` on the command, so the only skill in play is the
+    skill-under-test staged into ``HERMES_HOME/skills/<name>``.
+    """
+
+    def __init__(self, model: str | None = None) -> None:
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "hermes"
+
+    def _ensure_ready(self, ctx: RunContext) -> None:
+        if not self._cli_available():
+            raise HarnessConfigurationError(
+                "hermes CLI is not available for the `hermes` backend.\n\n"
+                "Install the Hermes Agent (`curl -fsSL "
+                "https://hermes-agent.nousresearch.com/install.sh | bash`) and "
+                "authenticate it (`hermes login`), or set `HERMES_CLI_PATH` to "
+                "the hermes binary, then rerun caliper."
+            )
+
+    def _prepare(self, ctx: RunContext) -> None:
+        # Isolate Hermes' whole home per attempt (parallel-safe; never mutates
+        # the user's real ~/.hermes). Seeding only auth/config — not SOUL.md or
+        # MEMORY.md — is what neutralizes the agent; --ignore-rules on the
+        # command completes the strip.
+        hermes_home = Path(ctx.isolated_home) / ".hermes"
+        real_home = Path.home() / ".hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        for filename in _SEED_FILES:
+            src = real_home / filename
+            if src.exists():
+                shutil.copy2(src, hermes_home / filename)
+        ctx.extras["hermes_home"] = str(hermes_home)
+
+        skill_name = self._stage_skill(ctx, hermes_home)
+        if skill_name:
+            ctx.extras["skill_name"] = skill_name
+
+    def _stage_skill(self, ctx: RunContext, hermes_home: Path) -> str | None:
+        """Copy the already-staged skill into ``HERMES_HOME/skills/<name>``.
+
+        The runner has already staged the skill directory (cheat surfaces
+        excluded) into ``isolated_home``; we re-stage that sanitized copy as a
+        local Hermes skill so ``--skills <name>`` loads it natively — preserving
+        progressive disclosure (Hermes reads the body on demand via its
+        ``skill_view`` tool). Copying from the staged copy, not the original,
+        inherits the runner's forbidden-file exclusions.
+        """
+        if not ctx.skill_path:
+            return None
+        staged = Path(ctx.isolated_home) / "SKILL.md"
+        if not staged.exists():
+            return None
+
+        name = self._skill_name(staged.read_text()) or "skill-under-test"
+        dst = hermes_home / "skills" / name
+        dst.mkdir(parents=True, exist_ok=True)
+        home = Path(ctx.isolated_home)
+        for item in sorted(home.rglob("*")):
+            if not item.is_file():
+                continue
+            rel = item.relative_to(home)
+            # Skip the Hermes home we are seeding inside the same dir.
+            if rel.parts and rel.parts[0] == ".hermes":
+                continue
+            target = dst / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, target)
+        return name
+
+    def _skill_name(self, skill_text: str) -> str | None:
+        match = re.search(r"^---\n(.*?)\n---", skill_text, flags=re.DOTALL)
+        if not match:
+            return None
+        name = re.search(r"^name:\s*(.+?)\s*$", match.group(1), flags=re.MULTILINE)
+        return name.group(1).strip() if name else None
+
+    def _command(
+        self, ctx: RunContext
+    ) -> tuple[list[str], str | None, Callable[[], None] | None]:
+        # One shell invocation: run oneshot (its final text and any error go to
+        # stderr, where _diagnose reads them), then export the single persisted
+        # session as JSONL on stdout for _parse_stream. `exit $rc` propagates the
+        # oneshot's exit code so a failed run is classified as infra_error.
+        skill = ctx.extras.get("skill_name")
+        skills_arg = ' --skills "$CALIPER_SKILL"' if skill else ""
+        script = (
+            f'"$CALIPER_HERMES" -z "$CALIPER_PROMPT"{skills_arg} --ignore-rules 1>&2\n'
+            "rc=$?\n"
+            '"$CALIPER_HERMES" sessions export --source cli - 2>/dev/null\n'
+            "exit $rc\n"
+        )
+        return ["/bin/sh", "-c", script], None, None
+
+    def _environment(self, ctx: RunContext) -> dict[str, str]:
+        path = os.environ.get("PATH", "")
+        if ctx.extra_path:
+            path = os.pathsep.join(ctx.extra_path) + os.pathsep + path
+
+        env = {
+            "HOME": ctx.isolated_home,
+            "PATH": path,
+            "HERMES_HOME": ctx.extras["hermes_home"],
+            "CALIPER_HERMES": self._hermes_command() or "hermes",
+            "CALIPER_PROMPT": ctx.prompt,
+        }
+        skill = ctx.extras.get("skill_name")
+        if skill:
+            env["CALIPER_SKILL"] = skill
+        return self._passthrough(env, ("LANG", "LC_ALL", "TERM", "TMPDIR"))
+
+    def _cli_available(self) -> bool:
+        hermes = self._hermes_command()
+        return hermes is not None and self._version_ok(
+            hermes, timeout=15, args=("--version",)
+        )
+
+    def _hermes_command(self) -> str | None:
+        configured = os.environ.get("HERMES_CLI_PATH")
+        if configured and Path(configured).exists():
+            return configured
+        return shutil.which("hermes")
+
+    def _parse_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]:
+        """Parse a `hermes sessions export` record into turns.
+
+        The export is a single JSON object with a ``messages`` array of
+        OpenAI-style messages: ``user``/``assistant``/``tool`` roles, with an
+        assistant's ``tool_calls[].function`` carrying the call and a ``tool``
+        message carrying the result (linked by ``tool_call_id``).
+        """
+        record = self._load_export(stdout)
+        if record is None:
+            return [], ""
+
+        transcript: list[ConversationTurn] = []
+        final_output = ""
+        for message in record.get("messages", []):
+            if not isinstance(message, dict):
+                continue
+            role = message.get("role")
+            content = message.get("content")
+            text = content if isinstance(content, str) else ""
+
+            if role == "assistant":
+                if text.strip():
+                    transcript.append(ConversationTurn(role="assistant", content=text))
+                    final_output = text
+                for call in message.get("tool_calls") or []:
+                    turn = self._tool_use_turn(call)
+                    if turn is not None:
+                        transcript.append(turn)
+            elif role == "tool":
+                transcript.append(
+                    ConversationTurn(
+                        role="tool_result",
+                        content=text,
+                        tool_output=text,
+                        tool_name=message.get("tool_name"),
+                    )
+                )
+            elif role == "user":
+                if text.strip():
+                    transcript.append(ConversationTurn(role="user", content=text))
+
+        if not final_output:
+            for turn in reversed(transcript):
+                if turn.role == "assistant" and turn.content:
+                    final_output = turn.content
+                    break
+
+        return transcript, final_output
+
+    def _load_export(self, stdout: str) -> dict | None:
+        """Return the export record, tolerating extra non-JSON lines."""
+        stripped = stdout.strip()
+        if not stripped:
+            return None
+        try:
+            obj = json.loads(stripped)
+            return obj if isinstance(obj, dict) else None
+        except json.JSONDecodeError:
+            pass
+        for line in stripped.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict) and "messages" in obj:
+                return obj
+        return None
+
+    def _tool_use_turn(self, call: object) -> ConversationTurn | None:
+        if not isinstance(call, dict):
+            return None
+        function = call.get("function")
+        if not isinstance(function, dict):
+            return None
+        tool_name = function.get("name") or "tool"
+        tool_input = self._parse_arguments(function.get("arguments"))
+        return ConversationTurn(
+            role="tool_use",
+            content=f"[tool: {tool_name}]",
+            tool_name=tool_name,
+            tool_input=tool_input,
+        )
+
+    def _parse_arguments(self, arguments: object) -> dict | None:
+        if isinstance(arguments, dict):
+            return arguments
+        if isinstance(arguments, str) and arguments.strip():
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError:
+                return {"raw": arguments}
+            return parsed if isinstance(parsed, dict) else {"raw": arguments}
+        return None
+
+    def _resolved_model(self, proc: ProcessResult, ctx: RunContext) -> str | None:
+        # Hermes echoes the concrete model in its session export, so we record
+        # what actually ran even when no model was passed and the config default
+        # was used. Fall back to the requested model if the export lacks it.
+        record = self._load_export(proc.stdout)
+        if record:
+            model = record.get("model")
+            if isinstance(model, str) and model:
+                return model
+        return ctx.model
+
+    def _error_field(self, proc: ProcessResult, final_output: str) -> str | None:
+        # The oneshot's final text is routed to stderr, so stderr is only an
+        # error signal when the run itself failed.
+        if proc.timed_out:
+            return "timeout"
+        if proc.returncode != 0:
+            return proc.stderr or None
+        return None
+
+    def _diagnose(self, proc: ProcessResult, final_output: str) -> str | None:
+        if proc.returncode == 0:
+            return None
+
+        text = "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
+        if not text:
+            return None
+        lowered = text.lower()
+
+        provider_markers = (
+            "no api key",
+            "missing api key",
+            "no credentials",
+            "auth is missing",
+            "access_token",
+            "out of extra usage",
+            "insufficient credits",
+            "no credits",
+            "quota",
+        )
+        if any(marker in lowered for marker in provider_markers):
+            return (
+                "hermes cannot run with the current provider/credential "
+                "configuration.\n\n"
+                "Caliper copies your `~/.hermes` auth and config into an isolated "
+                "home and runs `hermes -z`. The hermes CLI returned:\n"
+                f"  {text[:500]}\n\n"
+                "Make sure `~/.hermes/config.yaml`'s default model/provider points "
+                "at a provider you have credits for (an earlier default may have "
+                "gone stale), verify `hermes -z 'Reply OK'` works in your normal "
+                "shell, then rerun caliper."
+            )
+
+        auth_markers = (
+            "401",
+            "unauthorized",
+            "not logged in",
+            "please login",
+            "please run /login",
+            "authentication",
+            "invalid api key",
+            "subscription",
+        )
+        if any(marker in lowered for marker in auth_markers):
+            return (
+                "hermes cannot run with the current authentication "
+                "configuration.\n\n"
+                "Caliper drives the local hermes CLI and reuses its `~/.hermes` "
+                "credentials. The hermes CLI returned:\n"
+                f"  {text[:500]}\n\n"
+                "Authenticate hermes (`hermes login`), verify `hermes -z 'Reply "
+                "OK'` works in your normal shell, then rerun caliper."
+            )
+
+        return None

--- a/caliper/judge/base.py
+++ b/caliper/judge/base.py
@@ -19,6 +19,10 @@ class JudgeResult:
     # autorater response, or the judge call threw). Distinct from a `passed`
     # verdict of False, which is a genuine task failure.
     errored: bool = False
+    # The concrete model the autorater used, when the judge CLI reports it (e.g.
+    # claude-code echoes it in its JSON output). ``None`` when no LLM autorater
+    # ran (assert-only task) or the backend does not surface the model.
+    resolved_model: str | None = None
 
 
 class Judge(ABC):

--- a/caliper/judge/claude_code_judge.py
+++ b/caliper/judge/claude_code_judge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 
@@ -19,16 +20,17 @@ def evaluate_with_claude_code(
     transcript: list[ConversationTurn],
     model: str | None,
     spec_dir: str,
-) -> tuple[bool, str, bool]:
+) -> tuple[bool, str, bool, str | None]:
     user_msg = _USER_TMPL.format(
         expect=expect,
         transcript=_format_transcript(transcript),
     )
     prompt = f"{_SYSTEM}\n\n{user_msg}"
-    raw, error = _run_claude_code(prompt, model)
+    raw, resolved_model, error = _run_claude_code(prompt, model)
     if error:
-        return False, error, True
-    return _parse_rich_response(raw, spec_dir)
+        return False, error, True, resolved_model
+    passed, reasoning, errored = _parse_rich_response(raw, spec_dir)
+    return passed, reasoning, errored, resolved_model
 
 
 def _judge_env() -> dict[str, str]:
@@ -39,8 +41,12 @@ def _judge_env() -> dict[str, str]:
     return env
 
 
-def _run_claude_code(prompt: str, model: str | None) -> tuple[str, str | None]:
-    cmd = ["claude", "-p", prompt, "--output-format", "text"]
+def _run_claude_code(
+    prompt: str, model: str | None
+) -> tuple[str, str | None, str | None]:
+    # JSON output (over plain text) so we can read the *concrete* model Claude
+    # used — its verdict text lives in `.result` and the model in `.modelUsage`.
+    cmd = ["claude", "-p", prompt, "--output-format", "json"]
     if model:
         cmd += ["--model", model]
 
@@ -52,12 +58,38 @@ def _run_claude_code(prompt: str, model: str | None) -> tuple[str, str | None]:
             timeout=60,
             env=_judge_env(),
         )
-        raw = proc.stdout.strip()
     except subprocess.TimeoutExpired:
-        return "", "Judge timed out."
+        return "", model, "Judge timed out."
+
+    raw, resolved_model = _extract_verdict_and_model(proc.stdout, model)
 
     if raw.startswith("```"):
         lines = raw.splitlines()
         raw = "\n".join(line for line in lines if not line.startswith("```")).strip()
 
-    return raw, None
+    return raw, resolved_model, None
+
+
+def _extract_verdict_and_model(
+    stdout: str, requested_model: str | None
+) -> tuple[str, str | None]:
+    """Pull the verdict text and concrete model from Claude's JSON envelope.
+
+    Falls back to treating stdout as the raw verdict (and the requested model)
+    if the envelope is missing or unparseable, so a CLI change can't break the
+    judge outright.
+    """
+    stripped = stdout.strip()
+    try:
+        envelope = json.loads(stripped)
+    except json.JSONDecodeError:
+        return stripped, requested_model
+    if not isinstance(envelope, dict):
+        return stripped, requested_model
+
+    verdict = str(envelope.get("result", "")).strip() or stripped
+    model_usage = envelope.get("modelUsage")
+    resolved = None
+    if isinstance(model_usage, dict) and model_usage:
+        resolved = next(iter(model_usage))
+    return verdict, resolved or requested_model

--- a/caliper/judge/codex_judge.py
+++ b/caliper/judge/codex_judge.py
@@ -25,7 +25,7 @@ def evaluate_with_codex(
     model: str | None,
     cwd: str,
     timeout: int = 60,
-) -> tuple[bool, str, bool]:
+) -> tuple[bool, str, bool, str | None]:
     user_msg = _USER_TMPL.format(
         expect=expect,
         transcript=_format_transcript(transcript),
@@ -33,9 +33,12 @@ def evaluate_with_codex(
     prompt = f"{_SYSTEM}\n\n{user_msg}"
     raw, error = _run_codex(prompt, model, cwd, timeout)
     if error:
-        return False, error, True
+        return False, error, True, model
 
-    return _parse_rich_response(_strip_markdown_fence(raw), cwd)
+    passed, reasoning, errored = _parse_rich_response(_strip_markdown_fence(raw), cwd)
+    # Codex's judge invocation doesn't surface the resolved model, so we can only
+    # report the one that was requested (None when its own default was used).
+    return passed, reasoning, errored, model
 
 
 def _run_codex(

--- a/caliper/judge/hermes_judge.py
+++ b/caliper/judge/hermes_judge.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from caliper.harness.base import ConversationTurn
+from caliper.judge.script_assert import (
+    _SYSTEM,
+    _USER_TMPL,
+    _format_transcript,
+    _parse_rich_response,
+)
+
+
+def evaluate_with_hermes(
+    *,
+    expect: str,
+    transcript: list[ConversationTurn],
+    model: str | None,
+    spec_dir: str,
+    timeout: int = 60,
+) -> tuple[bool, str, bool, str | None]:
+    user_msg = _USER_TMPL.format(
+        expect=expect,
+        transcript=_format_transcript(transcript),
+    )
+    prompt = f"{_SYSTEM}\n\n{user_msg}"
+    raw, error = _run_hermes(prompt, model, spec_dir, timeout)
+    if error:
+        return False, error, True, model
+    passed, reasoning, errored = _parse_rich_response(
+        _strip_markdown_fence(raw), spec_dir
+    )
+    # hermes' judge invocation (`-z`, final text only) doesn't surface the
+    # resolved model, so we report the requested one (None on its own default).
+    return passed, reasoning, errored, model
+
+
+def _run_hermes(
+    prompt: str, model: str | None, cwd: str, timeout: int
+) -> tuple[str, str | None]:
+    hermes = _hermes_command()
+    if not hermes:
+        return "", "hermes CLI not found"
+
+    # A judge is a single autorater call: `hermes -z` prints only the final
+    # response text, which is the JSON verdict we asked for. --ignore-rules keeps
+    # persona/memory out of the grader; the judge reuses the real ~/.hermes.
+    cmd = [hermes, "-z", prompt, "--ignore-rules"]
+    if model:
+        cmd[2:2] = ["--model", model]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            encoding="utf-8",
+            text=True,
+            timeout=timeout,
+            env=dict(os.environ),
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        return "", "Judge timed out."
+    except OSError as exc:
+        return "", f"hermes judge failed: {exc}"
+
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip()
+        return "", f"hermes judge exited {proc.returncode}: {detail[:200]}"
+
+    return proc.stdout.strip(), None
+
+
+def _hermes_command() -> str | None:
+    configured = os.environ.get("HERMES_CLI_PATH")
+    if configured and Path(configured).exists():
+        return configured
+    return shutil.which("hermes")
+
+
+def _strip_markdown_fence(raw: str) -> str:
+    raw = raw.strip()
+    if not raw.startswith("```"):
+        return raw
+    lines = raw.splitlines()
+    return "\n".join(line for line in lines if not line.startswith("```")).strip()

--- a/caliper/judge/pi_judge.py
+++ b/caliper/judge/pi_judge.py
@@ -22,7 +22,7 @@ def evaluate_with_pi(
     model: str | None,
     spec_dir: str,
     timeout: int = 60,
-) -> tuple[bool, str, bool]:
+) -> tuple[bool, str, bool, str | None]:
     user_msg = _USER_TMPL.format(
         expect=expect,
         transcript=_format_transcript(transcript),
@@ -30,8 +30,11 @@ def evaluate_with_pi(
     prompt = f"{_SYSTEM}\n\n{user_msg}"
     raw, error = _run_pi(prompt, model, spec_dir, timeout)
     if error:
-        return False, error, True
-    return _parse_rich_response(raw, spec_dir)
+        return False, error, True, model
+    passed, reasoning, errored = _parse_rich_response(raw, spec_dir)
+    # pi's judge invocation doesn't surface the resolved model, so we can only
+    # report the one that was requested (None when its own default was used).
+    return passed, reasoning, errored, model
 
 
 def _run_pi(

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -154,10 +154,14 @@ class EvalJudge(Judge):
         if static_result is not None:
             assert_passed, assert_evidence = static_result
 
+        autorater_model: str | None = None
         if task.expect:
-            llm_passed, llm_reasoning, autorater_errored = self._llm_evaluate(
-                task, transcript, spec_dir
-            )
+            (
+                llm_passed,
+                llm_reasoning,
+                autorater_errored,
+                autorater_model,
+            ) = self._llm_evaluate(task, transcript, spec_dir)
             autorater_reasoning = llm_reasoning
             # An errored autorater yields no verdict: leave autorater_passed None
             # so it is dropped from the checks rather than counted as a failure.
@@ -184,11 +188,12 @@ class EvalJudge(Judge):
             autorater_passed=autorater_passed,
             autorater_reasoning=autorater_reasoning,
             errored=errored,
+            resolved_model=autorater_model,
         )
 
     def _llm_evaluate(
         self, task: TaskSpec, transcript: list[ConversationTurn], spec_dir: str
-    ) -> tuple[bool, str, bool]:
+    ) -> tuple[bool, str, bool, str | None]:
         match normalize_backend(self._backend):
             case "codex":
                 from caliper.judge.codex_judge import evaluate_with_codex
@@ -217,5 +222,14 @@ class EvalJudge(Judge):
                     model=self._model,
                     spec_dir=spec_dir,
                 )
+            case "hermes":
+                from caliper.judge.hermes_judge import evaluate_with_hermes
+
+                return evaluate_with_hermes(
+                    expect=task.expect,
+                    transcript=transcript,
+                    model=self._model,
+                    spec_dir=spec_dir,
+                )
             case _:
-                return False, f"Unknown judge backend: {self._backend!r}", True
+                return False, f"Unknown judge backend: {self._backend!r}", True, None

--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -38,6 +38,21 @@ _RULE = "—" if _UNICODE else "-"
 _WARN = "⚠" if _UNICODE else "!"
 _CHECK = "✓" if _UNICODE else "OK"
 _CROSS = "✗" if _UNICODE else "X"
+
+
+def _engine_label(backend: str | None, model: str | None) -> str:
+    """`backend · model` when a model is known, else just the backend."""
+    label = backend or "?"
+    return f"{label} {_SEP} {model}" if model else label
+
+
+def _judge_suffix(backend: str | None, model: str | None) -> str:
+    """A ` · judge <engine>` fragment, or empty when the judge is unrecorded."""
+    if not backend:
+        return ""
+    return f"  {_SEP}  judge {_engine_label(backend, model)}"
+
+
 _UP = "↑" if _UNICODE else "up"
 _DOWN = "↓" if _UNICODE else "down"
 _BAR_FULL = "█" if _UNICODE else "#"
@@ -134,11 +149,12 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
     ts = results.run.timestamp.strftime("%Y-%m-%d %H:%M")
     k = results.run.k
 
+    judge_suffix = _judge_suffix(results.run.judge_backend, results.run.judge_model)
     console.print()
     console.rule(
         f"{_BANNER}  {_RULE}  [bold]{spec}[/bold]  ([cyan]{backend}[/cyan]"
         + (f" {_SEP} [dim]{model}[/dim]" if model else "")
-        + f")  {_RULE}  {ts}",
+        + f"){judge_suffix}  {_RULE}  {ts}",
         style="cyan",
     )
     console.print()
@@ -345,9 +361,11 @@ def print_comparison(comp: RunComparison) -> None:
         f"{_BANNER}  {_RULE}  compare  {_RULE}  [bold]{comp.a.spec}[/bold]",
         style="cyan",
     )
+    a_engine = _engine_label(comp.a.backend, comp.a.model)
+    b_engine = _engine_label(comp.b.backend, comp.b.model)
     console.print(
-        f"    [bold]A[/bold] {a_ts} ([cyan]{comp.a.backend}[/cyan])   {_SEP}"
-        f"   [bold]B[/bold] {b_ts} ([cyan]{comp.b.backend}[/cyan])   {_SEP}"
+        f"    [bold]A[/bold] {a_ts} ([cyan]{a_engine}[/cyan])   {_SEP}"
+        f"   [bold]B[/bold] {b_ts} ([cyan]{b_engine}[/cyan])   {_SEP}"
         f"   k=[cyan]{comp.a.k}[/cyan]"
         + (f"/[cyan]{comp.b.k}[/cyan]" if comp.k_mismatch else "")
     )

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -45,6 +45,8 @@ def run(
     judge: Judge,
     backend: str = DEFAULT_BACKEND,
     model: str | None = None,
+    judge_backend: str | None = None,
+    judge_model: str | None = None,
     k: int = 3,
     workers: int = 4,
     timeout: int = 120,
@@ -63,6 +65,13 @@ def run(
 
     task_results_with: list[TaskResult] = []
     task_results_without: list[TaskResult] = []
+    # Collects the concrete model each attempt resolved (same value every time),
+    # so RunMeta can record the real model even when the CLI's default was used.
+    # list.append is atomic under the GIL, so it is safe across worker threads.
+    resolved_models: list[str] = []
+    # Same, for the judge autorater's concrete model (only set for expect: tasks
+    # whose judge CLI reports it, e.g. claude-code).
+    judge_models: list[str] = []
 
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures_with = {
@@ -80,6 +89,8 @@ def run(
                 on_attempt_done,
                 on_task_done,
                 fail_fast_unusable,
+                resolved_models,
+                judge_models,
             ): task
             for task in spec.tasks
         }
@@ -99,6 +110,8 @@ def run(
                     on_attempt_done,
                     on_task_done,
                     fail_fast_unusable,
+                    resolved_models,
+                    judge_models,
                 ): task
                 for task in spec.tasks
             }
@@ -138,7 +151,15 @@ def run(
             timestamp=datetime.now(tz=timezone.utc),
             k=k,
             backend=backend,
-            model=model,
+            # Prefer the explicitly requested model; otherwise fall back to the
+            # concrete model an attempt resolved (e.g. from hermes' export), so a
+            # default-model run still records what actually ran.
+            model=model or (resolved_models[0] if resolved_models else None),
+            judge_backend=judge_backend,
+            # Prefer the explicitly requested judge model; else the concrete model
+            # an autorater reported (e.g. claude-code). Stays None for assert-only
+            # runs, where no LLM judge ran.
+            judge_model=judge_model or (judge_models[0] if judge_models else None),
         ),
         skill_snapshot=skill_snapshot,
         task_results=task_results_with,
@@ -161,6 +182,8 @@ def _run_task(
     on_attempt_done: Callable[[AttemptEvent], None] | None,
     on_task_done: Callable[[TaskResult], None] | None,
     fail_fast_unusable: int,
+    resolved_models: list[str],
+    judge_models: list[str],
 ) -> TaskResult:
     attempts: list[AttemptRecord] = []
     consecutive_fail_fast_triggers = 0
@@ -176,6 +199,8 @@ def _run_task(
             timeout,
             with_skill,
             on_attempt_done,
+            resolved_models,
+            judge_models,
         )
         attempts.append(record)
         if record.outcome in _FAIL_FAST_OUTCOMES:
@@ -215,6 +240,8 @@ def _run_attempt(
     timeout: int,
     with_skill: bool,
     on_attempt_done: Callable[[AttemptEvent], None] | None,
+    resolved_models: list[str],
+    judge_models: list[str],
 ) -> AttemptRecord:
     tmp_dir = tempfile.mkdtemp(prefix="caliper-")
     try:
@@ -239,6 +266,8 @@ def _run_attempt(
             isolated_home=tmp_dir,
             extra_path=resolved_extra_path,
         )
+        if attempt_result.resolved_model:
+            resolved_models.append(attempt_result.resolved_model)
 
         # A timeout or infrastructure signal terminates the attempt before we
         # spend a (paid) judge call on garbage output. The pre-judge classifier
@@ -282,6 +311,8 @@ def _run_attempt(
             final_output=attempt_result.final_output,
             spec_dir=str(spec_path.parent),
         )
+        if judge_result.resolved_model:
+            judge_models.append(judge_result.resolved_model)
         outcome = classify_outcome(attempt_result, [], judge_result)
 
         return _finish(

--- a/caliper/schema/results.py
+++ b/caliper/schema/results.py
@@ -45,6 +45,10 @@ class RunMeta(BaseModel):
     k: int
     backend: str
     model: str | None = None
+    # The judge engine that graded this run. Optional so results saved before
+    # judge provenance was recorded still load (they render as an unknown judge).
+    judge_backend: str | None = None
+    judge_model: str | None = None
 
 
 class AttemptRecord(BaseModel):

--- a/caliper/schema/spec.py
+++ b/caliper/schema/spec.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-_VALID_BACKENDS: frozenset[str] = frozenset({"claude-code", "codex", "pi"})
+_VALID_BACKENDS: frozenset[str] = frozenset({"claude-code", "codex", "pi", "hermes"})
 
 # The engine (backend + model) is a runtime axis, not a spec field: it is chosen
 # at invocation via --model / --judge-model and defaults to this. A saved run

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -94,6 +94,18 @@ overrides pi's configured default:
 caliper run path/to/spec.eval.yaml --model pi:claude-sonnet-4-6 --judge-model pi
 ```
 
+For hermes (Nous Research), the `:model` half is a `provider/model` value passed
+straight to hermes's `-m`; omit it to use your `~/.hermes/config.yaml` default:
+
+```bash
+caliper run path/to/spec.eval.yaml --model hermes:anthropic/claude-sonnet-4.6 --judge-model hermes
+```
+
+Hermes is a stateful agent, so Caliper normalizes it to a neutral agent per
+attempt (isolated `HERMES_HOME`, no persona/memory, `--ignore-rules`, the
+skill-under-test staged as the only local skill) and recovers the full tool-call
+trajectory by running `hermes -z` then `hermes sessions export`.
+
 ## Key concepts
 
 - **pass@k** — probability that at least 1 of k attempts passes (default k=3), computed over the *usable* attempts only
@@ -103,7 +115,7 @@ caliper run path/to/spec.eval.yaml --model pi:claude-sonnet-4-6 --judge-model pi
 - **judge** — the spec drives evaluation: `expect:` triggers an LLM verdict (which may generate a Python assertion script); `assert:` runs a deterministic Python script; both can be combined and both must pass
 - **cheat detection** — transcript is scanned for reads of forbidden files (spec, results)
 - **isolation** — each attempt runs in a fresh temp HOME with no session history
-- **engine as a runtime axis** — backend + model are not spec fields; they are chosen per run and recorded in `RunMeta`, so the same spec can target any agent and never ages when a model goes stale
+- **engine as a runtime axis** — backend + model are not spec fields; they are chosen per run and recorded in `RunMeta` (skill `backend`/`model` **and** `judge_backend`/`judge_model`), so the same spec can target any agent and never ages when a model goes stale. A default-model run records the concrete model the agent resolved wherever the backend reports it (skill model from hermes' export, `judge_model` from the claude-code judge's JSON), not a bare "default"; `judge_model` is empty for an assert-only run where no LLM judge fired
 - **`--model TARGET`** — select the skill engine at run time (default `claude-code`); accepts `backend:model`, bare backend (`codex`), or bare model name
 - **`--judge-model TARGET`** — same syntax, selects the judge engine independently
 

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -123,5 +123,8 @@ Add `assert:` when the outcome is a fact that an LLM judge might guess wrong:
 | `claude-code` | Claude Code CLI | Default for most skills |
 | `codex` | Codex CLI | For Codex-targeted skills |
 | `pi` | pi CLI (authenticated) | For pi / agentskills.io skills; native `--skill` loading |
+| `hermes` | Hermes Agent CLI (authenticated) | Nous Research; normalized to a neutral agent, `hermes:<provider>/<model>` picks the model |
 
 The skill engine (`--model`) and judge engine (`--judge-model`) are chosen independently at run time. Every backend is a CLI agent; for API billing, configure a CLI with an API key rather than selecting a separate backend.
+
+`hermes` is a stateful agent (persistent memory + persona), so Caliper strips it to a neutral agent per attempt — isolated `HERMES_HOME`, no `SOUL.md`/`MEMORY.md`, `--ignore-rules`, skill-under-test staged as the only local skill — and recovers the full trajectory via `hermes sessions export` after the `hermes -z` run.

--- a/tests/hermes-smoke.eval.yaml
+++ b/tests/hermes-smoke.eval.yaml
@@ -1,0 +1,15 @@
+# End-to-end smoke eval for the `hermes` backend.
+# The engine is a runtime axis, not a spec field — pick it when you run:
+#   caliper run tests/hermes-smoke.eval.yaml --model hermes
+skill: {}
+
+tasks:
+  - name: Write hello to a file
+    setup: rm -f /tmp/caliper-e2e-smoke-hermes.txt
+    cleanup: rm -f /tmp/caliper-e2e-smoke-hermes.txt
+    prompt: Write the text "hello" to /tmp/caliper-e2e-smoke-hermes.txt using a shell command.
+    assert: |
+      from pathlib import Path
+      p = Path("/tmp/caliper-e2e-smoke-hermes.txt")
+      assert p.exists(), "file was not created"
+      assert "hello" in p.read_text(), "file does not contain hello"

--- a/tests/test_claude_judge.py
+++ b/tests/test_claude_judge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 
 from caliper.harness.base import ConversationTurn
@@ -43,3 +44,33 @@ def test_eval_judge_claude_code_invokes_claude_cli(monkeypatch, tmp_path) -> Non
     assert cmd[cmd.index("--model") + 1] == "claude-test"
     assert "The assistant says hello." in cmd[2]
     assert kwargs["timeout"] == 60
+
+
+def test_claude_judge_extracts_concrete_model_from_envelope(
+    monkeypatch, tmp_path
+) -> None:
+    """The verdict lives in `.result`; the concrete model in `.modelUsage`."""
+    envelope = {
+        "type": "result",
+        "result": '{"mode": "verdict", "passed": true, "reasoning": "ok"}',
+        "modelUsage": {"claude-opus-4-8": {"inputTokens": 10, "outputTokens": 2}},
+    }
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(envelope), stderr=""
+        )
+
+    monkeypatch.setattr("caliper.judge.claude_code_judge.subprocess.run", fake_run)
+
+    # No model requested → the judge should still record what Claude actually used.
+    result = EvalJudge(backend="claude-code").evaluate(
+        task=TaskSpec(id="t1", name="t", prompt="p", expect="says ok"),
+        transcript=[ConversationTurn(role="assistant", content="ok")],
+        final_output="ok",
+        spec_dir=str(tmp_path),
+    )
+
+    assert result.passed is True
+    assert result.autorater_passed is True
+    assert result.resolved_model == "claude-opus-4-8"

--- a/tests/test_codex_judge.py
+++ b/tests/test_codex_judge.py
@@ -20,7 +20,7 @@ def test_eval_judge_expect_only_calls_llm(monkeypatch, tmp_path) -> None:
 
     def fake_eval(*, expect, transcript, model, cwd, timeout=60):
         calls.append((expect, model, cwd))
-        return True, "Codex accepted the transcript.", False
+        return True, "Codex accepted the transcript.", False, model
 
     monkeypatch.setattr(
         "caliper.judge.script_assert.EvalJudge._llm_evaluate",
@@ -77,7 +77,7 @@ def test_eval_judge_assert_failure_makes_overall_fail(tmp_path) -> None:
 def test_eval_judge_both_checks_must_pass(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         "caliper.judge.script_assert.EvalJudge._llm_evaluate",
-        lambda self, task, transcript, spec_dir: (True, "LLM says yes", False),
+        lambda self, task, transcript, spec_dir: (True, "LLM says yes", False, None),
     )
 
     judge = EvalJudge(backend="codex")
@@ -100,7 +100,7 @@ def test_eval_judge_both_checks_must_pass(monkeypatch, tmp_path) -> None:
 
 
 def _errored_llm(self, task, transcript, spec_dir):
-    return False, "judge flaked", True
+    return False, "judge flaked", True, None
 
 
 def test_errored_autorater_dropped_when_assert_passes(monkeypatch, tmp_path) -> None:
@@ -184,7 +184,7 @@ def test_codex_judge_uses_output_last_message(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr("caliper.judge.codex_judge.subprocess.run", fake_run)
 
-    passed, reasoning, errored = evaluate_with_codex(
+    passed, reasoning, errored, _model = evaluate_with_codex(
         expect="The assistant says hello.",
         transcript=[ConversationTurn(role="assistant", content="hello")],
         model="test-model",
@@ -209,7 +209,7 @@ def test_eval_judge_uses_codex_for_expect_when_configured(
 
     def fake_eval(*, expect, transcript, model, cwd, timeout=60):
         calls.append((expect, transcript, model, cwd, timeout))
-        return True, "Codex accepted the transcript.", False
+        return True, "Codex accepted the transcript.", False, model
 
     monkeypatch.setattr("caliper.judge.codex_judge.evaluate_with_codex", fake_eval)
 

--- a/tests/test_hermes_harness.py
+++ b/tests/test_hermes_harness.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from caliper.harness.base import HarnessConfigurationError
+from caliper.harness.hermes import HermesHarness
+
+
+def _version(cmd):
+    return subprocess.CompletedProcess(
+        cmd, 0, stdout="Hermes Agent v0.18.0\n", stderr=""
+    )
+
+
+def _fake_home(tmp_path):
+    """A fake ~/.hermes with auth/config *and* persona/memory to strip."""
+    real = tmp_path / "realhome" / ".hermes"
+    real.mkdir(parents=True)
+    (real / "auth.json").write_text("{}")
+    (real / "config.yaml").write_text("model:\n  provider: anthropic\n")
+    (real / ".env").write_text("SECRET=1\n")
+    (real / "SOUL.md").write_text("You are a quirky persona.")
+    (real / "MEMORY.md").write_text("The user's cat is named Mochi.")
+    return tmp_path / "realhome"
+
+
+def _install(monkeypatch, home, on_run):
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("HERMES_CLI_PATH", raising=False)
+    monkeypatch.setattr("caliper.harness.hermes.shutil.which", lambda _n: "hermes")
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", on_run)
+
+
+def test_hermes_seeds_only_neutral_config_and_ignores_rules(
+    monkeypatch, tmp_path
+) -> None:
+    home = _fake_home(tmp_path)
+    iso = tmp_path / "iso"
+    iso.mkdir()
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    _install(monkeypatch, home, fake_run)
+
+    HermesHarness().run(
+        task_id="task-001",
+        attempt=1,
+        prompt="Hello",
+        skill_path=None,
+        model=None,
+        timeout=30,
+        isolated_home=str(iso),
+    )
+
+    seeded = iso / ".hermes"
+    # auth/config/.env are copied verbatim so the agent can authenticate...
+    assert (seeded / "auth.json").exists()
+    assert (seeded / "config.yaml").exists()
+    assert (seeded / ".env").exists()
+    # ...but persona and memory are never seeded — Hermes is stripped to neutral.
+    assert not (seeded / "SOUL.md").exists()
+    assert not (seeded / "MEMORY.md").exists()
+
+    run_cmd, run_kwargs = calls[1]
+    assert run_cmd[0] == "/bin/sh"
+    script = run_cmd[2]
+    assert "--ignore-rules" in script
+    env = run_kwargs["env"]
+    assert env["HERMES_HOME"] == str(seeded)
+    assert env["HOME"] == str(iso)
+    assert env["CALIPER_PROMPT"] == "Hello"
+
+
+def test_hermes_stages_skill_and_passes_skills_flag(monkeypatch, tmp_path) -> None:
+    home = _fake_home(tmp_path)
+    iso = tmp_path / "iso"
+    iso.mkdir()
+    # The runner stages the skill dir into isolated_home; simulate that.
+    (iso / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: test\n---\n\nDo the thing.\n"
+    )
+    (iso / "REFERENCE.md").write_text("Extra detail.")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    _install(monkeypatch, home, fake_run)
+
+    HermesHarness().run(
+        task_id="task-001",
+        attempt=1,
+        prompt="Do it",
+        skill_path=str(iso / "SKILL.md"),
+        model=None,
+        timeout=30,
+        isolated_home=str(iso),
+    )
+
+    staged = iso / ".hermes" / "skills" / "my-skill"
+    assert (staged / "SKILL.md").exists()
+    # Progressive-disclosure siblings travel with the skill.
+    assert (staged / "REFERENCE.md").exists()
+
+    run_cmd, run_kwargs = calls[1]
+    script = run_cmd[2]
+    assert "--skills" in script
+    assert run_kwargs["env"]["CALIPER_SKILL"] == "my-skill"
+
+
+def test_hermes_no_skills_flag_without_skill(monkeypatch, tmp_path) -> None:
+    home = _fake_home(tmp_path)
+    iso = tmp_path / "iso"
+    iso.mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    _install(monkeypatch, home, fake_run)
+
+    result_calls = []
+    monkeypatch.setattr(
+        "caliper.harness.base.subprocess.run",
+        lambda cmd, **kw: (result_calls.append((cmd, kw)) or fake_run(cmd, **kw)),
+    )
+
+    HermesHarness().run(
+        task_id="task-001",
+        attempt=1,
+        prompt="Hello",
+        skill_path=None,
+        model=None,
+        timeout=30,
+        isolated_home=str(iso),
+    )
+
+    script = result_calls[1][0][2]
+    assert "--skills" not in script
+    assert "CALIPER_SKILL" not in result_calls[1][1]["env"]
+
+
+def test_hermes_parses_export_trajectory(monkeypatch, tmp_path) -> None:
+    home = _fake_home(tmp_path)
+    iso = tmp_path / "iso"
+    iso.mkdir()
+
+    export = {
+        "id": "20260703_000000_abc",
+        "source": "cli",
+        "model": "stepfun/step-3.7-flash:free",
+        "messages": [
+            {"role": "user", "content": "Run echo.", "tool_calls": None},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "echo HELLO123"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_name": "terminal",
+                "tool_call_id": "call_1",
+                "content": '{"output": "HELLO123", "exit_code": 0}',
+            },
+            {"role": "assistant", "content": "Done: HELLO123", "tool_calls": None},
+        ],
+    }
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(export), stderr="Done: HELLO123"
+        )
+
+    _install(monkeypatch, home, fake_run)
+
+    result = HermesHarness().run(
+        task_id="task-001",
+        attempt=1,
+        prompt="Run echo",
+        skill_path=None,
+        model=None,
+        timeout=30,
+        isolated_home=str(iso),
+    )
+
+    assert result.final_output == "Done: HELLO123"
+    assert [t.role for t in result.transcript] == [
+        "user",
+        "tool_use",
+        "tool_result",
+        "assistant",
+    ]
+    tool_use = result.transcript[1]
+    assert tool_use.tool_name == "terminal"
+    # tool_input is parsed from the JSON-string arguments so the cheat-detector
+    # can inspect any paths/commands.
+    assert tool_use.tool_input == {"command": "echo HELLO123"}
+    assert "HELLO123" in result.transcript[2].tool_output
+    # A successful run reports no error even though the final text is on stderr.
+    assert result.error is None
+    assert result.exit_code == 0
+    # The concrete model is recovered from the export's top-level `model` field,
+    # so a default-model run still records what actually ran.
+    assert result.resolved_model == "stepfun/step-3.7-flash:free"
+
+
+def test_hermes_missing_cli_raises_configuration_error(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("caliper.harness.hermes.shutil.which", lambda _n: None)
+    monkeypatch.delenv("HERMES_CLI_PATH", raising=False)
+
+    with pytest.raises(HarnessConfigurationError, match="hermes CLI is not available"):
+        HermesHarness().run(
+            task_id="task-001",
+            attempt=1,
+            prompt="Hello",
+            skill_path=None,
+            model=None,
+            timeout=12,
+            isolated_home=str(tmp_path),
+        )
+
+
+def test_hermes_credit_failure_raises_configuration_error(
+    monkeypatch, tmp_path
+) -> None:
+    home = _fake_home(tmp_path)
+    iso = tmp_path / "iso"
+    iso.mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1:] == ["--version"]:
+            return _version(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr="HTTP 400: You're out of extra usage."
+        )
+
+    _install(monkeypatch, home, fake_run)
+
+    with pytest.raises(HarnessConfigurationError, match="provider/credential"):
+        HermesHarness().run(
+            task_id="task-001",
+            attempt=1,
+            prompt="Hello",
+            skill_path=None,
+            model=None,
+            timeout=12,
+            isolated_home=str(iso),
+        )

--- a/tests/test_hermes_judge.py
+++ b/tests/test_hermes_judge.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import subprocess
+
+from caliper.harness.base import ConversationTurn
+from caliper.judge.hermes_judge import evaluate_with_hermes
+from caliper.judge.script_assert import EvalJudge
+from caliper.schema.spec import TaskSpec
+
+
+def test_hermes_backend_is_a_valid_judge(monkeypatch, tmp_path) -> None:
+    """Regression: `--judge-model hermes` must dispatch, not 'Unknown judge backend'."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout='{"mode": "verdict", "passed": true, "reasoning": "ok"}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "caliper.judge.hermes_judge.shutil.which", lambda _: "/usr/bin/hermes"
+    )
+    monkeypatch.setattr("caliper.judge.hermes_judge.subprocess.run", fake_run)
+
+    result = EvalJudge(backend="hermes", model="anthropic/claude-sonnet-4.6").evaluate(
+        task=TaskSpec(id="t1", name="t", prompt="p", expect="says ok"),
+        transcript=[ConversationTurn(role="assistant", content="ok")],
+        final_output="ok",
+        spec_dir=str(tmp_path),
+    )
+
+    assert result.passed is True
+    assert result.autorater_passed is True
+    cmd = captured["cmd"]
+    assert cmd[0] == "/usr/bin/hermes"
+    assert "-z" in cmd
+    assert "--ignore-rules" in cmd
+    assert cmd[cmd.index("--model") + 1] == "anthropic/claude-sonnet-4.6"
+
+
+def test_hermes_judge_strips_markdown_fence(monkeypatch, tmp_path) -> None:
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout='```json\n{"mode": "verdict", "passed": false, "reasoning": "no"}\n```',
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "caliper.judge.hermes_judge.shutil.which", lambda _: "/usr/bin/hermes"
+    )
+    monkeypatch.setattr("caliper.judge.hermes_judge.subprocess.run", fake_run)
+
+    passed, reasoning, errored, _model = evaluate_with_hermes(
+        expect="anything", transcript=[], model=None, spec_dir=str(tmp_path)
+    )
+
+    assert (passed, errored) == (False, False)
+    assert reasoning == "no"
+
+
+def test_hermes_judge_reports_cli_error_as_errored(monkeypatch, tmp_path) -> None:
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="not logged in")
+
+    monkeypatch.setattr(
+        "caliper.judge.hermes_judge.shutil.which", lambda _: "/usr/bin/hermes"
+    )
+    monkeypatch.setattr("caliper.judge.hermes_judge.subprocess.run", fake_run)
+
+    passed, reasoning, errored, _model = evaluate_with_hermes(
+        expect="anything", transcript=[], model=None, spec_dir=str(tmp_path)
+    )
+
+    assert (passed, errored) == (False, True)
+    assert "not logged in" in reasoning
+
+
+def test_hermes_judge_missing_cli_errors(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("caliper.judge.hermes_judge.shutil.which", lambda _: None)
+    monkeypatch.delenv("HERMES_CLI_PATH", raising=False)
+
+    passed, reasoning, errored, _model = evaluate_with_hermes(
+        expect="anything", transcript=[], model=None, spec_dir=str(tmp_path)
+    )
+
+    assert (passed, errored) == (False, True)
+    assert "hermes CLI not found" in reasoning

--- a/tests/test_parse_target.py
+++ b/tests/test_parse_target.py
@@ -11,6 +11,12 @@ from caliper.schema.spec import parse_target
         # backend:model compound
         ("codex:gpt-5-codex", ("codex", "gpt-5-codex")),
         ("pi:claude-sonnet-4-6", ("pi", "claude-sonnet-4-6")),
+        # hermes takes a provider/model value straight through to its -m flag
+        (
+            "hermes:anthropic/claude-sonnet-4.6",
+            ("hermes", "anthropic/claude-sonnet-4.6"),
+        ),
+        ("hermes", ("hermes", None)),
         # alias normalised on the backend side
         ("claude:claude-sonnet-4-6", ("claude-code", "claude-sonnet-4-6")),
         # backend only (known name, no colon)

--- a/tests/test_pi_judge.py
+++ b/tests/test_pi_judge.py
@@ -60,7 +60,7 @@ def test_pi_judge_reports_cli_error_as_errored(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("caliper.judge.pi_judge.shutil.which", lambda _: "/usr/bin/pi")
     monkeypatch.setattr("caliper.judge.pi_judge.subprocess.run", fake_run)
 
-    passed, reasoning, errored = evaluate_with_pi(
+    passed, reasoning, errored, _model = evaluate_with_pi(
         expect="anything",
         transcript=[],
         model=None,
@@ -76,7 +76,7 @@ def test_pi_judge_missing_cli_errors(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("caliper.judge.pi_judge.shutil.which", lambda _: None)
     monkeypatch.delenv("PI_CLI_PATH", raising=False)
 
-    passed, reasoning, errored = evaluate_with_pi(
+    passed, reasoning, errored, _model = evaluate_with_pi(
         expect="anything", transcript=[], model=None, spec_dir=str(tmp_path)
     )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -311,3 +311,110 @@ def test_stage_ignores_lone_command_file(tmp_path) -> None:
     _stage_skill_directory(str(tmp_path / "review.md"), str(home), [])
 
     assert not (home / "unrelated.md").exists()
+
+
+class ResolvedModelHarness(HarnessBackend):
+    """A harness that reports the concrete model it resolved for each attempt."""
+
+    def __init__(self, resolved_model: str) -> None:
+        self._resolved = resolved_model
+
+    @property
+    def name(self) -> str:
+        return "resolving"
+
+    def run(
+        self,
+        task_id: str,
+        attempt: int,
+        prompt: str,
+        *,
+        skill_path: str | None,
+        model: str | None,
+        timeout: int,
+        isolated_home: str,
+        extra_path: list[str] | None = None,
+    ) -> AttemptResult:
+        return AttemptResult(
+            task_id=task_id,
+            attempt=attempt,
+            transcript=[],
+            final_output="done",
+            exit_code=0,
+            duration_seconds=0.1,
+            resolved_model=self._resolved,
+        )
+
+
+class ModelReportingJudge(Judge):
+    """A judge that reports the concrete model its autorater resolved."""
+
+    def __init__(self, resolved_model: str) -> None:
+        self._resolved = resolved_model
+
+    def evaluate(self, task, transcript, final_output, spec_dir) -> JudgeResult:
+        return JudgeResult(passed=True, reasoning="ok", resolved_model=self._resolved)
+
+
+def test_runmeta_records_judge_engine_and_resolved_model(tmp_path) -> None:
+    spec_path = tmp_path / "prov.eval.yaml"
+    spec_path.write_text("skill: {}\ntasks: []\n")
+
+    results = run(
+        spec=_one_task_spec(),
+        spec_path=spec_path,
+        harness=ResolvedModelHarness("stepfun/step-3.7-flash:free"),
+        judge=RecordingJudge(),
+        # No skill model requested — the backend's resolved model should fill it.
+        model=None,
+        judge_backend="hermes",
+        judge_model="anthropic/claude-sonnet-4.6",
+        k=1,
+        workers=1,
+        timeout=30,
+    )
+
+    # The judge engine that graded the run is persisted for reproducibility.
+    assert results.run.judge_backend == "hermes"
+    assert results.run.judge_model == "anthropic/claude-sonnet-4.6"
+    # A default-model run still records the concrete model that actually ran.
+    assert results.run.model == "stepfun/step-3.7-flash:free"
+
+
+def test_runmeta_fills_default_judge_model_from_autorater(tmp_path) -> None:
+    spec_path = tmp_path / "prov.eval.yaml"
+    spec_path.write_text("skill: {}\ntasks: []\n")
+
+    results = run(
+        spec=_one_task_spec(),
+        spec_path=spec_path,
+        harness=ResolvedModelHarness("some/model"),
+        judge=ModelReportingJudge("claude-opus-4-8"),
+        judge_backend="claude-code",
+        # No judge model requested — the autorater's concrete model fills it.
+        judge_model=None,
+        k=1,
+        workers=1,
+        timeout=30,
+    )
+
+    assert results.run.judge_backend == "claude-code"
+    assert results.run.judge_model == "claude-opus-4-8"
+
+
+def test_runmeta_prefers_explicit_model_over_resolved(tmp_path) -> None:
+    spec_path = tmp_path / "prov.eval.yaml"
+    spec_path.write_text("skill: {}\ntasks: []\n")
+
+    results = run(
+        spec=_one_task_spec(),
+        spec_path=spec_path,
+        harness=ResolvedModelHarness("some/other-model"),
+        judge=RecordingJudge(),
+        model="anthropic/claude-sonnet-4.6",
+        k=1,
+        workers=1,
+        timeout=30,
+    )
+
+    assert results.run.model == "anthropic/claude-sonnet-4.6"


### PR DESCRIPTION
## Summary

Adds Nous Research's **Hermes Agent** as a fourth CLI backend (harness **and** judge), and closes the model-provenance gaps that surfaced while wiring it up.

### Hermes backend
- New `caliper/harness/hermes.py` + `caliper/judge/hermes_judge.py`; registered in `_VALID_BACKENDS`, `get_harness`, and the judge dispatch.
- Hermes is a **stateful** agent (persistent memory, a persona, auto-generated skills), so it's **normalized to a neutral agent** per attempt: an isolated `HERMES_HOME` seeded with auth/config only (never `SOUL.md`/`MEMORY.md`), `--ignore-rules`, and the skill-under-test staged as the sole local skill. This keeps its pass@k apples-to-apples with the flat backends.
- Full trajectory (tool calls + results, for `expect:` autoraters) is recovered by running `hermes -z` then `hermes sessions export`, whose OpenAI-style JSONL parses into `ConversationTurn`s. Model selection reuses `hermes:<provider>/<model>`.

### Model + judge provenance in `RunMeta`
Spotted while reviewing what a saved run actually records:
- **Judge engine persisted** — `judge_backend`/`judge_model` were computed and thrown away; now saved.
- **Concrete resolved model captured** — a default-model run recorded `model=None`. Now it records what actually ran wherever the backend reports it: the skill model from hermes' export, and the judge model from the `claude-code` judge (now run with `--output-format json` to read `.modelUsage`). `judge_model` stays empty for `assert:`-only runs, where no LLM judge fires.
- **`compare` now shows the model** beside the backend (previously backend only — it hid the very axis a comparison exists to diff); both report and compare headers show the judge engine.
- New optional `RunMeta` fields default to `None`, so results saved before this change still load.

## Testing
- **126 tests pass**; `ruff format --check` + `ruff check` clean.
- Validated end-to-end against the real `hermes` CLI: a skill run produces a parsed `user → tool_use → tool_result → assistant` trajectory; an `expect:` run grades via the JSON-output claude judge (`outcome=pass`) and records `judge_model=claude-haiku-4-5-20251001`.
- New tests cover: neutral-agent invariant (no SOUL/MEMORY staged, `--ignore-rules` present), skill staging, export parsing, resolved skill/judge model capture, judge dispatch, and `hermes:provider/model` addressing.

## Note
The `evaluate_with_*` judge functions now return a 4-tuple `(passed, reasoning, errored, model)`; codex/pi/hermes judges report the requested model (their invocation modes don't surface the resolved one) — broadening that is a small follow-up.