### PR TITLE
Render the caliper run sample to SVG, matching the compare examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,25 +118,9 @@ caliper run my-skill.eval.yaml --k 3          # add --baseline to diff vs the ba
 
 **4. Read the output**
 
-```text
-─────────── CALIPER  —  my-skill  (claude-code)  —  2026-06-19 14:23 ───────────
+![caliper run of my-skill at k=3: 'Writes a conventional commit message' passes 3/3 (100.0%), 'Generates a valid config file' 2/3 (66.7%, PARTIAL); overall Score 83.3%, 159K in / 2K out, 1m 0s wall at 10.0s per attempt, with a failure panel showing the failing attempt's assertion error](docs/assets/run-output.svg)
 
-╭──────────────────────────────────┬───────┬─────────┬────────┬──────┬───────────╮
-│ Task                             │ k (3) │ success │ Tokens │ Wall │           │
-├──────────────────────────────────┼───────┼─────────┼────────┼──────┼───────────┤
-│ Writes a conventional commit msg │  3/3  │  100.0% │    79K │  27s │  ✓ PASS   │
-│ Generates a valid config file    │  2/3  │   66.7% │    82K │  33s │ ~ PARTIAL │
-╰──────────────────────────────────┴───────┴─────────┴────────┴──────┴───────────╯
-
- Score   83.3%  █████████████████░░░
-
- Tokens   159K in / 2K out
- Wall     1m 0s  10.0s per attempt
-
-Results saved to .caliper/results/my-skill/2026-06-19T14-23-01Z.json
-```
-
-`--verbose` adds `pass@k` and `pass^k` columns (both derived from the raw rate).
+The report ends with the per-task failure panels — for each attempt that didn't pass, the output plus the assertion or autorater reason *why*. Full results are also saved as JSON under `.caliper/results/<spec>/` for you to inspect or `caliper compare` later. `--verbose` adds `pass@k` and `pass^k` columns (both derived from the raw rate) and a panel for every task.
 
 ### Not sure what to put in a spec?
 

