### PR TITLE
Render README compare examples as Markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,15 @@ caliper run commit-commands.eval.yaml --k 3 --baseline
 
 You write a spec — a few lines of YAML describing what "working" means, which you hand-write or have `/grill-skill` generate for you. With `--baseline`, Caliper runs each task with and without the skill and diffs the two runs task by task:
 
-```text
-─────────────────── CALIPER  —  compare  —  commit-commands ────────────────────
-    no skill → with skill   ·   k=3
+**CALIPER — compare — `commit-commands`** · `no skill → with skill` · k=3
 
-╭───────────────────────┬─────────────────┬────────┬───────────╮
-│ Task                  │         success │      Δ │ attempts  │
-├───────────────────────┼─────────────────┼────────┼───────────┤
-│ Commits a new feature │  33.3% → 100.0% │ +66.7% │ ✓✗✗ → ✓✓✓ │
-│ Commits a bug fix     │  33.3% → 100.0% │ +66.7% │ ✗✓✗ → ✓✓✓ │
-╰───────────────────────┴─────────────────┴────────┴───────────╯
+| Task | success | Δ | attempts |
+|---|---:|---:|---|
+| Commits a new feature | 33.3% → 100.0% | +66.7% | ✓✗✗ → ✓✓✓ |
+| Commits a bug fix | 33.3% → 100.0% | +66.7% | ✗✓✗ → ✓✓✓ |
 
- Overall  33.3% → 100.0%   Δ (matched) +66.7% ↑
- Tokens  290K → 180K   Δ -38% (-110K)
- Wall    1m 1s → 42s   Δ -31% (-19s)
-```
+**Overall** 33.3% → 100.0% · Δ (matched) **+66.7% ↑** · **Tokens** 290K → 180K (−38%, −110K) · **Wall** 1m 1s → 42s (−31%, −19s)
+
 ---
 
 Agent skills are hard to test. A skill that works on your machine, on this prompt, today, might fail tomorrow after a model update or a one-line prompt edit. Caliper makes reliability measurable: define what success looks like, run the skill repeatedly, and get a success rate you can track over time.
@@ -495,25 +489,19 @@ Each positional (`A`, `B`) is addressed exactly like `report`'s argument: a spec
 name (which resolves to its latest run) or a path to a results JSON. There are
 no `--run-a/-b` flags. To pin a historical run, name its JSON path.
 
-```
-──────────────────── CALIPER  —  compare  —  commit-simple ─────────────────────
-    2026-07-01T10-00-00Z (claude-code) → 2026-07-02T09-00-00Z (claude-code)   ·   k=5
+**CALIPER — compare — `commit-simple`** · 2026-07-01T10-00-00Z (claude-code) → 2026-07-02T09-00-00Z (claude-code) · k=5
 
-╭──────────────────┬─────────────────┬────────┬───────────────╮
-│ Task             │         success │      Δ │ attempts      │
-├──────────────────┼─────────────────┼────────┼───────────────┤
-│ commits cleanly  │ 100.0% → 100.0% │      — │ ✓✓✓✓✓ → ✓✓✓✓✓ │
-│ handles conflict │  100.0% → 20.0% │ -80.0% │ ✓✓✓✓✓ → ✓✗✗✗✗ │
-│ pushes upstream  │       80.0% → — │      — │ ✓✓✓✓✗ → ⊘⊘⊘⊘⊘ │
-╰──────────────────┴─────────────────┴────────┴───────────────╯
+| Task | success | Δ | attempts |
+|---|---:|---:|---|
+| commits cleanly | 100.0% → 100.0% | — | ✓✓✓✓✓ → ✓✓✓✓✓ |
+| handles conflict | 100.0% → 20.0% | -80.0% | ✓✓✓✓✓ → ✓✗✗✗✗ |
+| pushes upstream | 80.0% → — | — | ✓✓✓✓✗ → ⊘⊘⊘⊘⊘ |
 
- Overall  100.0% → 60.0%   Δ (matched) -40.0% ↓
- Tokens  1.2M → 700K   Δ -42% (-500K)
- Wall    6m 18s → 3m 40s   Δ -42% (-2m 38s)
- ⚠ 1 regression: handles conflict
- ⊘ 1 unmeasured (excluded from Δ): pushes upstream
- unmatched — only in A: flaky task   only in B: new task
-```
+- **Overall** 100.0% → 60.0% · Δ (matched) **-40.0% ↓**
+- **Tokens** 1.2M → 700K (−42%, −500K) · **Wall** 6m 18s → 3m 40s (−42%, −2m 38s)
+- ⚠ 1 regression: handles conflict
+- ⊘ 1 unmeasured (excluded from Δ): pushes upstream
+- unmatched — only in A: flaky task · only in B: new task
 
 How the diff reads:
 


### PR DESCRIPTION
## What

Converts the two `caliper compare` sample outputs in `README.md` from hand-drawn ASCII-box tables to Markdown tables.

## Why

The old blocks were authored at **one monospace cell per glyph**. But `✓ ✗ ⊘ → Δ` are Unicode **ambiguous-width** symbols: many fonts/renderers (GitHub web, some terminals, phones) draw them wider than one cell while the box-drawing borders (`│ ╭ ┼`) stay exactly one cell. The result is the borders drifting out of alignment — and the drift changes with the reader's screen and font, which is the "weird table" that was reported.

Padding the columns can't fix this durably: spaces are always one cell, but the overflow from a wide glyph is font-dependent and often fractional, so no fixed amount of padding lines up the border rows and the glyph rows across every font.

## Fix

Markdown tables are rendered by GitHub as **HTML cells that size to their content**, so they can't misalign regardless of glyph width. The run-context header and the Overall/Tokens/Wall summary lines move into surrounding prose. No code or tooling changes — the CLI still emits its `rich` tables unchanged; this only affects how the docs display.

## Trade-off

The samples lose the literal terminal look (no ASCII box). If keeping the exact terminal aesthetic matters more, the alternative is rendering these blocks as SVG images — heavier, but pixel-identical everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015cjuwQg5gkyR9KQzky5N3p)_