### PR TITLE
feat(results): persist attempt transcript in saved results JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,10 @@ them up per run:
   Those four are **disjoint**, so the computed `total_tokens` never
   double-counts. Wall-clock time comes from `duration_seconds`, which was already
   recorded.
+- Each `AttemptRecord` also carries an optional `transcript` array of ordered
+  turns (`role`, `content`, and tool `tool_name`/`tool_input`/`tool_output` when
+  present). This preserves the full tool-call trace in saved results for later
+  inspection; older JSON without the field still loads (`transcript` is `null`).
 - In the summary, **`in` = input + cache_read + cache_creation** and **`out` =
   output**. The **unusable** slice (timeout / infra / judge error) is broken out
   separately, so wasted spend stays visible without distorting the per-attempt

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
@@ -26,6 +26,7 @@ from caliper.schema.results import (
     RunResults,
     SkillSnapshot,
     TaskResult,
+    TranscriptTurn,
 )
 from caliper.schema.spec import DEFAULT_BACKEND, EvalSpec, TaskSpec, spec_name
 from caliper.scoring import aggregate_scores, score_outcomes
@@ -247,6 +248,12 @@ def _run_task(
     return result
 
 
+def _persist_transcript(
+    turns: list[ConversationTurn],
+) -> list[TranscriptTurn]:
+    return [TranscriptTurn(**asdict(turn)) for turn in turns]
+
+
 def _run_attempt(
     task: TaskSpec,
     attempt: int,
@@ -306,6 +313,7 @@ def _run_attempt(
                     duration_seconds=attempt_result.duration_seconds,
                     outcome=pre_judge_outcome,
                     usage=attempt_result.usage,
+                    transcript=_persist_transcript(attempt_result.transcript),
                     assert_evidence=evidence,
                 ),
                 task,
@@ -322,6 +330,7 @@ def _run_attempt(
                     duration_seconds=attempt_result.duration_seconds,
                     outcome=outcome,
                     usage=attempt_result.usage,
+                    transcript=_persist_transcript(attempt_result.transcript),
                     cheat_evidence=cheat_violations,
                 ),
                 task,
@@ -345,6 +354,7 @@ def _run_attempt(
                 duration_seconds=attempt_result.duration_seconds,
                 outcome=outcome,
                 usage=attempt_result.usage,
+                transcript=_persist_transcript(attempt_result.transcript),
                 assert_passed=judge_result.assert_passed,
                 assert_evidence=judge_result.assert_evidence,
                 autorater_passed=judge_result.autorater_passed,

--- a/caliper/schema/results.py
+++ b/caliper/schema/results.py
@@ -70,6 +70,16 @@ class SkillSnapshot(BaseModel):
     files: dict[str, FileSnapshot] = Field(default_factory=dict)
 
 
+class TranscriptTurn(BaseModel):
+    """One turn in an attempt's conversation, including tool calls when present."""
+
+    role: str
+    content: str
+    tool_name: str | None = None
+    tool_input: dict | None = None
+    tool_output: str | None = None
+
+
 class RunMeta(BaseModel):
     spec: str
     timestamp: datetime
@@ -90,6 +100,9 @@ class AttemptRecord(BaseModel):
     # Token accounting for this attempt, when the backend reports it. Optional so
     # results saved before usage tracking still load (they render as "—").
     usage: TokenUsage | None = None
+    # Ordered conversation turns, including tool_use/tool_result when present.
+    # Optional so results saved before transcript persistence still load.
+    transcript: list[TranscriptTurn] | None = None
     cheat_evidence: list[str] = Field(default_factory=list)
     assert_passed: bool | None = None
     assert_evidence: str | None = None

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -138,11 +138,12 @@ trajectory by running `hermes -z` then `hermes sessions export`.
 Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.json`
 alongside the spec file. Each result includes a full skill snapshot (content + git SHA
 of the skill file and any referenced scripts) for reproducibility. Each attempt
-records its `outcome` (see above), an optional `usage` block (token counts), and
-per-task results include an `unusable` count; a task with no usable attempts has
-`score: null`. When `--fail-fast N` stops a task early, that task may contain
-fewer than k attempt records. Run-level usage totals are **derived** at render
-time, not persisted — the saved JSON holds only per-attempt `usage`, while
+records its `outcome` (see above), an optional `usage` block (token counts), an
+optional `transcript` array (ordered turns with `tool_name`/`tool_input`/`tool_output`
+when present), and per-task results include an `unusable` count; a task with no usable
+attempts has `score: null`. When `--fail-fast N` stops a task early, that task may
+contain fewer than k attempt records. Run-level usage totals are **derived** at
+render time, not persisted — the saved JSON holds only per-attempt `usage`, while
 `report --format json` adds a computed `usage_totals` block.
 
 ## Designing good evals — full guidance

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -150,3 +150,12 @@ If the skill under test needs MCP tools, declare them in a top-level `mcp:` bloc
 The skill engine (`--model`) and judge engine (`--judge-model`) are chosen independently at run time. Every backend is a CLI agent; for API billing, configure a CLI with an API key rather than selecting a separate backend.
 
 `hermes` is a stateful agent (persistent memory + persona), so Caliper strips it to a neutral agent per attempt — isolated `HERMES_HOME`, no `SOUL.md`/`MEMORY.md`, `--ignore-rules`, skill-under-test staged as the only local skill — and recovers the full trajectory via `hermes sessions export` after the `hermes -z` run.
+
+## Results storage
+
+Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.json`
+alongside the spec file. Each attempt records its `outcome`, optional `usage`, and
+optional `transcript` (ordered turns with `tool_name`/`tool_input`/`tool_output` when present)
+so saved runs remain inspectable after the fact — including which MCP tools fired.
+Older JSON without `transcript` still loads (`null`). `report` and `compare` do not
+render the transcript; it is stored for later analysis.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from caliper.harness.base import AttemptResult, HarnessBackend
+from caliper.harness.base import AttemptResult, ConversationTurn, HarnessBackend
 from caliper.judge.base import JudgeResult
 from caliper.runner import _stage_skill_directory, run
 from caliper.schema.results import Outcome
@@ -422,3 +422,67 @@ def test_runmeta_prefers_explicit_model_over_resolved(tmp_path) -> None:
     )
 
     assert results.run.model == "anthropic/claude-sonnet-4.6"
+
+
+class TranscriptHarness(HarnessBackend):
+    @property
+    def name(self) -> str:
+        return "transcript"
+
+    def run(
+        self,
+        task_id: str,
+        attempt: int,
+        prompt: str,
+        *,
+        skill_path: str | None,
+        model: str | None,
+        timeout: int,
+        isolated_home: str,
+        extra_path: list[str] | None = None,
+        mcp_servers: dict | None = None,
+    ) -> AttemptResult:
+        return AttemptResult(
+            task_id=task_id,
+            attempt=attempt,
+            transcript=[
+                ConversationTurn(role="assistant", content="calling tool"),
+                ConversationTurn(
+                    role="tool_use",
+                    content="[tool: mcp__wiki__read]",
+                    tool_name="mcp__wiki__read",
+                    tool_input={"page": "home"},
+                ),
+                ConversationTurn(
+                    role="tool_result",
+                    content="ok",
+                    tool_name="mcp__wiki__read",
+                    tool_output="ok",
+                ),
+            ],
+            final_output="done",
+            exit_code=0,
+            duration_seconds=0.2,
+        )
+
+
+def test_runner_persists_attempt_transcript(tmp_path) -> None:
+    spec_path = tmp_path / "transcript.eval.yaml"
+    spec_path.write_text("skill: {}\ntasks: []\n")
+
+    results = run(
+        spec=_one_task_spec(),
+        spec_path=spec_path,
+        harness=TranscriptHarness(),
+        judge=RecordingJudge(),
+        k=1,
+        workers=1,
+        timeout=30,
+    )
+
+    attempt = results.task_results[0].attempts[0]
+    assert attempt.transcript is not None
+    assert len(attempt.transcript) == 3
+    assert attempt.transcript[1].tool_name == "mcp__wiki__read"
+    assert attempt.transcript[1].tool_input == {"page": "home"}
+    assert attempt.transcript[2].tool_output == "ok"

--- a/tests/test_transcript_persistence.py
+++ b/tests/test_transcript_persistence.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from caliper.schema.results import (
+    AggregateScore,
+    AttemptRecord,
+    Outcome,
+    RunMeta,
+    RunResults,
+    SkillSnapshot,
+    TaskResult,
+    TranscriptTurn,
+)
+
+
+def test_old_results_json_without_transcript_still_loads() -> None:
+    old = {
+        "attempt": 1,
+        "output": "hi",
+        "duration_seconds": 2.0,
+        "outcome": "pass",
+    }
+    record = AttemptRecord.model_validate(old)
+    assert record.transcript is None
+    assert record.passed is True
+
+
+def test_attempt_record_transcript_round_trips_through_json() -> None:
+    record = AttemptRecord(
+        attempt=1,
+        output="done",
+        duration_seconds=3.5,
+        outcome=Outcome.PASS,
+        transcript=[
+            TranscriptTurn(
+                role="assistant",
+                content="I'll read the wiki structure.",
+            ),
+            TranscriptTurn(
+                role="tool_use",
+                content="[tool: mcp__deepwiki__read_wiki_structure]",
+                tool_name="mcp__deepwiki__read_wiki_structure",
+                tool_input={"repo": "edonadei/caliper"},
+            ),
+            TranscriptTurn(
+                role="tool_result",
+                content='{"sections": ["intro"]}',
+                tool_name="mcp__deepwiki__read_wiki_structure",
+                tool_output='{"sections": ["intro"]}',
+            ),
+        ],
+    )
+
+    restored = AttemptRecord.model_validate_json(record.model_dump_json())
+    assert restored.transcript is not None
+    assert len(restored.transcript) == 3
+    assert restored.transcript[1].tool_name == "mcp__deepwiki__read_wiki_structure"
+    assert restored.transcript[1].tool_input == {"repo": "edonadei/caliper"}
+    assert restored.transcript[2].tool_output == '{"sections": ["intro"]}'
+
+
+def test_run_results_transcript_round_trips_through_json() -> None:
+    results = RunResults(
+        run=RunMeta(
+            spec="demo",
+            timestamp=datetime(2026, 7, 12, tzinfo=timezone.utc),
+            k=1,
+            backend="claude-code",
+        ),
+        skill_snapshot=SkillSnapshot(path="/fake/SKILL.md"),
+        task_results=[
+            TaskResult(
+                task_id="t1",
+                task_name="Task 1",
+                attempts=[
+                    AttemptRecord(
+                        attempt=1,
+                        output="ok",
+                        duration_seconds=1.0,
+                        outcome=Outcome.INFRA_ERROR,
+                        transcript=[
+                            TranscriptTurn(
+                                role="assistant",
+                                content="starting",
+                            )
+                        ],
+                    )
+                ],
+                successes=0,
+                unusable=1,
+                pass_at_k=None,
+            )
+        ],
+        aggregate=AggregateScore(avg_score=0.0, per_task=[]),
+    )
+
+    restored = RunResults.model_validate_json(results.model_dump_json())
+    attempt = restored.task_results[0].attempts[0]
+    assert attempt.outcome == Outcome.INFRA_ERROR
+    assert attempt.transcript is not None
+    assert attempt.transcript[0].content == "starting"


### PR DESCRIPTION
## Summary

Persist the full attempt conversation transcript (including tool_use/tool_result turns) in saved `.caliper/results/` JSON so runs remain inspectable after completion.

## Motivation

`AttemptResult.transcript` was already built in memory and used for cheat detection and judging, but dropped when writing results. This made it impossible to inspect which MCP tools fired after a run ended (see #48 context in #55).

## Changes

- Add `TranscriptTurn` model and optional `transcript` field on `AttemptRecord`
- Populate transcript from `AttemptResult.transcript` in all three runner outcome paths (pre-judge, cheat, judge)
- Document the new field in `README.md`, `skills/evaluate-skill/REFERENCE.md`, and `skills/grill-skill/REFERENCE.md`
- Add backwards-compat and round-trip tests plus a runner integration test

## Tests

```bash
pip install -e ".[dev]"
pytest
ruff format --check .
ruff check .
caliper validate skills/evaluate-skill/evaluate-skill.eval.yaml
```

- 204 tests passed
- ruff format/check passed
- caliper validate passed

## Notes

- `report` and `compare` rendering are intentionally unchanged; transcript is stored for later analysis only
- Secret redaction in persisted tool I/O is explicitly out of scope (noted in #55)

Fixes #55