### PR TITLE
Deepen the attempt seam: assembly out of the runner

### DIFF
--- a/caliper/attempt.py
+++ b/caliper/attempt.py
@@ -1,0 +1,158 @@
+"""Assembling one attempt's record from a finished harness run.
+
+This is **the seam where an attempt is assembled** (docs/CONTEXT.md → Outcome):
+given an ``AttemptResult`` the harness already produced, decide what happened
+and return the ``AttemptRecord`` that goes into the results file. Every grading
+rule lives here — the pre-judge skip, activation, cheat detection, the (paid)
+judge call, and the precedence between them.
+
+Deliberately **pure over an already-produced result**: no threads, no temp
+directories, no subprocesses. Those belong to the runner, which owns an
+attempt's *lifecycle* while this module owns its *verdict*. That split is what
+lets the rules most likely to change be tested without standing up a fake
+harness and a thread pool.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Protocol
+
+from caliper.activation import ActivationDetector, check_activation
+from caliper.harness.base import AttemptResult, ConversationTurn
+from caliper.judge.base import Judge
+from caliper.outcome import classify_outcome, classify_pre_judge
+from caliper.schema.results import AttemptRecord, Outcome, TranscriptTurn
+from caliper.schema.spec import TaskSpec
+
+
+class CheatDetector(Protocol):
+    """What this module needs of a cheat detector: violations from a transcript.
+
+    A structural seam, like :class:`caliper.judge.base.Judge` — the production
+    detector lives with the runner that configures it from
+    ``sandbox.forbidden_files``, and a test double conforms by shape.
+    """
+
+    def check(self, transcript: list[ConversationTurn]) -> list[str]: ...
+
+
+@dataclass(frozen=True)
+class AssembledAttempt:
+    """One attempt's record, plus what the assembly observed about the run.
+
+    ``judge_model`` is the concrete model the autorater resolved, when one ran
+    and reported it. It rides out here rather than on the record because it is a
+    *run*-level fact (it lands in ``RunMeta``) — returned rather than written
+    into the run's collector, so this module stays pure and the runner keeps
+    ownership of what it accumulates across attempts.
+    """
+
+    record: AttemptRecord
+    judge_model: str | None = None
+
+
+def assemble_attempt(
+    result: AttemptResult,
+    *,
+    attempt: int,
+    task: TaskSpec,
+    spec_dir: str,
+    expected_activation: list[str] | None,
+    activation: ActivationDetector,
+    cheat: CheatDetector,
+    judge: Judge,
+) -> AssembledAttempt:
+    """Grade one finished harness run into an ``AttemptRecord``.
+
+    Precedence follows ``classify_outcome``: timeout / infra error, then cheat,
+    then a missing execution check, then the judge's verdict. Each of the first
+    three exits *before* the judge is called, so an attempt that never got a
+    fair shot never spends a paid autorater call on garbage output.
+
+    ``expected_activation`` is what this run asserts the task should activate —
+    ``None`` on an ablated run, which drops the expectation but keeps the
+    observation (docs/adr/0015-ablation-names-its-subject-at-the-invocation.md).
+
+    ``attempt`` is the caller's own counter rather than ``result.attempt``: the
+    runner decides which of the k attempts this is, and the harness only echoes
+    it back, so the record is numbered from the authority instead of the echo.
+    """
+    # A timeout or infrastructure signal terminates the attempt before we spend
+    # a (paid) judge call on garbage output. The pre-judge classifier owns that
+    # predicate — nothing re-derives it — so the skip here and the final label
+    # can never drift apart.
+    pre_judge_outcome = classify_pre_judge(result)
+
+    # Recorded on *every* attempt that produced a whole transcript, asserted only
+    # when the task said so. A timeout/infra failure yields ``None`` — *not
+    # observed*, never a fabricated empty set — because the transcript may have
+    # been truncated, where an empty result would be a confident "the description
+    # never fired" manufactured from nothing. (Ablating the whole neighbourhood
+    # yields ``None`` too, from the detector itself: nothing installed means no
+    # choice existed to observe.)
+    activated = (
+        activation.detect(result.transcript) if pre_judge_outcome is None else None
+    )
+    activation_passed = check_activation(activated, expected_activation)
+
+    def with_outcome(
+        outcome: Outcome, judge_model: str | None = None, **verdict
+    ) -> AssembledAttempt:
+        """One attempt's record; only the verdict fields differ per exit path.
+
+        ``activated``/``activation_passed`` ride on every path, because
+        activation is observed from the transcript and owes nothing to the judge.
+        """
+        return AssembledAttempt(
+            record=AttemptRecord(
+                attempt=attempt,
+                output=result.final_output,
+                duration_seconds=result.duration_seconds,
+                outcome=outcome,
+                usage=result.usage,
+                transcript=_persist_transcript(result.transcript),
+                activated=activated,
+                activation_passed=activation_passed,
+                **verdict,
+            ),
+            judge_model=judge_model,
+        )
+
+    if pre_judge_outcome is not None:
+        evidence = result.error or f"harness exited {result.exit_code}"
+        return with_outcome(pre_judge_outcome, assert_evidence=evidence)
+
+    cheat_violations = cheat.check(result.transcript)
+    if cheat_violations:
+        return with_outcome(
+            classify_outcome(result, cheat_violations, None),
+            cheat_evidence=cheat_violations,
+        )
+
+    # An `activates:`-only task authored no execution check, so there is nothing
+    # to grade — skip the (paid) judge call rather than spending it to receive a
+    # non-verdict and label the attempt an error.
+    if not (task.expect or task.assert_script):
+        return with_outcome(
+            classify_outcome(result, [], None, has_execution_check=False)
+        )
+
+    judge_result = judge.evaluate(
+        task=task,
+        transcript=result.transcript,
+        final_output=result.final_output,
+        spec_dir=spec_dir,
+    )
+    return with_outcome(
+        classify_outcome(result, [], judge_result),
+        judge_model=judge_result.resolved_model,
+        assert_passed=judge_result.assert_passed,
+        assert_evidence=judge_result.assert_evidence,
+        autorater_passed=judge_result.autorater_passed,
+        autorater_reasoning=judge_result.autorater_reasoning,
+    )
+
+
+def _persist_transcript(turns: list[ConversationTurn]) -> list[TranscriptTurn]:
+    return [TranscriptTurn(**asdict(turn)) for turn in turns]

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -1,34 +1,30 @@
 from __future__ import annotations
 
-import hashlib
 import re
 import shutil
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
 
-from caliper.activation import ActivationDetector, check_activation
+from caliper.activation import ActivationDetector
+from caliper.attempt import assemble_attempt
 from caliper.harness.base import (
     ConversationTurn,
     HarnessBackend,
     HarnessConfigurationError,
 )
 from caliper.judge.base import Judge
-from caliper.outcome import classify_outcome, classify_pre_judge
 from caliper.schema.results import (
     ERA_INSTALL_AND_DISCOVER,
     AttemptRecord,
-    FileSnapshot,
     Outcome,
     RunMeta,
     RunResults,
-    SkillSnapshot,
     TaskResult,
-    TranscriptTurn,
 )
 from caliper.schema.spec import DEFAULT_BACKEND, EvalSpec, TaskSpec, spec_name
 from caliper.scoring import aggregate_activation, aggregate_scores, score_outcomes
@@ -39,6 +35,7 @@ from caliper.skills import (
     resolve_skills,
     validate_activates,
 )
+from caliper.skillsnapshot import snapshot_skill
 
 _FAIL_FAST_OUTCOMES = {Outcome.INFRA_ERROR, Outcome.TIMEOUT}
 
@@ -157,10 +154,9 @@ def run(
     ablated = sorted(set(ablate or []))
     skill_refs = apply_ablation(declared_refs, ablated)
 
-    snapshotter = _SkillSnapshotter()
     # Only the installed skills: a snapshot claims "this is what produced the
     # score", which an ablated skill demonstrably did not.
-    skill_snapshots = [snapshotter.snapshot(ref) for ref in skill_refs]
+    skill_snapshots = [snapshot_skill(ref) for ref in skill_refs]
     detector = ActivationDetector(
         [ref.name for ref in skill_refs], harness.activation_tool_names
     )
@@ -268,13 +264,14 @@ def _run_task(task: TaskSpec, env: _RunEnv, k: int) -> TaskResult:
     return result
 
 
-def _persist_transcript(
-    turns: list[ConversationTurn],
-) -> list[TranscriptTurn]:
-    return [TranscriptTurn(**asdict(turn)) for turn in turns]
-
-
 def _run_attempt(task: TaskSpec, attempt: int, env: _RunEnv) -> AttemptRecord:
+    """Run one attempt end to end: its lifecycle here, its verdict next door.
+
+    This function owns what an attempt *costs* — a fresh isolated home, the
+    task's setup/cleanup shell, one harness invocation — and hands the finished
+    result to :func:`caliper.attempt.assemble_attempt`, which owns what it
+    *means*.
+    """
     spec, spec_path = env.spec, env.spec_path
     tmp_dir = tempfile.mkdtemp(prefix="caliper-")
     try:
@@ -303,99 +300,20 @@ def _run_attempt(task: TaskSpec, attempt: int, env: _RunEnv) -> AttemptRecord:
         if attempt_result.resolved_model:
             env.resolved_models.append(attempt_result.resolved_model)
 
-        # A timeout or infrastructure signal terminates the attempt before we
-        # spend a (paid) judge call on garbage output. The pre-judge classifier
-        # owns that predicate — the runner no longer re-derives it — so the skip
-        # here and the final label can never drift apart.
-        pre_judge_outcome = classify_pre_judge(attempt_result)
-
-        # Recorded on *every* attempt that produced a whole transcript, asserted
-        # only when the task said so. A timeout/infra failure yields ``None`` —
-        # *not observed*, never a fabricated empty set — because the transcript
-        # may have been truncated, where an empty result would be a confident
-        # "the description never fired" manufactured from nothing. (Ablating the
-        # whole neighbourhood yields ``None`` too, from the detector itself:
-        # nothing installed means no choice existed to observe.)
-        activated = (
-            env.activation.detect(attempt_result.transcript)
-            if pre_judge_outcome is None
-            else None
-        )
-        activation_passed = check_activation(activated, env.expected_activation(task))
-
-        def record(outcome: Outcome, **verdict) -> AttemptRecord:
-            """One attempt's record; only the verdict fields differ per exit path.
-
-            ``activated``/``activation_passed`` ride on every path, because
-            activation is observed from the transcript and owes nothing to the
-            judge.
-            """
-            return AttemptRecord(
-                attempt=attempt,
-                output=attempt_result.final_output,
-                duration_seconds=attempt_result.duration_seconds,
-                outcome=outcome,
-                usage=attempt_result.usage,
-                transcript=_persist_transcript(attempt_result.transcript),
-                activated=activated,
-                activation_passed=activation_passed,
-                **verdict,
-            )
-
-        if pre_judge_outcome is not None:
-            evidence = (
-                attempt_result.error or f"harness exited {attempt_result.exit_code}"
-            )
-            return _finish(
-                record(pre_judge_outcome, assert_evidence=evidence),
-                task,
-                env.on_attempt_done,
-            )
-
-        cheat_violations = env.cheat.check(attempt_result.transcript)
-        if cheat_violations:
-            outcome = classify_outcome(attempt_result, cheat_violations, None)
-            return _finish(
-                record(outcome, cheat_evidence=cheat_violations),
-                task,
-                env.on_attempt_done,
-            )
-
-        # An `activates:`-only task authored no execution check, so there is
-        # nothing to grade — skip the (paid) judge call rather than spending it
-        # to receive a non-verdict and label the attempt an error.
-        if not (task.expect or task.assert_script):
-            return _finish(
-                record(
-                    classify_outcome(
-                        attempt_result, [], None, has_execution_check=False
-                    )
-                ),
-                task,
-                env.on_attempt_done,
-            )
-
-        judge_result = env.judge.evaluate(
+        assembled = assemble_attempt(
+            attempt_result,
+            attempt=attempt,
             task=task,
-            transcript=attempt_result.transcript,
-            final_output=attempt_result.final_output,
             spec_dir=str(spec_path.parent),
+            expected_activation=env.expected_activation(task),
+            activation=env.activation,
+            cheat=env.cheat,
+            judge=env.judge,
         )
-        if judge_result.resolved_model:
-            env.judge_models.append(judge_result.resolved_model)
-        outcome = classify_outcome(attempt_result, [], judge_result)
+        if assembled.judge_model:
+            env.judge_models.append(assembled.judge_model)
 
-        return _finish(
-            record(
-                outcome,
-                assert_passed=judge_result.assert_passed,
-                assert_evidence=judge_result.assert_evidence,
-                autorater_passed=judge_result.autorater_passed,
-                autorater_reasoning=judge_result.autorater_reasoning,
-            ),
-            task,
-            env.on_attempt_done,
-        )
+        return _finish(assembled.record, task, env.on_attempt_done)
     finally:
         _run_shell(task.cleanup)
         shutil.rmtree(tmp_dir, ignore_errors=True)
@@ -449,73 +367,3 @@ class _CheatDetector:
                 results.extend(self._extract_paths(item, depth + 1))
             return results
         return []
-
-
-class _SkillSnapshotter:
-    _REF_PATTERN = re.compile(r'[./~][^\s"\'<>]+\.(sh|py|md|js|ts)')
-
-    def snapshot(self, ref: SkillRef) -> SkillSnapshot:
-        path = Path(ref.path).expanduser().resolve()
-        name = ref.name
-        if not path.exists():
-            return SkillSnapshot(
-                name=name, path=str(path), source_kind=ref.source_kind, files={}
-            )
-
-        files: dict[str, FileSnapshot] = {}
-        content = path.read_text()
-        files[path.name] = FileSnapshot(
-            content=content,
-            hash="sha256:" + hashlib.sha256(content.encode()).hexdigest(),
-        )
-
-        # `referenced`, not `ref`: the parameter is the SkillRef, and reusing the
-        # name here silently rebound it to a Path for every skill whose SKILL.md
-        # points at a companion file — which is most real ones.
-        for match in self._REF_PATTERN.finditer(content):
-            referenced = Path(match.group()).expanduser()
-            if not referenced.is_absolute():
-                referenced = path.parent / referenced
-            referenced = referenced.resolve()
-            if referenced.exists() and referenced != path:
-                rel = str(referenced.relative_to(path.parent))
-                ref_content = referenced.read_text()
-                files[rel] = FileSnapshot(
-                    content=ref_content,
-                    hash="sha256:" + hashlib.sha256(ref_content.encode()).hexdigest(),
-                )
-
-        # A git source already knows its provenance exactly — caliper resolved
-        # the ref and cloned that commit — so it is taken from the ref rather
-        # than re-derived from the checkout, whose HEAD is the same thing by a
-        # longer route. Only a path source has to be interrogated.
-        if ref.source_kind == "git":
-            git_repo, git_sha = ref.git_repo, ref.git_sha
-        else:
-            git_repo, git_sha = self._git_info(path)
-        return SkillSnapshot(
-            name=name,
-            path=str(path),
-            source_kind=ref.source_kind,
-            git_repo=git_repo,
-            git_sha=git_sha,
-            files=files,
-        )
-
-    def _git_info(self, path: Path) -> tuple[str | None, str | None]:
-        try:
-            repo = subprocess.check_output(
-                ["git", "rev-parse", "--show-toplevel"],
-                cwd=str(path.parent),
-                stderr=subprocess.DEVNULL,
-                text=True,
-            ).strip()
-            sha = subprocess.check_output(
-                ["git", "rev-parse", "HEAD"],
-                cwd=str(path.parent),
-                stderr=subprocess.DEVNULL,
-                text=True,
-            ).strip()
-            return repo, sha
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return None, None

--- a/caliper/skillsnapshot.py
+++ b/caliper/skillsnapshot.py
@@ -1,0 +1,94 @@
+"""Capturing what a member of the [[skill neighbourhood]] *was* when a run used it.
+
+A snapshot is the run's own record of the text that produced its score: the
+``SKILL.md``, the companion files it points at (progressive disclosure is the
+normal shape), and the provenance of the whole. It is what ``compare`` reads to
+report [[skill drift]] — see docs/CONTEXT.md → Skill drift and docs/adr/0017.
+
+Lives beside :mod:`caliper.skillfetch` rather than in the runner: a git source
+already knows its commit because the fetcher resolved it, and only a *path*
+source has to be interrogated with ``git`` at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+
+from caliper.schema.results import FileSnapshot, SkillSnapshot
+from caliper.skills import SkillRef
+
+# A relative or home-anchored pointer to a companion file, as a SKILL.md writes
+# one: `./REFERENCE.md`, `references/style.md`, `~/bin/check.sh`.
+_REF_PATTERN = re.compile(r'[./~][^\s"\'<>]+\.(sh|py|md|js|ts)')
+
+
+def snapshot_skill(ref: SkillRef) -> SkillSnapshot:
+    """Capture ``ref``'s files and provenance as they are right now."""
+    path = Path(ref.path).expanduser().resolve()
+    if not path.exists():
+        return SkillSnapshot(
+            name=ref.name, path=str(path), source_kind=ref.source_kind, files={}
+        )
+
+    content = path.read_text()
+    files: dict[str, FileSnapshot] = {path.name: _file_snapshot(content)}
+
+    # `referenced`, not `ref`: the parameter is the SkillRef, and reusing the
+    # name here silently rebound it to a Path for every skill whose SKILL.md
+    # points at a companion file — which is most real ones.
+    for match in _REF_PATTERN.finditer(content):
+        referenced = Path(match.group()).expanduser()
+        if not referenced.is_absolute():
+            referenced = path.parent / referenced
+        referenced = referenced.resolve()
+        if referenced.exists() and referenced != path:
+            rel = str(referenced.relative_to(path.parent))
+            files[rel] = _file_snapshot(referenced.read_text())
+
+    # A git source already knows its provenance exactly — caliper resolved the
+    # ref and cloned that commit — so it is taken from the ref rather than
+    # re-derived from the checkout, whose HEAD is the same thing by a longer
+    # route. Only a path source has to be interrogated.
+    if ref.source_kind == "git":
+        git_repo, git_sha = ref.git_repo, ref.git_sha
+    else:
+        git_repo, git_sha = _git_info(path)
+
+    return SkillSnapshot(
+        name=ref.name,
+        path=str(path),
+        source_kind=ref.source_kind,
+        git_repo=git_repo,
+        git_sha=git_sha,
+        files=files,
+    )
+
+
+def _file_snapshot(content: str) -> FileSnapshot:
+    return FileSnapshot(
+        content=content,
+        hash="sha256:" + hashlib.sha256(content.encode()).hexdigest(),
+    )
+
+
+def _git_info(path: Path) -> tuple[str | None, str | None]:
+    """The repo and commit a path source sits at, or ``(None, None)``."""
+    try:
+        repo = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(path.parent),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(path.parent),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return repo, sha
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None, None

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from caliper.activation import ActivationDetector
+from caliper.attempt import assemble_attempt
+from caliper.harness.base import AttemptResult, ConversationTurn
+from caliper.judge.base import JudgeResult
+from caliper.schema.results import Outcome, TokenUsage
+from caliper.schema.spec import TaskSpec
+
+
+# --- doubles ---------------------------------------------------------------
+
+
+class RecordingJudge:
+    """A judge that answers with a fixed verdict and remembers being called."""
+
+    def __init__(self, result: JudgeResult | None = None) -> None:
+        self.result = result or JudgeResult(passed=True, reasoning="looks right")
+        self.calls = 0
+
+    def evaluate(
+        self,
+        task: TaskSpec,
+        transcript: list[ConversationTurn],
+        final_output: str,
+        spec_dir: str,
+    ) -> JudgeResult:
+        self.calls += 1
+        return self.result
+
+
+class StubCheatDetector:
+    """Reports a fixed violation list, whatever the transcript says."""
+
+    def __init__(self, violations: list[str] | None = None) -> None:
+        self.violations = violations or []
+
+    def check(self, transcript: list[ConversationTurn]) -> list[str]:
+        return list(self.violations)
+
+
+def _task(**overrides) -> TaskSpec:
+    fields = {"id": "task-001", "name": "t", "prompt": "go", "expect": "it works"}
+    fields.update(overrides)
+    return TaskSpec(**fields)
+
+
+def _read_turn(path: str) -> ConversationTurn:
+    return ConversationTurn(
+        role="tool_use",
+        content="[tool: Read]",
+        tool_name="Read",
+        tool_input={"file_path": path},
+    )
+
+
+def _result(**overrides) -> AttemptResult:
+    fields = dict(
+        task_id="task-001",
+        attempt=1,
+        transcript=[],
+        final_output="done",
+        exit_code=0,
+        duration_seconds=1.5,
+    )
+    fields.update(overrides)
+    return AttemptResult(**fields)
+
+
+def _assemble(result: AttemptResult, **overrides):
+    kwargs = dict(
+        attempt=1,
+        task=_task(),
+        spec_dir="/tmp",
+        expected_activation=None,
+        activation=ActivationDetector([], frozenset()),
+        cheat=StubCheatDetector(),
+        judge=RecordingJudge(),
+    )
+    kwargs.update(overrides)
+    return assemble_attempt(result, **kwargs)
+
+
+# --- the judged path -------------------------------------------------------
+
+
+def test_a_clean_attempt_with_a_passing_verdict_is_a_pass():
+    judge = RecordingJudge(
+        JudgeResult(
+            passed=True,
+            reasoning="ok",
+            assert_passed=True,
+            assert_evidence="",
+            autorater_passed=True,
+            autorater_reasoning="ok",
+        )
+    )
+
+    assembled = _assemble(_result(), judge=judge)
+
+    assert assembled.record.outcome is Outcome.PASS
+    assert assembled.record.autorater_passed is True
+    assert assembled.record.assert_passed is True
+    assert judge.calls == 1
+
+
+def test_a_failing_verdict_is_a_task_fail():
+    judge = RecordingJudge(JudgeResult(passed=False, reasoning="nope"))
+
+    assembled = _assemble(_result(), judge=judge)
+
+    assert assembled.record.outcome is Outcome.TASK_FAIL
+
+
+def test_the_attempt_record_carries_the_harness_result_verbatim():
+    usage = TokenUsage(input_tokens=10, output_tokens=4)
+    transcript = [ConversationTurn(role="assistant", content="hi")]
+
+    assembled = _assemble(
+        _result(
+            duration_seconds=2.25,
+            final_output="the answer",
+            usage=usage,
+            transcript=transcript,
+        )
+    )
+
+    record = assembled.record
+    assert record.duration_seconds == 2.25
+    assert record.output == "the answer"
+    assert record.usage == usage
+    assert [t.content for t in record.transcript or []] == ["hi"]
+
+
+def test_the_record_is_numbered_from_the_caller_not_the_harnesss_echo():
+    """The runner owns the 1..k counter; a backend only echoes it back."""
+    assembled = _assemble(_result(attempt=99), attempt=3)
+
+    assert assembled.record.attempt == 3
+
+
+def test_the_judges_resolved_model_is_reported_back():
+    judge = RecordingJudge(
+        JudgeResult(passed=True, reasoning="ok", resolved_model="claude-sonnet-5")
+    )
+
+    assembled = _assemble(_result(), judge=judge)
+
+    assert assembled.judge_model == "claude-sonnet-5"
+
+
+def test_no_judge_model_when_the_autorater_reports_none():
+    assert _assemble(_result()).judge_model is None
+
+
+# --- the early exits, in precedence order ----------------------------------
+
+
+def test_a_timeout_never_reaches_the_judge():
+    judge = RecordingJudge()
+
+    assembled = _assemble(
+        _result(timed_out=True, exit_code=124, error="timeout"), judge=judge
+    )
+
+    assert assembled.record.outcome is Outcome.TIMEOUT
+    assert assembled.record.assert_evidence == "timeout"
+    assert judge.calls == 0
+
+
+def test_a_nonzero_exit_is_infra_error_with_the_exit_code_as_evidence():
+    judge = RecordingJudge()
+
+    assembled = _assemble(_result(exit_code=1), judge=judge)
+
+    assert assembled.record.outcome is Outcome.INFRA_ERROR
+    assert assembled.record.assert_evidence == "harness exited 1"
+    assert judge.calls == 0
+
+
+def test_a_forbidden_file_read_is_a_cheat_and_skips_the_judge():
+    judge = RecordingJudge()
+
+    assembled = _assemble(
+        _result(), cheat=StubCheatDetector(["/x/answers.txt"]), judge=judge
+    )
+
+    assert assembled.record.outcome is Outcome.CHEAT
+    assert assembled.record.cheat_evidence == ["/x/answers.txt"]
+    assert judge.calls == 0
+
+
+def test_a_task_with_no_execution_check_is_not_checked_and_skips_the_judge():
+    judge = RecordingJudge()
+
+    assembled = _assemble(
+        _result(), task=_task(expect=None, activates=["tdd"]), judge=judge
+    )
+
+    assert assembled.record.outcome is Outcome.NOT_CHECKED
+    assert judge.calls == 0
+
+
+def test_a_cheat_outranks_a_missing_execution_check():
+    """A trigger probe that read the answer key is still a cheat."""
+    assembled = _assemble(
+        _result(),
+        task=_task(expect=None, activates=["tdd"]),
+        cheat=StubCheatDetector(["/x/answers.txt"]),
+    )
+
+    assert assembled.record.outcome is Outcome.CHEAT
+
+
+# --- activation rides on every path ----------------------------------------
+
+
+def _detector() -> ActivationDetector:
+    return ActivationDetector(["tdd", "grilling"], frozenset({"Skill"}))
+
+
+def test_activation_is_observed_and_scored_on_a_judged_attempt():
+    assembled = _assemble(
+        _result(transcript=[_read_turn("/skills/tdd/SKILL.md")]),
+        activation=_detector(),
+        expected_activation=["tdd"],
+    )
+
+    assert assembled.record.activated == ["tdd"]
+    assert assembled.record.activation_passed is True
+
+
+def test_an_unexpected_activation_fails_the_exact_set_match():
+    assembled = _assemble(
+        _result(transcript=[_read_turn("/skills/grilling/SKILL.md")]),
+        activation=_detector(),
+        expected_activation=["tdd"],
+    )
+
+    assert assembled.record.activated == ["grilling"]
+    assert assembled.record.activation_passed is False
+
+
+def test_activation_is_observed_but_not_scored_when_nothing_was_expected():
+    """An ablated run drops the expectation and keeps the observation."""
+    assembled = _assemble(
+        _result(transcript=[_read_turn("/skills/tdd/SKILL.md")]),
+        activation=_detector(),
+        expected_activation=None,
+    )
+
+    assert assembled.record.activated == ["tdd"]
+    assert assembled.record.activation_passed is None
+
+
+def test_activation_rides_on_a_cheat_too():
+    assembled = _assemble(
+        _result(transcript=[_read_turn("/skills/tdd/SKILL.md")]),
+        activation=_detector(),
+        expected_activation=["tdd"],
+        cheat=StubCheatDetector(["/x/answers.txt"]),
+    )
+
+    assert assembled.record.outcome is Outcome.CHEAT
+    assert assembled.record.activated == ["tdd"]
+    assert assembled.record.activation_passed is True
+
+
+def test_activation_rides_on_a_trigger_probe():
+    assembled = _assemble(
+        _result(transcript=[_read_turn("/skills/tdd/SKILL.md")]),
+        task=_task(expect=None, activates=["tdd"]),
+        activation=_detector(),
+        expected_activation=["tdd"],
+    )
+
+    assert assembled.record.outcome is Outcome.NOT_CHECKED
+    assert assembled.record.activation_passed is True
+
+
+def test_a_truncated_transcript_yields_no_observation_rather_than_an_empty_set():
+    """A timeout may have cut the transcript short: `None`, never a fabricated `[]`."""
+    assembled = _assemble(
+        _result(timed_out=True, exit_code=124, error="timeout", transcript=[]),
+        activation=_detector(),
+        expected_activation=["tdd"],
+    )
+
+    assert assembled.record.outcome is Outcome.TIMEOUT
+    assert assembled.record.activated is None
+    assert assembled.record.activation_passed is None