--- a/docs/assets/run-output.svg
+++ b/docs/assets/run-output.svg
@@ -1,0 +1,164 @@
+<svg class="rich-terminal" viewBox="0 0 1141 660.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1841590463-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1841590463-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1841590463-r1 { fill: #c5c8c6 }
+.terminal-1841590463-r2 { fill: #68a0b3 }
+.terminal-1841590463-r3 { fill: #68a0b3;font-weight: bold }
+.terminal-1841590463-r4 { fill: #c5c8c6;font-weight: bold }
+.terminal-1841590463-r5 { fill: #00823d;font-weight: bold }
+.terminal-1841590463-r6 { fill: #868887 }
+.terminal-1841590463-r7 { fill: #98a84b;font-weight: bold }
+.terminal-1841590463-r8 { fill: #d0b344;font-weight: bold }
+.terminal-1841590463-r9 { fill: #98a84b }
+.terminal-1841590463-r10 { fill: #868887;font-weight: bold }
+.terminal-1841590463-r11 { fill: #cc555a }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1841590463-clip-terminal">
+      <rect x="0" y="0" width="1121.3999999999999" height="609.0" />
+    </clipPath>
+    <clipPath id="terminal-1841590463-line-0">
+    <rect x="0" y="1.5" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-1">
+    <rect x="0" y="25.9" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-2">
+    <rect x="0" y="50.3" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-3">
+    <rect x="0" y="74.7" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-4">
+    <rect x="0" y="99.1" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-5">
+    <rect x="0" y="123.5" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-6">
+    <rect x="0" y="147.9" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-7">
+    <rect x="0" y="172.3" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-8">
+    <rect x="0" y="196.7" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-9">
+    <rect x="0" y="221.1" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-10">
+    <rect x="0" y="245.5" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-11">
+    <rect x="0" y="269.9" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-12">
+    <rect x="0" y="294.3" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-13">
+    <rect x="0" y="318.7" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-14">
+    <rect x="0" y="343.1" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-15">
+    <rect x="0" y="367.5" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-16">
+    <rect x="0" y="391.9" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-17">
+    <rect x="0" y="416.3" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-18">
+    <rect x="0" y="440.7" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-19">
+    <rect x="0" y="465.1" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-20">
+    <rect x="0" y="489.5" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-21">
+    <rect x="0" y="513.9" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-22">
+    <rect x="0" y="538.3" width="1122.4" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1841590463-line-23">
+    <rect x="0" y="562.7" width="1122.4" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1139" height="658" rx="8"/><text class="terminal-1841590463-title" fill="#c5c8c6" text-anchor="middle" x="569" y="27">caliper&#160;run</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1841590463-clip-terminal)">
+    
+    <g class="terminal-1841590463-matrix">
+    <text class="terminal-1841590463-r1" x="1122.4" y="20" textLength="12.2" clip-path="url(#terminal-1841590463-line-0)">
+</text><text class="terminal-1841590463-r2" x="0" y="44.4" textLength="85.4" clip-path="url(#terminal-1841590463-line-1)">──────&#160;</text><text class="terminal-1841590463-r3" x="85.4" y="44.4" textLength="85.4" clip-path="url(#terminal-1841590463-line-1)">CALIPER</text><text class="terminal-1841590463-r1" x="170.8" y="44.4" textLength="61" clip-path="url(#terminal-1841590463-line-1)">&#160;&#160;—&#160;&#160;</text><text class="terminal-1841590463-r4" x="231.8" y="44.4" textLength="97.6" clip-path="url(#terminal-1841590463-line-1)">my-skill</text><text class="terminal-1841590463-r4" x="353.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-1)">(</text><text class="terminal-1841590463-r2" x="366" y="44.4" textLength="134.2" clip-path="url(#terminal-1841590463-line-1)">claude-code</text><text class="terminal-1841590463-r4" x="500.2" y="44.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-1)">)</text><text class="terminal-1841590463-r1" x="512.4" y="44.4" textLength="329.4" clip-path="url(#terminal-1841590463-line-1)">&#160;&#160;·&#160;&#160;judge&#160;claude-code&#160;&#160;—&#160;&#160;</text><text class="terminal-1841590463-r3" x="841.8" y="44.4" textLength="48.8" clip-path="url(#terminal-1841590463-line-1)">2026</text><text class="terminal-1841590463-r1" x="890.6" y="44.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-1)">-</text><text class="terminal-1841590463-r3" x="902.8" y="44.4" textLength="24.4" clip-path="url(#terminal-1841590463-line-1)">06</text><text class="terminal-1841590463-r1" x="927.2" y="44.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-1)">-</text><text class="terminal-1841590463-r3" x="939.4" y="44.4" textLength="24.4" clip-path="url(#terminal-1841590463-line-1)">19</text><text class="terminal-1841590463-r5" x="976" y="44.4" textLength="61" clip-path="url(#terminal-1841590463-line-1)">14:23</text><text class="terminal-1841590463-r2" x="1037" y="44.4" textLength="85.4" clip-path="url(#terminal-1841590463-line-1)">&#160;──────</text><text class="terminal-1841590463-r1" x="1122.4" y="44.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-1)">
+</text><text class="terminal-1841590463-r1" x="1122.4" y="68.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-2)">
+</text><text class="terminal-1841590463-r1" x="0" y="93.2" textLength="1049.2" clip-path="url(#terminal-1841590463-line-3)">╭──────────────────────────────────────┬───────┬─────────┬────────┬──────┬───────────╮</text><text class="terminal-1841590463-r1" x="1122.4" y="93.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-3)">
+</text><text class="terminal-1841590463-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-4)">│</text><text class="terminal-1841590463-r3" x="24.4" y="117.6" textLength="439.2" clip-path="url(#terminal-1841590463-line-4)">Task&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1841590463-r1" x="475.8" y="117.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-4)">│</text><text class="terminal-1841590463-r3" x="500.2" y="117.6" textLength="61" clip-path="url(#terminal-1841590463-line-4)">k&#160;(3)</text><text class="terminal-1841590463-r1" x="573.4" y="117.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-4)">│</text><text class="terminal-1841590463-r3" x="597.8" y="117.6" textLength="85.4" clip-path="url(#terminal-1841590463-line-4)">success</text><text class="terminal-1841590463-r1" x="695.4" y="117.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-4)">│</text><text class="terminal-1841590463-r3" x="719.8" y="117.6" textLength="73.2" clip-path="url(#terminal-1841590463-line-4)">Tokens</text><text class="terminal-1841590463-r1" x="805.2" y="117.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-4)">│</text><text class="terminal-1841590463-r3" x="829.6" y="117.6" textLength="48.8" clip-path="url(#terminal-1841590463-line-4)">Wall</text><text class="terminal-1841590463-r1" x="890.6" y="117.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-4)">│</text><text class="terminal-1841590463-r1" x="1037" y="117.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-4)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="117.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-4)">
+</text><text class="terminal-1841590463-r1" x="0" y="142" textLength="1049.2" clip-path="url(#terminal-1841590463-line-5)">├──────────────────────────────────────┼───────┼─────────┼────────┼──────┼───────────┤</text><text class="terminal-1841590463-r1" x="1122.4" y="142" textLength="12.2" clip-path="url(#terminal-1841590463-line-5)">
+</text><text class="terminal-1841590463-r1" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-6)">│</text><text class="terminal-1841590463-r1" x="24.4" y="166.4" textLength="439.2" clip-path="url(#terminal-1841590463-line-6)">Writes&#160;a&#160;conventional&#160;commit&#160;message</text><text class="terminal-1841590463-r1" x="475.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-6)">│</text><text class="terminal-1841590463-r1" x="500.2" y="166.4" textLength="61" clip-path="url(#terminal-1841590463-line-6)">&#160;3/3&#160;</text><text class="terminal-1841590463-r1" x="573.4" y="166.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-6)">│</text><text class="terminal-1841590463-r1" x="597.8" y="166.4" textLength="85.4" clip-path="url(#terminal-1841590463-line-6)">&#160;100.0%</text><text class="terminal-1841590463-r1" x="695.4" y="166.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-6)">│</text><text class="terminal-1841590463-r6" x="719.8" y="166.4" textLength="73.2" clip-path="url(#terminal-1841590463-line-6)">&#160;&#160;&#160;79K</text><text class="terminal-1841590463-r1" x="805.2" y="166.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-6)">│</text><text class="terminal-1841590463-r6" x="829.6" y="166.4" textLength="48.8" clip-path="url(#terminal-1841590463-line-6)">&#160;27s</text><text class="terminal-1841590463-r1" x="890.6" y="166.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-6)">│</text><text class="terminal-1841590463-r7" x="915" y="166.4" textLength="109.8" clip-path="url(#terminal-1841590463-line-6)">&#160;✓&#160;PASS&#160;&#160;</text><text class="terminal-1841590463-r1" x="1037" y="166.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-6)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="166.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-6)">
+</text><text class="terminal-1841590463-r1" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-7)">│</text><text class="terminal-1841590463-r1" x="24.4" y="190.8" textLength="439.2" clip-path="url(#terminal-1841590463-line-7)">Generates&#160;a&#160;valid&#160;config&#160;file&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1841590463-r1" x="475.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-7)">│</text><text class="terminal-1841590463-r1" x="500.2" y="190.8" textLength="61" clip-path="url(#terminal-1841590463-line-7)">&#160;2/3&#160;</text><text class="terminal-1841590463-r1" x="573.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-7)">│</text><text class="terminal-1841590463-r1" x="597.8" y="190.8" textLength="85.4" clip-path="url(#terminal-1841590463-line-7)">&#160;&#160;66.7%</text><text class="terminal-1841590463-r1" x="695.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-7)">│</text><text class="terminal-1841590463-r6" x="719.8" y="190.8" textLength="73.2" clip-path="url(#terminal-1841590463-line-7)">&#160;&#160;&#160;82K</text><text class="terminal-1841590463-r1" x="805.2" y="190.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-7)">│</text><text class="terminal-1841590463-r6" x="829.6" y="190.8" textLength="48.8" clip-path="url(#terminal-1841590463-line-7)">&#160;33s</text><text class="terminal-1841590463-r1" x="890.6" y="190.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-7)">│</text><text class="terminal-1841590463-r8" x="915" y="190.8" textLength="109.8" clip-path="url(#terminal-1841590463-line-7)">~&#160;PARTIAL</text><text class="terminal-1841590463-r1" x="1037" y="190.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-7)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-7)">
+</text><text class="terminal-1841590463-r1" x="0" y="215.2" textLength="1049.2" clip-path="url(#terminal-1841590463-line-8)">╰──────────────────────────────────────┴───────┴─────────┴────────┴──────┴───────────╯</text><text class="terminal-1841590463-r1" x="1122.4" y="215.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-8)">
+</text><text class="terminal-1841590463-r1" x="1122.4" y="239.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-9)">
+</text><text class="terminal-1841590463-r4" x="12.2" y="264" textLength="61" clip-path="url(#terminal-1841590463-line-10)">Score</text><text class="terminal-1841590463-r3" x="109.8" y="264" textLength="48.8" clip-path="url(#terminal-1841590463-line-10)">83.3</text><text class="terminal-1841590463-r2" x="158.6" y="264" textLength="12.2" clip-path="url(#terminal-1841590463-line-10)">%</text><text class="terminal-1841590463-r9" x="195.2" y="264" textLength="207.4" clip-path="url(#terminal-1841590463-line-10)">█████████████████</text><text class="terminal-1841590463-r6" x="402.6" y="264" textLength="36.6" clip-path="url(#terminal-1841590463-line-10)">░░░</text><text class="terminal-1841590463-r1" x="1122.4" y="264" textLength="12.2" clip-path="url(#terminal-1841590463-line-10)">
+</text><text class="terminal-1841590463-r1" x="1122.4" y="288.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-11)">
+</text><text class="terminal-1841590463-r4" x="0" y="312.8" textLength="85.4" clip-path="url(#terminal-1841590463-line-12)">&#160;Tokens</text><text class="terminal-1841590463-r1" x="122" y="312.8" textLength="292.8" clip-path="url(#terminal-1841590463-line-12)">159K&#160;in&#160;/&#160;2K&#160;out&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1841590463-r1" x="1122.4" y="312.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-12)">
+</text><text class="terminal-1841590463-r4" x="0" y="337.2" textLength="85.4" clip-path="url(#terminal-1841590463-line-13)">&#160;Wall&#160;&#160;</text><text class="terminal-1841590463-r1" x="122" y="337.2" textLength="85.4" clip-path="url(#terminal-1841590463-line-13)">1m&#160;0s&#160;&#160;</text><text class="terminal-1841590463-r6" x="207.4" y="337.2" textLength="207.4" clip-path="url(#terminal-1841590463-line-13)">10.0s&#160;per&#160;attempt</text><text class="terminal-1841590463-r1" x="1122.4" y="337.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-13)">
+</text><text class="terminal-1841590463-r1" x="1122.4" y="361.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-14)">
+</text><text class="terminal-1841590463-r1" x="1122.4" y="386" textLength="12.2" clip-path="url(#terminal-1841590463-line-15)">
+</text><text class="terminal-1841590463-r6" x="0" y="410.4" textLength="24.4" clip-path="url(#terminal-1841590463-line-16)">╭─</text><text class="terminal-1841590463-r6" x="24.4" y="410.4" textLength="341.6" clip-path="url(#terminal-1841590463-line-16)">────────────────────────────</text><text class="terminal-1841590463-r10" x="378.2" y="410.4" textLength="353.8" clip-path="url(#terminal-1841590463-line-16)">Generates&#160;a&#160;valid&#160;config&#160;file</text><text class="terminal-1841590463-r6" x="744.2" y="410.4" textLength="353.8" clip-path="url(#terminal-1841590463-line-16)">─────────────────────────────</text><text class="terminal-1841590463-r6" x="1098" y="410.4" textLength="24.4" clip-path="url(#terminal-1841590463-line-16)">─╮</text><text class="terminal-1841590463-r1" x="1122.4" y="410.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-16)">
+</text><text class="terminal-1841590463-r6" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-17)">│</text><text class="terminal-1841590463-r1" x="24.4" y="434.8" textLength="158.6" clip-path="url(#terminal-1841590463-line-17)">&#160;&#160;Attempt&#160;1&#160;&#160;</text><text class="terminal-1841590463-r9" x="183" y="434.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-17)">✓</text><text class="terminal-1841590463-r1" x="195.2" y="434.8" textLength="231.8" clip-path="url(#terminal-1841590463-line-17)">&#160;&#160;(11.0s&#160;·&#160;27K&#160;tok)</text><text class="terminal-1841590463-r6" x="1110.2" y="434.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-17)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="434.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-17)">
+</text><text class="terminal-1841590463-r6" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-18)">│</text><text class="terminal-1841590463-r6" x="73.2" y="459.2" textLength="85.4" clip-path="url(#terminal-1841590463-line-18)">output:</text><text class="terminal-1841590463-r1" x="158.6" y="459.2" textLength="329.4" clip-path="url(#terminal-1841590463-line-18)">&#160;Wrote&#160;/tmp/app.config.json</text><text class="terminal-1841590463-r6" x="1110.2" y="459.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-18)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="459.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-18)">
+</text><text class="terminal-1841590463-r6" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-19)">│</text><text class="terminal-1841590463-r1" x="24.4" y="483.6" textLength="158.6" clip-path="url(#terminal-1841590463-line-19)">&#160;&#160;Attempt&#160;2&#160;&#160;</text><text class="terminal-1841590463-r9" x="183" y="483.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-19)">✓</text><text class="terminal-1841590463-r1" x="195.2" y="483.6" textLength="231.8" clip-path="url(#terminal-1841590463-line-19)">&#160;&#160;(11.0s&#160;·&#160;27K&#160;tok)</text><text class="terminal-1841590463-r6" x="1110.2" y="483.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-19)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="483.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-19)">
+</text><text class="terminal-1841590463-r6" x="0" y="508" textLength="12.2" clip-path="url(#terminal-1841590463-line-20)">│</text><text class="terminal-1841590463-r6" x="73.2" y="508" textLength="85.4" clip-path="url(#terminal-1841590463-line-20)">output:</text><text class="terminal-1841590463-r1" x="158.6" y="508" textLength="329.4" clip-path="url(#terminal-1841590463-line-20)">&#160;Wrote&#160;/tmp/app.config.json</text><text class="terminal-1841590463-r6" x="1110.2" y="508" textLength="12.2" clip-path="url(#terminal-1841590463-line-20)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="508" textLength="12.2" clip-path="url(#terminal-1841590463-line-20)">
+</text><text class="terminal-1841590463-r6" x="0" y="532.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-21)">│</text><text class="terminal-1841590463-r1" x="24.4" y="532.4" textLength="158.6" clip-path="url(#terminal-1841590463-line-21)">&#160;&#160;Attempt&#160;3&#160;&#160;</text><text class="terminal-1841590463-r11" x="183" y="532.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-21)">✗</text><text class="terminal-1841590463-r1" x="195.2" y="532.4" textLength="231.8" clip-path="url(#terminal-1841590463-line-21)">&#160;&#160;(11.0s&#160;·&#160;27K&#160;tok)</text><text class="terminal-1841590463-r6" x="1110.2" y="532.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-21)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="532.4" textLength="12.2" clip-path="url(#terminal-1841590463-line-21)">
+</text><text class="terminal-1841590463-r6" x="0" y="556.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-22)">│</text><text class="terminal-1841590463-r6" x="73.2" y="556.8" textLength="85.4" clip-path="url(#terminal-1841590463-line-22)">output:</text><text class="terminal-1841590463-r1" x="158.6" y="556.8" textLength="329.4" clip-path="url(#terminal-1841590463-line-22)">&#160;Wrote&#160;/tmp/app.config.json</text><text class="terminal-1841590463-r6" x="1110.2" y="556.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-22)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="556.8" textLength="12.2" clip-path="url(#terminal-1841590463-line-22)">
+</text><text class="terminal-1841590463-r6" x="0" y="581.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-23)">│</text><text class="terminal-1841590463-r6" x="73.2" y="581.2" textLength="671" clip-path="url(#terminal-1841590463-line-23)">assert:&#160;AssertionError:&#160;data[&#x27;port&#x27;]&#160;==&#160;8080&#160;(got&#160;3000)</text><text class="terminal-1841590463-r6" x="1110.2" y="581.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-23)">│</text><text class="terminal-1841590463-r1" x="1122.4" y="581.2" textLength="12.2" clip-path="url(#terminal-1841590463-line-23)">
+</text><text class="terminal-1841590463-r6" x="0" y="605.6" textLength="1122.4" clip-path="url(#terminal-1841590463-line-24)">╰──────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1841590463-r1" x="1122.4" y="605.6" textLength="12.2" clip-path="url(#terminal-1841590463-line-24)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/render_readme_samples.py
+++ b/docs/render_readme_samples.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python3
-"""Render the README's `caliper compare` example outputs to SVG.
+"""Render the README's sample terminal outputs to SVG.
 
 The README shows sample terminal output. Hand-drawn ASCII-box tables drift out
 of alignment in any renderer that draws the ambiguous-width glyphs (✓ ✗ ⊘ → Δ)
 wider than one cell, which is font-dependent — so the same block looks broken on
 some screens and fine on others. Instead we render the *real* reporter output
-(caliper.reporter.print_comparison) into a recording rich Console and export it
-as SVG: a vector image that looks like a terminal and is pixel-identical
-everywhere, because it no longer depends on the reader's font.
+(caliper.reporter.print_results / print_comparison) into a recording rich Console
+and export it as SVG: a vector image that looks like a terminal and is
+pixel-identical everywhere, because it no longer depends on the reader's font.
 
 These SVGs are committed and embedded in README.md. Regenerate them whenever the
-compare view changes:
+run or compare views change:
 
     python docs/render_readme_samples.py
 
-The two comparisons below are illustrative fixtures, not real runs; they exist
-only to reproduce the numbers the README prose explains. Keep them in sync with
-that prose.
+The fixtures below are illustrative, not real runs; they exist only to reproduce
+the numbers the README prose explains. Keep them in sync with that prose.
 """
 
 from __future__ import annotations
@@ -28,11 +27,18 @@ from pathlib import Path
 from rich.console import Console
 
 import caliper.reporter as reporter
-from caliper.reporter import print_comparison
+from caliper.reporter import print_comparison, print_results
 from caliper.schema.results import (
+    AggregateScore,
+    AttemptRecord,
     Outcome,
     RunComparison,
     RunMeta,
+    RunResults,
+    SkillSnapshot,
+    TaskResult,
+    TaskScore,
+    TokenUsage,
     UsageTotals,
 )
 
@@ -155,13 +161,99 @@ def _compare_example() -> RunComparison:
     )
 
 
-def _render(comp: RunComparison, out_name: str, title: str) -> Path:
+def _att(
+    attempt: int,
+    outcome: Outcome,
+    seconds: float,
+    tokens: TokenUsage,
+    output: str,
+    assert_evidence: str | None = None,
+) -> AttemptRecord:
+    return AttemptRecord(
+        attempt=attempt,
+        output=output,
+        duration_seconds=seconds,
+        outcome=outcome,
+        usage=tokens,
+        assert_passed=None if assert_evidence is None else outcome is P,
+        assert_evidence=assert_evidence,
+    )
+
+
+def _run_example() -> RunResults:
+    """A single `caliper run … --k 3` of the two tasks in the README's spec: a
+    clean-passing autorater task and a script-assertion task that fails once (so
+    the report shows a PASS row, a PARTIAL row, and the failure panel that
+    explains *why*). Token/wall figures are chosen to sum to the summary line."""
+    run = RunMeta(
+        spec="my-skill",
+        timestamp=datetime(2026, 6, 19, 14, 23, 0),
+        k=3,
+        backend="claude-code",
+        judge_backend="claude-code",
+    )
+    # 26_000 in + 350 out per attempt → 79K over three; 9s each → 27s.
+    commit_usage = TokenUsage(input_tokens=26_000, output_tokens=350)
+    commit = TaskResult(
+        task_id="writes-a-conventional-commit-message",
+        task_name="Writes a conventional commit message",
+        attempts=[
+            _att(i, P, 9.0, commit_usage, "feat(auth): add token refresh\n\n…")
+            for i in (1, 2, 3)
+        ],
+        successes=3,
+        unusable=0,
+        pass_at_k=1.0,
+    )
+    # 27_000 in + 350 out per attempt → 82K over three; 11s each → 33s.
+    config_usage = TokenUsage(input_tokens=27_000, output_tokens=350)
+    config = TaskResult(
+        task_id="generates-a-valid-config-file",
+        task_name="Generates a valid config file",
+        attempts=[
+            _att(1, P, 11.0, config_usage, "Wrote /tmp/app.config.json"),
+            _att(2, P, 11.0, config_usage, "Wrote /tmp/app.config.json"),
+            _att(
+                3,
+                F,
+                11.0,
+                config_usage,
+                "Wrote /tmp/app.config.json",
+                assert_evidence="AssertionError: data['port'] == 8080 (got 3000)",
+            ),
+        ],
+        successes=2,
+        unusable=0,
+        pass_at_k=1.0,
+    )
+    task_results = [commit, config]
+    return RunResults(
+        run=run,
+        skill_snapshot=SkillSnapshot(path="./SKILL.md"),
+        task_results=task_results,
+        aggregate=AggregateScore(
+            avg_score=sum(tr.score for tr in task_results) / len(task_results),
+            per_task=[
+                TaskScore(
+                    task_id=tr.task_id,
+                    task_name=tr.task_name,
+                    k=run.k,
+                    successes=tr.successes,
+                    score=tr.score,
+                )
+                for tr in task_results
+            ],
+        ),
+    )
+
+
+def _record_svg(render, out_name: str, title: str) -> Path:
     """Drive the real reporter into a recording console and export SVG."""
     rec = Console(record=True, width=_WIDTH, file=io.StringIO())
     original = reporter.console
     reporter.console = rec
     try:
-        print_comparison(comp)
+        render()
     finally:
         reporter.console = original
     _ASSETS.mkdir(parents=True, exist_ok=True)
@@ -172,8 +264,21 @@ def _render(comp: RunComparison, out_name: str, title: str) -> Path:
 
 def main() -> None:
     for path in (
-        _render(_baseline_example(), "compare-baseline.svg", "caliper compare"),
-        _render(_compare_example(), "compare-runs.svg", "caliper compare"),
+        _record_svg(
+            lambda: print_comparison(_baseline_example()),
+            "compare-baseline.svg",
+            "caliper compare",
+        ),
+        _record_svg(
+            lambda: print_comparison(_compare_example()),
+            "compare-runs.svg",
+            "caliper compare",
+        ),
+        _record_svg(
+            lambda: print_results(_run_example()),
+            "run-output.svg",
+            "caliper run",
+        ),
     ):
         print(f"wrote {path}")
 


### PR DESCRIPTION
## What

Section 4 of the README (**Read the output**) was the last hand-drawn ASCII-box block. The two `caliper compare` examples were already converted to committed SVGs so their ambiguous-width glyphs (`✓ ✗ ⊘ ~`) stop drifting font-dependently — [`docs/render_readme_samples.py`](docs/render_readme_samples.py) explains the reasoning. The `caliper run` example is the same kind of block, so it gets the same treatment: an SVG rendered from the real `reporter.print_results`.

## Changes

- **`docs/render_readme_samples.py`** — new `_run_example()` fixture (two tasks at k=3: a clean autorater PASS + a script-assertion PARTIAL, which also exercises the failure panel). Refactored the render helper into a printer-agnostic `_record_svg` so it drives `print_results` alongside `print_comparison`. The two existing compare SVGs regenerate **byte-identical**, and the script stays idempotent.
- **`docs/assets/run-output.svg`** — new generated image.
- **`README.md`** — swapped the stale `text` mockup for the image, plus a short prose note on the failure panels and where results are saved (the `Results saved to…` line is printed by the CLI, not the reporter, so it's now described rather than faked).

## Bonus fix

The old mockup's numbers didn't add up (rows summed to 161K, the summary said 159K). The fixture's per-task tokens/wall now genuinely sum to the summary line (79K + 82K → 159K in / 2K out; 27s + 33s → 1m 0s at 10.0s/attempt; Score 83.3%).