### PR TITLE
fix(judge): map model-unavailable failures to actionable --judge-model hint

### DIFF
--- a/caliper/judge/errors.py
+++ b/caliper/judge/errors.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import re
+
+_JUDGE_MODEL_HINT = (
+    "Pass `--judge-model <backend[:model]>` to select an available judge model."
+)
+
+
+def _extract_anthropic_not_found_message(text: str) -> str | None:
+    for candidate in (text, *_json_object_candidates(text)):
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        error = payload.get("error")
+        if isinstance(error, dict) and error.get("type") == "not_found_error":
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+    return None
+
+
+def _json_object_candidates(text: str) -> list[str]:
+    return re.findall(r"\{[^{}]*\}", text)
+
+
+def is_model_unavailable(text: str) -> bool:
+    """Return True when *text* looks like a backend model-resolution failure."""
+    if not text.strip():
+        return False
+
+    lowered = text.lower()
+    if _extract_anthropic_not_found_message(text):
+        return True
+    if "not_found_error" in lowered:
+        return True
+    if "model_not_found" in lowered or "model not found" in lowered:
+        return True
+    if "invalid model" in lowered:
+        return True
+    if "does not exist" in lowered and (
+        re.search(r"\bthe model\b", lowered)
+        or ("`" in text and re.search(r"\bmodel\b", lowered))
+    ):
+        return True
+    if re.search(r"\b404\b", text) and re.search(r"\bmodel\b", lowered):
+        return True
+    return False
+
+
+def format_model_unavailable_message(text: str, model: str | None) -> str:
+    detail = _extract_anthropic_not_found_message(text)
+    if detail is None:
+        compact = re.sub(r"\s+", " ", text).strip()
+        detail = compact[:160] if compact else "model unavailable"
+
+    model_part = f" '{model}'" if model else ""
+    return f"Judge model{model_part} is unavailable ({detail}). {_JUDGE_MODEL_HINT}"
+
+
+def judge_failure_reason(raw: str, model: str | None) -> str:
+    if is_model_unavailable(raw):
+        return format_model_unavailable_message(raw, model)
+    return f"Judge returned unparseable response: {raw[:200]}"

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from caliper.harness import get_harness
 from caliper.harness.base import ConversationTurn
 from caliper.judge.base import Judge, JudgeResult
+from caliper.judge.errors import is_model_unavailable, judge_failure_reason
 from caliper.schema.spec import DEFAULT_BACKEND, TaskSpec, resolve_judge_model
 
 _SYSTEM = """\
@@ -89,7 +90,9 @@ def _run_inline_script(code: str, spec_dir: str) -> tuple[bool, str]:
         Path(tmp_path).unlink(missing_ok=True)
 
 
-def _parse_rich_response(raw: str, spec_dir: str) -> tuple[bool, str, bool]:
+def _parse_rich_response(
+    raw: str, spec_dir: str, model: str | None = None
+) -> tuple[bool, str, bool]:
     """Parse an autorater response into (passed, reasoning, errored).
 
     ``errored`` is True when the autorater failed to yield a usable verdict at
@@ -99,7 +102,10 @@ def _parse_rich_response(raw: str, spec_dir: str) -> tuple[bool, str, bool]:
     try:
         verdict = json.loads(raw)
     except json.JSONDecodeError:
-        return False, f"Judge returned unparseable response: {raw[:200]}", True
+        return False, judge_failure_reason(raw, model), True
+
+    if isinstance(verdict, dict) and verdict.get("type") == "error":
+        return False, judge_failure_reason(raw, model), True
 
     mode = verdict.get("mode", "verdict")
     reasoning = str(verdict.get("reasoning", ""))
@@ -217,8 +223,10 @@ class EvalJudge(Judge):
 
         result = harness.run_prompt(prompt, cwd=spec_dir, timeout=60)
         if result.error:
-            return False, result.error, True, result.resolved_model
-        passed, reasoning, errored = _parse_rich_response(
-            _strip_markdown_fence(result.text), spec_dir
-        )
+            error = result.error
+            if is_model_unavailable(error):
+                error = judge_failure_reason(error, self._model)
+            return False, error, True, result.resolved_model
+        raw = _strip_markdown_fence(result.text)
+        passed, reasoning, errored = _parse_rich_response(raw, spec_dir, self._model)
         return passed, reasoning, errored, result.resolved_model

--- a/tests/test_judge_model_unavailable.py
+++ b/tests/test_judge_model_unavailable.py
@@ -29,7 +29,8 @@ def test_is_model_unavailable_openai_style() -> None:
 
 
 def test_is_model_unavailable_rejects_unrelated_unparseable() -> None:
-    assert not is_model_unavailable('{"mode": "verdict", "passed": true')
+    assert not is_model_unavailable('{"mode": "verdict", "passed": true}')
+    assert not is_model_unavailable("model.py does not exist")
 
 
 def test_format_model_unavailable_message_includes_hint() -> None:

