### PR TITLE
fix(harness): classify judge API failures at harness boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,5 +609,8 @@ Contributions are welcome. See [`CONTRIBUTING.md`](.github/CONTRIBUTING.md) for 
 **`codex judge failed: model ... is not supported`**
 The model name is not available to your Codex account. Use a model that `codex exec --model <name>` accepts.
 
+**`Judge model ... is unavailable` / `Judge authentication failed` / `Judge rate limited`**
+The judge CLI reached the provider and the call was refused. Caliper classifies these at the harness boundary (from the CLI's structured output) and suggests passing `--judge-model <backend[:model]>` to pick an available judge engine or model. Example: `caliper run my-skill.eval.yaml --judge-model claude-code:claude-haiku-4-5-20251001`.
+
 **A task passes only because of `assert:`**
 When a task has only `assert:`, no LLM judge runs. Add `expect:` if you also want an LLM to evaluate the transcript.

--- a/caliper/harness/base.py
+++ b/caliper/harness/base.py
@@ -10,7 +10,6 @@ from typing import Callable
 from caliper.harness.prompt_failure import (
     PromptFailure,
     PromptFailureKind,
-    format_judge_failure,
 )
 from caliper.schema.results import TokenUsage
 from caliper.schema.spec import McpServer
@@ -396,10 +395,13 @@ class CliHarness(HarnessBackend):
                 kind=PromptFailureKind.OTHER,
                 message=f"{self.name} judge exited {proc.returncode}{suffix}",
             )
