### PR TITLE
Collapse the vestigial Judge ABC into a Protocol

### DIFF
--- a/caliper/judge/base.py
+++ b/caliper/judge/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Protocol
 
 from caliper.harness.base import ConversationTurn
 from caliper.schema.spec import TaskSpec
@@ -25,10 +25,14 @@ class JudgeResult:
     resolved_model: str | None = None
 
 
-class Judge(ABC):
-    strategy: str = "autorater"
+class Judge(Protocol):
+    """The judge contract: what the runner depends on to grade an attempt.
 
-    @abstractmethod
+    A structural seam, not a family — there is one production implementation
+    (``EvalJudge``); test doubles conform by shape. Backend variation lives in
+    ``HarnessBackend.run_prompt`` (see PR #61), not here.
+    """
+
     def evaluate(
         self,
         task: TaskSpec,

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -137,8 +137,6 @@ def _run_assert_from_task(task: TaskSpec, spec_dir: str) -> tuple[bool, str] | N
 class EvalJudge(Judge):
     """Universal judge: runs the static assert script and/or calls an LLM to evaluate."""
 
-    strategy = "script"
-
     def __init__(
         self, backend: str = DEFAULT_BACKEND, model: str | None = None
     ) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -9,7 +9,7 @@ from caliper.harness.base import (
     HarnessConfigurationError,
 )
 from caliper.harness.mcp import resolve_servers
-from caliper.judge.base import Judge, JudgeResult
+from caliper.judge.base import JudgeResult
 from caliper.runner import run
 from caliper.schema.spec import EvalSpec, McpServer, SkillConfig, TaskSpec
 
@@ -275,7 +275,7 @@ class _McpHarness(HarnessBackend):
         )
 
 
-class _PassJudge(Judge):
+class _PassJudge:
     def evaluate(self, task, transcript, final_output, spec_dir) -> JudgeResult:
         return JudgeResult(passed=True, reasoning="ok")
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from caliper.harness.base import AttemptResult, HarnessBackend
-from caliper.judge.base import Judge, JudgeResult
+from caliper.judge.base import JudgeResult
 from caliper.runner import _stage_skill_directory, run
 from caliper.schema.results import Outcome
 from caliper.schema.spec import EvalSpec, SkillConfig, TaskSpec
@@ -108,7 +108,7 @@ class MixedOutcomeHarness(HarnessBackend):
         )
 
 
-class RecordingJudge(Judge):
+class RecordingJudge:
     def __init__(self) -> None:
         self.calls = 0
 
@@ -117,7 +117,7 @@ class RecordingJudge(Judge):
         return JudgeResult(passed=True, reasoning="should not run")
 
 
-class JudgeErrorThenPass(Judge):
+class JudgeErrorThenPass:
     def __init__(self) -> None:
         self.calls = 0
 
@@ -350,7 +350,7 @@ class ResolvedModelHarness(HarnessBackend):
         )
 
 
-class ModelReportingJudge(Judge):
+class ModelReportingJudge:
     """A judge that reports the concrete model its autorater resolved."""
 
     def __init__(self, resolved_model: str) -> None:


### PR DESCRIPTION
## What

Follow-up to #61. That PR moved backend variation down into `HarnessBackend.run_prompt` and deleted the four judge driver modules — which left `caliper/judge/base.py` carrying a `Judge` ABC that no longer models a family of judges, plus a dead field.

Post-#61 reality:
- **One** production implementer, `EvalJudge`. The four `(Judge)` subclasses that remained were all test doubles.
- `Judge.strategy` (`= "autorater"`, overridden to `"script"`) was **read nowhere** — it *looked* like a dispatch key but was inert.
- The one place the abstraction earned its keep is the runner: `run_task(judge: Judge, ...)` depends on the contract, not on `EvalJudge`, so test doubles can substitute.

So the ABC's real job was a **test seam**, not polymorphism over judge kinds.

## Change

- **`base.py`:** `Judge(ABC)` → `Judge(Protocol)` — a plain static structural seam (no `@runtime_checkable`; nothing does `isinstance`). Drop the dead `strategy` field. Add a docstring naming the file's responsibility: the judge contract the runner depends on, plus the `JudgeResult` verdict. `JudgeResult` stays put.
- **`EvalJudge`:** keeps explicit `class EvalJudge(Judge)` for type-checked conformance on the real judge; drops its `strategy = "script"`.
- **Four test doubles** (`RecordingJudge`, `JudgeErrorThenPass`, `ModelReportingJudge`, `_PassJudge`): conform structurally now — no base class.
- **`runner.py`:** unchanged. `judge: Judge` is now satisfied by the Protocol, so the evaluation loop stays decoupled from `EvalJudge`.

## Out of scope

No second judge strategy is planned; `EvalJudge` is the whole story. The single-shot "autorater writes and runs a Python assert script" capability in `script_assert.py` is untouched.

## Verification

`ruff format --check .` / `ruff check .` clean (pinned 0.13.0); 204 passed. The runner tests exercise substitutability through the (now structural) doubles, so green confirms the Protocol seam holds.