--- a/tests/test_judge_model_unavailable.py
+++ b/tests/test_judge_model_unavailable.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from caliper.harness.base import ConversationTurn
+from caliper.judge.errors import (
+    format_model_unavailable_message,
+    is_model_unavailable,
+    judge_failure_reason,
+)
+from caliper.judge.script_assert import EvalJudge
+from caliper.schema.spec import DEFAULT_JUDGE_MODEL, TaskSpec
+
+
+def test_is_model_unavailable_anthropic_not_found_error() -> None:
+    raw = (
+        "API Error: 404\n"
+        '{"type":"error","error":{"type":"not_found_error",'
+        '"message":"model: claude-sonnet-4-20250514"}}'
+    )
+    assert is_model_unavailable(raw)
+
+
+def test_is_model_unavailable_openai_style() -> None:
+    assert is_model_unavailable("ERROR: model_not_found: gpt-5-codex does not exist")
+
+
+def test_is_model_unavailable_rejects_unrelated_unparseable() -> None:
+    assert not is_model_unavailable('{"mode": "verdict", "passed": true')
+
+
+def test_format_model_unavailable_message_includes_hint() -> None:
+    raw = (
+        '{"type":"error","error":{"type":"not_found_error",'
+        '"message":"model: claude-sonnet-5"}}'
+    )
+    message = format_model_unavailable_message(raw, DEFAULT_JUDGE_MODEL)
+    assert "claude-sonnet-5" in message
+    assert "--judge-model" in message
+
+
+def test_judge_failure_reason_preserves_generic_message() -> None:
+    raw = "not json at all"
+    assert judge_failure_reason(raw, None).startswith(
+        "Judge returned unparseable response:"
+    )
+
+
+def _task(**overrides) -> TaskSpec:
+    fields = {"id": "t1", "name": "t", "prompt": "p", "expect": "says ok"}
+    fields.update(overrides)
+    return TaskSpec(**fields)
+
+
+def _spawn(monkeypatch, stdout: str = "", returncode: int = 0, stderr: str = ""):
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(
+            cmd, returncode, stdout=stdout, stderr=stderr
+        )
+
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
+    return calls
+
+
+def _codex_cli_present(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex.cmd")
+    monkeypatch.setattr(
+        "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
+    )
+    monkeypatch.delenv("CODEX_CLI_PATH", raising=False)
+
+
+def test_eval_judge_maps_json_only_model_error(monkeypatch, tmp_path) -> None:
+    stdout = (
+        '{"type":"error","error":{"type":"not_found_error",'
+        '"message":"model: claude-sonnet-4-20250514"}}'
+    )
+    _spawn(monkeypatch, stdout=stdout)
+    judge = EvalJudge(backend="claude-code")
+    result = judge.evaluate(
+        task=_task(expect="x"),
+        transcript=[],
+        final_output="",
+        spec_dir=str(tmp_path),
+    )
+    assert result.errored is True
+    assert "--judge-model" in result.autorater_reasoning
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        (
+            "API Error: 404\n"
+            '{"type":"error","error":{"type":"not_found_error",'
+            '"message":"model: claude-sonnet-4-20250514"}}'
+        ),
+    ],
+)
+def test_eval_judge_maps_model_unavailable_to_actionable_error(
+    monkeypatch, tmp_path, stdout: str
+) -> None:
+    _spawn(monkeypatch, stdout=stdout)
+    judge = EvalJudge(backend="claude-code")
+    result = judge.evaluate(
+        task=_task(expect="The assistant says hello."),
+        transcript=[ConversationTurn(role="assistant", content="hello")],
+        final_output="hello",
+        spec_dir=str(tmp_path),
+    )
+    assert result.errored is True
+    assert "--judge-model" in result.autorater_reasoning
+    assert DEFAULT_JUDGE_MODEL in result.autorater_reasoning
+
+
+def test_eval_judge_codex_harness_error_maps_model_unavailable(
+    monkeypatch, tmp_path
+) -> None:
+    def fake_run(cmd, **kwargs):
+        output_path = cmd[cmd.index("--output-last-message") + 1]
+        Path(output_path).write_text("")
+        return subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="",
+            stderr='ERROR: {"error":{"message":"The model `gpt-5-codex` does not exist"}}',
+        )
+
+    _codex_cli_present(monkeypatch, tmp_path)
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
+    judge = EvalJudge(backend="codex", model="gpt-5-codex")
+    result = judge.evaluate(
+        task=_task(expect="x"),
+        transcript=[],
+        final_output="",
+        spec_dir=str(tmp_path),
+    )
+    assert result.errored is True
+    assert "--judge-model" in result.autorater_reasoning
+    assert "gpt-5-codex" in result.autorater_reasoning


### PR DESCRIPTION
## Summary

When the autorater CLI returns a model-resolution failure (for example Anthropic `not_found_error` / HTTP 404, or Codex "model does not exist"), Caliper now surfaces an actionable `--judge-model` hint instead of the generic `Judge returned unparseable response` `judge_error`.

## Motivation

Fixes #71. PR #70 pinned the default claude-code judge model, but when a judge model is still unavailable the failure mode was buried inside an unparseable-response message. This change makes that failure explicit and tells users how to recover.

## Changes

- Add `caliper/judge/errors.py` with backend-agnostic model-unavailable detection helpers.
- Wire helpers into `EvalJudge` for both harness `result.error` and unparseable/JSON error stdout paths.
- Treat bare JSON `{"type":"error", ...}` envelopes as judge errors when they indicate model unavailability.
- Add regression tests for Anthropic 404, JSON-only error envelopes, Codex stderr errors, and a false-positive guard (`model.py does not exist`).

## Tests

```bash
pytest tests/test_judge_model_unavailable.py -v
pytest -q
ruff check caliper/judge/
ruff format --check .
```

Result: 8 new tests pass; full suite 220 passed; ruff clean.

## Notes

- Detection is intentionally conservative: unrelated unparseable responses still use the existing generic message.
- Non-model harness errors (auth, missing CLI, timeouts) are unchanged.

Fixes #71