+            # The harness carries the structural failure; the judge formats it
+            # (see caliper/judge/script_assert.py). ``error`` holds the raw
+            # message for callers that only read text.
             return PromptResult(
                 text="",
                 resolved_model=model,
-                error=format_judge_failure(failure, model),
+                error=failure.message,
                 failure=failure,
             )
         return PromptResult(

--- a/caliper/harness/base.py
+++ b/caliper/harness/base.py
@@ -7,6 +7,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Callable
 
+from caliper.harness.prompt_failure import (
+    PromptFailure,
+    PromptFailureKind,
+    format_judge_failure,
+)
 from caliper.schema.results import TokenUsage
 from caliper.schema.spec import McpServer
 
@@ -96,12 +101,15 @@ class PromptResult:
     The judge's half of the backend seam: ``text`` is the agent's final answer,
     ``resolved_model`` the concrete model when the backend can report it (else
     the requested one, ``None`` on an unobserved CLI default), and ``error`` a
-    human-readable reason when no answer was produced at all.
+    human-readable reason when no answer was produced at all. When the harness
+    classifies an upstream API failure, ``failure`` carries the typed kind and
+    ``error`` is the formatted judge-facing message.
     """
 
     text: str
     resolved_model: str | None = None
     error: str | None = None
+    failure: PromptFailure | None = None
 
 
 class HarnessBackend(ABC):
@@ -383,10 +391,17 @@ class CliHarness(HarnessBackend):
         """Read the agent's final answer out of a finished prompt call."""
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout).strip()
+            failure = PromptFailure(
+                kind=PromptFailureKind.OTHER,
+                message=detail[:200]
+                if detail
+                else f"{self.name} judge exited {proc.returncode}",
+            )
             return PromptResult(
                 text="",
                 resolved_model=model,
-                error=f"{self.name} judge exited {proc.returncode}: {detail[:200]}",
+                error=format_judge_failure(failure, model),
+                failure=failure,
             )
         return PromptResult(
             text=self._prompt_text(proc), resolved_model=model, error=None

--- a/caliper/harness/base.py
+++ b/caliper/harness/base.py
@@ -391,11 +391,10 @@ class CliHarness(HarnessBackend):
         """Read the agent's final answer out of a finished prompt call."""
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout).strip()
+            suffix = f": {detail[:200]}" if detail else ""
             failure = PromptFailure(
                 kind=PromptFailureKind.OTHER,
-                message=detail[:200]
-                if detail
-                else f"{self.name} judge exited {proc.returncode}",
+                message=f"{self.name} judge exited {proc.returncode}{suffix}",
             )
             return PromptResult(
                 text="",

--- a/caliper/harness/claude_code.py
+++ b/caliper/harness/claude_code.py
@@ -16,6 +16,11 @@ from caliper.harness.base import (
     PromptResult,
     RunContext,
 )
+from caliper.harness.prompt_failure import (
+    PromptFailure,
+    classify_claude_api_error_status,
+    format_judge_failure,
+)
 from caliper.harness.mcp import resolve_servers
 from caliper.schema.results import TokenUsage
 
@@ -249,8 +254,12 @@ class ClaudeCodeHarness(CliHarness):
     def _prompt_output(
         self, proc: ProcessResult, model: str | None, extras: dict
     ) -> PromptResult:
-        # No returncode gate on purpose: a failed call yields empty/garbage text,
-        # which the caller's verdict parse reports as an unusable response.
+        classified = _classify_claude_prompt_failure(proc.stdout, model)
+        if classified is not None:
+            return classified
+
+        # Unclassified errors still flow text through so the caller's verdict
+        # parse can report an unusable response (see PR #61).
         text, resolved = _extract_verdict_and_model(proc.stdout, model)
         return PromptResult(text=text, resolved_model=resolved, error=None)
 
@@ -440,6 +449,36 @@ class ClaudeCodeHarness(CliHarness):
                     break
 
         return transcript, final_output
+
+
+def _classify_claude_prompt_failure(
+    stdout: str, model: str | None
+) -> PromptResult | None:
+    """Return a classified upstream failure, or None to keep today's text path."""
+    stripped = stdout.strip()
+    try:
+        envelope = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(envelope, dict) or not envelope.get("is_error"):
+        return None
+
+    status = envelope.get("api_error_status")
+    if not isinstance(status, int):
+        return None
+
+    kind = classify_claude_api_error_status(status)
+    if kind is None:
+        return None
+
+    message = str(envelope.get("result", "")).strip() or f"API error {status}"
+    failure = PromptFailure(kind=kind, message=message, status=status)
+    return PromptResult(
+        text="",
+        resolved_model=model,
+        error=format_judge_failure(failure, model),
+        failure=failure,
+    )
 
 
 def _extract_verdict_and_model(

--- a/caliper/harness/claude_code.py
+++ b/caliper/harness/claude_code.py
@@ -19,7 +19,6 @@ from caliper.harness.base import (
 from caliper.harness.prompt_failure import (
     PromptFailure,
     classify_claude_api_error_status,
-    format_judge_failure,
 )
 from caliper.harness.mcp import resolve_servers
 from caliper.schema.results import TokenUsage
@@ -473,10 +472,12 @@ def _classify_claude_prompt_failure(
 
     message = str(envelope.get("result", "")).strip() or f"API error {status}"
     failure = PromptFailure(kind=kind, message=message, status=status)
+    # Carry the structural failure; the judge switches on ``failure.kind`` to
+    # build the user-facing message (see caliper/judge/script_assert.py).
     return PromptResult(
         text="",
         resolved_model=model,
-        error=format_judge_failure(failure, model),
+        error=message,
         failure=failure,
     )
 

--- a/caliper/harness/prompt_failure.py
+++ b/caliper/harness/prompt_failure.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class PromptFailureKind(str, Enum):
+    MODEL_UNAVAILABLE = "model_unavailable"
+    AUTH = "auth"
+    RATE_LIMITED = "rate_limited"
+    OTHER = "other"
+
+
+_CLASSIFIED_CLAUDE_STATUSES: dict[int, PromptFailureKind] = {
+    404: PromptFailureKind.MODEL_UNAVAILABLE,
+    401: PromptFailureKind.AUTH,
+    429: PromptFailureKind.RATE_LIMITED,
+}
+
+_JUDGE_MODEL_HINT = (
+    "Pass `--judge-model <backend[:model]>` to select an available judge model."
+)
+
+
+@dataclass(frozen=True)
+class PromptFailure:
+    kind: PromptFailureKind
+    message: str
+    status: int | None = None
+
+
+def classify_claude_api_error_status(status: int) -> PromptFailureKind | None:
+    return _CLASSIFIED_CLAUDE_STATUSES.get(status)
+
+
+def format_judge_failure(failure: PromptFailure, model: str | None) -> str:
+    model_part = f" '{model}'" if model else ""
+    if failure.kind is PromptFailureKind.MODEL_UNAVAILABLE:
+        return (
+            f"Judge model{model_part} is unavailable ({failure.message}). "
+            f"{_JUDGE_MODEL_HINT}"
+        )
+    if failure.kind is PromptFailureKind.AUTH:
+        return f"Judge authentication failed ({failure.message}). {_JUDGE_MODEL_HINT}"
+    if failure.kind is PromptFailureKind.RATE_LIMITED:
+        return (
+            f"Judge rate limited ({failure.message}). Try again later or "
+            f"pass `--judge-model` to use a different backend."
+        )
+    return failure.message

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from caliper.harness import get_harness
 from caliper.harness.base import ConversationTurn
+from caliper.harness.prompt_failure import format_judge_failure
 from caliper.judge.base import Judge, JudgeResult
 from caliper.schema.spec import DEFAULT_BACKEND, TaskSpec, resolve_judge_model
 
@@ -216,6 +217,11 @@ class EvalJudge(Judge):
         prompt = f"{_SYSTEM}\n\n{user_msg}"
 
         result = harness.run_prompt(prompt, cwd=spec_dir, timeout=60)
+        if result.failure is not None:
+            # Switch on the typed kind here, in the judge — provider status codes
+            # never leak past the harness boundary (issue #75, ADR-0001).
+            reasoning = format_judge_failure(result.failure, result.resolved_model)
+            return False, reasoning, True, result.resolved_model
         if result.error:
             return False, result.error, True, result.resolved_model
         passed, reasoning, errored = _parse_rich_response(

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from caliper.harness import get_harness
 from caliper.harness.base import ConversationTurn
 from caliper.judge.base import Judge, JudgeResult
-from caliper.harness.prompt_failure import format_judge_failure
 from caliper.schema.spec import DEFAULT_BACKEND, TaskSpec, resolve_judge_model
 
 _SYSTEM = """\
@@ -217,13 +216,6 @@ class EvalJudge(Judge):
         prompt = f"{_SYSTEM}\n\n{user_msg}"
 
         result = harness.run_prompt(prompt, cwd=spec_dir, timeout=60)
-        if result.failure is not None:
-            return (
-                False,
-                format_judge_failure(result.failure, self._model),
-                True,
-                result.resolved_model,
-            )
         if result.error:
             return False, result.error, True, result.resolved_model
         passed, reasoning, errored = _parse_rich_response(

--- a/caliper/judge/script_assert.py
+++ b/caliper/judge/script_assert.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from caliper.harness import get_harness
 from caliper.harness.base import ConversationTurn
 from caliper.judge.base import Judge, JudgeResult
+from caliper.harness.prompt_failure import format_judge_failure
 from caliper.schema.spec import DEFAULT_BACKEND, TaskSpec, resolve_judge_model
 
 _SYSTEM = """\
@@ -216,6 +217,13 @@ class EvalJudge(Judge):
         prompt = f"{_SYSTEM}\n\n{user_msg}"
 
         result = harness.run_prompt(prompt, cwd=spec_dir, timeout=60)
+        if result.failure is not None:
+            return (
+                False,
+                format_judge_failure(result.failure, self._model),
+                True,
+                result.resolved_model,
+            )
         if result.error:
             return False, result.error, True, result.resolved_model
         passed, reasoning, errored = _parse_rich_response(

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -219,3 +219,8 @@ expect: |
   explains the failing path. Fail if it only gives generic style advice, misses
   the bug, or claims tests passed without running or inspecting them.
 ```
+
+## Troubleshooting
+
+**`Judge model ... is unavailable` / `Judge authentication failed` / `Judge rate limited`**
+The judge CLI reached the provider and the call was refused. Caliper classifies these at the harness boundary (from the CLI's structured output) and suggests passing `--judge-model <backend[:model]>` to pick an available judge engine or model.

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -159,3 +159,8 @@ optional `transcript` (ordered turns with `tool_name`/`tool_input`/`tool_output`
 so saved runs remain inspectable after the fact — including which MCP tools fired.
 Older JSON without `transcript` still loads (`null`). `report` and `compare` do not
 render the transcript; it is stored for later analysis.
+
+## Troubleshooting
+
+**`Judge model ... is unavailable` / `Judge authentication failed` / `Judge rate limited`**
+The judge CLI reached the provider and the call was refused. Caliper classifies these at the harness boundary (from the CLI's structured output) and suggests passing `--judge-model <backend[:model]>` to pick an available judge engine or model.

--- a/tests/test_prompt_failure.py
+++ b/tests/test_prompt_failure.py
@@ -50,7 +50,8 @@ def test_classify_claude_prompt_failure_uses_recorded_fixture() -> None:
     assert result.failure.kind is PromptFailureKind.MODEL_UNAVAILABLE
     assert result.failure.status == 404
     assert "claude-sonnet-4-20250514" in result.failure.message
-    assert "--judge-model" in (result.error or "")
+    # The harness carries the raw provider message; the judge formats it.
+    assert result.error == result.failure.message
 
 
 def test_classify_claude_prompt_failure_leaves_unclassified_is_error_alone() -> None:

--- a/tests/test_prompt_failure.py
+++ b/tests/test_prompt_failure.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from caliper.harness.base import ProcessResult
+from caliper.harness.claude_code import (
+    ClaudeCodeHarness,
+    _classify_claude_prompt_failure,
+)
+from caliper.harness.base import ConversationTurn
+from caliper.harness.prompt_failure import (
+    PromptFailureKind,
+    classify_claude_api_error_status,
+    format_judge_failure,
+)
+from caliper.judge.script_assert import EvalJudge
+from caliper.schema.spec import DEFAULT_JUDGE_MODEL, TaskSpec
+
+# Recorded from `claude -p "say ok" --output-format json --model claude-sonnet-4-20250514`
+# against a retired model (issue #75).
+RETIRED_MODEL_ENVELOPE = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": True,
+    "api_error_status": 404,
+    "terminal_reason": "api_error",
+    "result": (
+        "There's an issue with the selected model (claude-sonnet-4-20250514). "
+        "It may not exist or you may not have access to it."
+    ),
+    "modelUsage": {},
+}
+
+
+def test_classify_claude_api_error_status_maps_observed_codes() -> None:
+    assert classify_claude_api_error_status(404) is PromptFailureKind.MODEL_UNAVAILABLE
+    assert classify_claude_api_error_status(401) is PromptFailureKind.AUTH
+    assert classify_claude_api_error_status(429) is PromptFailureKind.RATE_LIMITED
+    assert classify_claude_api_error_status(500) is None
+
+
+def test_classify_claude_prompt_failure_uses_recorded_fixture() -> None:
+    stdout = json.dumps(RETIRED_MODEL_ENVELOPE)
+    result = _classify_claude_prompt_failure(stdout, DEFAULT_JUDGE_MODEL)
+
+    assert result is not None
+    assert result.text == ""
+    assert result.failure is not None
+    assert result.failure.kind is PromptFailureKind.MODEL_UNAVAILABLE
+    assert result.failure.status == 404
+    assert "claude-sonnet-4-20250514" in result.failure.message
+    assert "--judge-model" in (result.error or "")
+
+
+def test_classify_claude_prompt_failure_leaves_unclassified_is_error_alone() -> None:
+    envelope = {
+        **RETIRED_MODEL_ENVELOPE,
+        "api_error_status": 500,
+        "result": "temporary upstream failure",
+    }
+    assert _classify_claude_prompt_failure(json.dumps(envelope), None) is None
+
+
+def test_claude_prompt_output_classifies_in_harness_not_downstream(
+    monkeypatch,
+) -> None:
+    stdout = json.dumps(RETIRED_MODEL_ENVELOPE)
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "caliper.harness.claude_code.shutil.which", lambda _name: "claude"
+    )
+
+    result = ClaudeCodeHarness(model=DEFAULT_JUDGE_MODEL).run_prompt(
+        "anything", cwd="."
+    )
+
+    assert result.failure is not None
+    assert result.failure.kind is PromptFailureKind.MODEL_UNAVAILABLE
+    assert result.text == ""
+
+
+def test_claude_prompt_output_unclassified_is_error_passes_text_through(
+    monkeypatch,
+) -> None:
+    envelope = {
+        "type": "result",
+        "is_error": True,
+        "api_error_status": 500,
+        "result": '{"mode": "verdict", "passed": false, "reasoning": "refused"}',
+        "modelUsage": {},
+    }
+    stdout = json.dumps(envelope)
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "caliper.harness.claude_code.shutil.which", lambda _name: "claude"
+    )
+
+    result = ClaudeCodeHarness().run_prompt("anything", cwd=".")
+
+    assert result.failure is None
+    assert result.error is None
+    assert '"mode": "verdict"' in result.text
+
+
+def _task(**overrides) -> TaskSpec:
+    fields = {"id": "t1", "name": "t", "prompt": "p", "expect": "says ok"}
+    fields.update(overrides)
+    return TaskSpec(**fields)
+
+
+def test_eval_judge_surfaces_classified_model_unavailable(
+    monkeypatch, tmp_path
+) -> None:
+    stdout = json.dumps(RETIRED_MODEL_ENVELOPE)
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("caliper.harness.base.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "caliper.harness.claude_code.shutil.which", lambda _name: "claude"
+    )
+
+    result = EvalJudge(backend="claude-code").evaluate(
+        task=_task(expect="x"),
+        transcript=[ConversationTurn(role="assistant", content="hello")],
+        final_output="hello",
+        spec_dir=str(tmp_path),
+    )
+
+    assert result.errored is True
+    assert "--judge-model" in (result.autorater_reasoning or "")
+    assert DEFAULT_JUDGE_MODEL in (result.autorater_reasoning or "")
+    assert "unparseable" not in (result.autorater_reasoning or "").lower()
+
+
+def test_format_judge_failure_auth_includes_hint() -> None:
+    from caliper.harness.prompt_failure import PromptFailure
+
+    message = format_judge_failure(
+        PromptFailure(kind=PromptFailureKind.AUTH, message="invalid token", status=401),
+        "claude-opus-4-8",
+    )
+    assert "authentication failed" in message
+    assert "--judge-model" in message
+
+
+def test_claude_harness_does_not_classify_without_envelope(monkeypatch) -> None:
+    result = _classify_claude_prompt_failure("plain text", None)
+    assert result is None
+
+    harness_result = ClaudeCodeHarness()._prompt_output(
+        ProcessResult(stdout="plain text", stderr="", returncode=0, timed_out=False),
+        None,
+        {},
+    )
+    assert harness_result.failure is None
+    assert harness_result.text == "plain text"


### PR DESCRIPTION
## Summary

Classify upstream judge API failures (model unavailable, auth, rate limited) in the harness layer via a typed `PromptFailure` on `PromptResult`, instead of reconstructing causes from prose in the judge.

## Motivation

Fixes #75 (supersedes the approach in closed #72).

When claude-code returns a structured error envelope (`is_error`, `api_error_status`, `result`), the harness previously discarded the status fields and passed only the prose `result` to the judge. That produced misleading `Judge returned unparseable response` errors and buried the real cause from #71.

## Changes

- Add `caliper/harness/prompt_failure.py` with `PromptFailureKind` and message formatting.
- Extend `PromptResult` with optional `failure`.
- `ClaudeCodeHarness._prompt_output`: classify observed `api_error_status` values (404/401/429) using the recorded retired-model fixture; unclassified `is_error` envelopes still pass text through (partial gate).
- `CliHarness._prompt_output`: attach `PromptFailureKind.OTHER` on nonzero exit.
- `EvalJudge`: format errors from `result.failure` (no substring matching in judge).
- Docs: README Troubleshooting + evaluate-skill / grill-skill REFERENCEs.
- Tests: `tests/test_prompt_failure.py` with the real recorded claude envelope.

## Tests

```bash
ruff format .
ruff check .
pytest
```

Result: **220 passed**

## Notes

- Codex/pi/hermes classification is intentionally out of scope until real CLI recordings exist (per issue design).
- composer-2.5 review: **APPROVE**