--- a/tests/test_git_sources.py
+++ b/tests/test_git_sources.py
@@ -317,36 +317,6 @@ def test_resolve_records_provenance_for_both_kinds(tmp_path: Path, origin: Path)
     assert refs[1].git_repo == str(origin)
 
 
-def test_a_skill_referencing_companion_files_still_snapshots(tmp_path: Path):
-    """Progressive disclosure is the normal shape, so the snapshot must survive it.
-
-    Every other snapshot test uses a SKILL.md that points at nothing, which is
-    what let a name collision in the referenced-file loop reach a real run.
-    """
-    from caliper.runner import _SkillSnapshotter
-    from caliper.skills import SkillRef
-
-    directory = tmp_path / "mine"
-    directory.mkdir()
-    (directory / "REFERENCE.md").write_text("# Reference\n")
-    (directory / "SKILL.md").write_text(
-        "---\nname: mine\ndescription: d.\n---\n\nSee [ref](./REFERENCE.md).\n"
-    )
-    ref = SkillRef(
-        name="mine",
-        path=directory / "SKILL.md",
-        source_kind="git",
-        git_repo="owner/name",
-        git_sha="a" * 40,
-    )
-
-    snap = _SkillSnapshotter().snapshot(ref)
-
-    assert snap.source_kind == "git"
-    assert snap.git_sha == "a" * 40
-    assert set(snap.files) == {"SKILL.md", "REFERENCE.md"}
-
-
 def test_a_git_source_colliding_on_name_is_refused(tmp_path: Path, origin: Path):
     local = _write_skill(tmp_path / "mine", "tdd")
     fetcher = SkillFetcher(cache_dir=tmp_path / "cache")

--- a/tests/test_skillsnapshot.py
+++ b/tests/test_skillsnapshot.py
@@ -1,0 +1,111 @@
+"""Snapshotting a neighbourhood member — files captured, provenance recorded.
+
+See docs/CONTEXT.md → Skill drift and
+docs/adr/0017-unpinned-git-sources-are-allowed-because-drift-is-reported.md.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from caliper.skills import SkillRef
+from caliper.skillsnapshot import snapshot_skill
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return subprocess.check_output(
+        ["git", *args], cwd=str(cwd), text=True, stderr=subprocess.DEVNULL
+    ).strip()
+
+
+def _write_skill(directory: Path, name: str, body: str | None = None) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "SKILL.md"
+    path.write_text(
+        body
+        if body is not None
+        else f"---\nname: {name}\ndescription: A skill for testing.\n---\n\nBody.\n"
+    )
+    return path
+
+
+def test_a_skill_referencing_companion_files_still_snapshots(tmp_path: Path):
+    """Progressive disclosure is the normal shape, so the snapshot must survive it.
+
+    Every other snapshot test uses a SKILL.md that points at nothing, which is
+    what let a name collision in the referenced-file loop reach a real run.
+    """
+    directory = tmp_path / "mine"
+    directory.mkdir()
+    (directory / "REFERENCE.md").write_text("# Reference\n")
+    (directory / "SKILL.md").write_text(
+        "---\nname: mine\ndescription: d.\n---\n\nSee [ref](./REFERENCE.md).\n"
+    )
+    ref = SkillRef(
+        name="mine",
+        path=directory / "SKILL.md",
+        source_kind="git",
+        git_repo="owner/name",
+        git_sha="a" * 40,
+    )
+
+    snap = snapshot_skill(ref)
+
+    assert snap.source_kind == "git"
+    assert snap.git_sha == "a" * 40
+    assert set(snap.files) == {"SKILL.md", "REFERENCE.md"}
+
+
+def test_a_git_sources_provenance_comes_from_the_ref_not_the_checkout(tmp_path: Path):
+    """Caliper resolved the commit at fetch, so the checkout is never re-read.
+
+    The checkout here sits in a repo at a *different* commit; the snapshot must
+    still report what the ref says it fetched.
+    """
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    _git("init", "-b", "main", cwd=repo)
+    _git("config", "user.email", "t@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    _write_skill(repo, "mine")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "first", cwd=repo)
+
+    snap = snapshot_skill(
+        SkillRef(
+            name="mine",
+            path=repo / "SKILL.md",
+            source_kind="git",
+            git_repo="owner/name",
+            git_sha="b" * 40,
+        )
+    )
+
+    assert (snap.git_repo, snap.git_sha) == ("owner/name", "b" * 40)
+
+
+def test_a_path_source_is_interrogated_for_its_repo_and_commit(tmp_path: Path):
+    """A path source promised nothing, so its provenance is read off the disk."""
+    repo = tmp_path / "work"
+    repo.mkdir()
+    _git("init", "-b", "main", cwd=repo)
+    _git("config", "user.email", "t@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    local = _write_skill(repo / "skills" / "mine", "mine")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "first", cwd=repo)
+
+    snap = snapshot_skill(SkillRef(name="mine", path=local))
+
+    assert snap.source_kind == "path"
+    assert Path(snap.git_repo or "").resolve() == repo.resolve()
+    assert snap.git_sha == _git("rev-parse", "HEAD", cwd=repo)
+    assert set(snap.files) == {"SKILL.md"}
+
+
+def test_a_missing_skill_file_snapshots_as_empty(tmp_path: Path):
+    snap = snapshot_skill(SkillRef(name="gone", path=tmp_path / "gone" / "SKILL.md"))
+
+    assert snap.files == {}
+    assert snap.name == "gone"


### PR DESCRIPTION
## Why

`_run_attempt` owned an attempt's **lifecycle** and its **verdict** at once: `mkdtemp`/`rmtree`, the task's setup/cleanup shell and one harness call, plus the pre-judge skip, activation, cheat detection, the judge call, the precedence between them, and a `record()` closure spread across four exit paths.

The rules most likely to change — `not_checked`, activation, cheat precedence, ablation — had no interface. Reaching any of them in a test cost a thread pool, a temp dir, a fake harness and a fake judge. `runner.py` is also the repo's hottest file (7 of the last 25 commits), and every feature landed as another statement in the same function.

## What

**`caliper/attempt.py`** (new) owns what an attempt *means*:

```python
assemble_attempt(result, *, attempt, task, spec_dir,
                 expected_activation, activation, cheat, judge) -> AssembledAttempt
```

Pure over an already-produced `AttemptResult` — no threads, no temp dirs, no subprocesses. One record-assembly path instead of four. A `CheatDetector` Protocol declares what it needs of a detector, mirroring how `Judge` is a structural seam. The judge's resolved model is *returned* rather than written into the run's collector, which is what lets the module stay pure.

**`caliper/skillsnapshot.py`** (new) takes `_SkillSnapshotter` out of the runner and puts it beside `skillfetch.py`, which already resolved the commit — an orchestrator has no business shelling out to `git rev-parse`. Its tests move out of `test_git_sources.py`, where they only sat because the class was private.

**`caliper/runner.py`** keeps what an attempt *costs*, and nothing else: 521 → 369 lines.

## Behaviour

Preserved throughout. Every classification, evidence string and skip is the same code in a new home; the record is still numbered from the runner's own `1..k` counter rather than the harness's echo of it. No CLI flag, spec field, judge behaviour or results-schema change, so no doc updates are due under `CLAUDE.md`.

## Tests

412 passing, up from 392. The 20 new tests need no fake harness and no thread pool — `tests/test_attempt.py` runs in 0.08s and covers each exit path, the judge-skip on all three early exits, and activation riding on every path including cheat and trigger probes. `tests/test_skillsnapshot.py` covers provenance against real git repos rather than relying on where pytest's tmp dir happens to sit.

`ruff format --check` and `ruff check` clean at the pinned 0.15.20.

## Deliberately not in scope

- **Six keyword args instead of a bundle.** Passing `_RunEnv` would make `attempt.py` import the orchestrator it was extracted from; explicit parameters keep the dependency one-way.
- **Trimming `test_not_checked.py`.** Its `run()`-level tests now overlap the cheap ones, but they also exercise the fail-fast loop and the reporter helpers. Removing coverage inside a refactor is a separate, deliberate pass.