### PR TITLE
fix(activation): keep an observation a truncated transcript did show

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,10 +753,14 @@ them up per run:
 - Each `AttemptRecord` carries `activated`, the skills the agent chose to load,
   recorded on every attempt whether or not the task asserted on it. It is
   `null` when nothing was *observable*: an attempt with the whole neighbourhood
-  ablated (no skills installed), or a timeout / infra failure whose transcript
-  may be truncated. A
-  bare `[]` in those cases would be a fabricated "the description never fired",
-  so caliper never writes one.
+  ablated (no skills installed), or a timeout / infra failure whose truncated
+  transcript showed no activation. A bare `[]` in those cases would be a
+  fabricated "the description never fired", so caliper never writes one.
+- A truncated transcript that *did* show an activation **keeps** it: truncation
+  can hide evidence, never invent it. The attempt stays out of the activation
+  score all the same (that denominator excludes `timeout` / `infra_error` by
+  outcome), and its `activation_passed` is `null` — an observation, never a
+  verdict. See [Activation admissibility](docs/CONTEXT.md).
 - `activation_passed` is the verdict: `null` = **not asserted** (a different
   `null` from `activated`'s, matching the existing `assert_passed` idiom).
 - `TaskResult` carries `activation_expected` (the task's `activates:` set) plus

--- a/caliper/attempt.py
+++ b/caliper/attempt.py
@@ -85,16 +85,25 @@ def assemble_attempt(
     pre_judge_outcome = classify_pre_judge(result)
 
     # Recorded on *every* attempt that produced a whole transcript, asserted only
-    # when the task said so. A timeout/infra failure yields ``None`` — *not
-    # observed*, never a fabricated empty set — because the transcript may have
-    # been truncated, where an empty result would be a confident "the description
-    # never fired" manufactured from nothing. (Ablating the whole neighbourhood
-    # yields ``None`` too, from the detector itself: nothing installed means no
-    # choice existed to observe.)
-    activated = (
-        activation.detect(result.transcript) if pre_judge_outcome is None else None
-    )
-    activation_passed = check_activation(activated, expected_activation)
+    # when the task said so. A timeout/infra failure may have cut the transcript
+    # short, and truncation is not symmetric: it can hide evidence, never invent
+    # it. So a *positive* observation survives as evidence, while an empty one
+    # collapses to ``None`` — a bare ``[]`` there would be a confident "the
+    # description never fired" manufactured from nothing. (Ablating the whole
+    # neighbourhood yields ``None`` too, from the detector itself: nothing
+    # installed means no choice existed to observe.)
+    #
+    # The verdict is withheld either way. A kept observation is *inadmissible*:
+    # evidence for a human reading saved results, never a judgement on an
+    # attempt the activation scoreboard already excludes by outcome. See
+    # docs/CONTEXT.md → Activation admissibility.
+    observed = activation.detect(result.transcript)
+    if pre_judge_outcome is None:
+        activated = observed
+        activation_passed = check_activation(activated, expected_activation)
+    else:
+        activated = observed or None
+        activation_passed = None
 
     def with_outcome(
         outcome: Outcome, judge_model: str | None = None, **verdict

--- a/caliper/attempt.py
+++ b/caliper/attempt.py
@@ -84,9 +84,10 @@ def assemble_attempt(
     # can never drift apart.
     pre_judge_outcome = classify_pre_judge(result)
 
-    # Truncation hides an activation, never invents one: a positive observation
-    # survives a timeout/infra failure, an empty one collapses to ``None``. No
-    # verdict either way. See docs/CONTEXT.md → Activation admissibility.
+    # A timeout or infra failure can cut the transcript off partway. A skill we
+    # saw load before the cut still loaded, so keep it. Seeing nothing is
+    # ambiguous (nothing loaded, or we missed it), so record ``None``, not an
+    # empty list. Neither is graded. See docs/CONTEXT.md → Activation admissibility.
     observed = activation.detect(result.transcript)
     if pre_judge_outcome is None:
         activated = observed

--- a/caliper/attempt.py
+++ b/caliper/attempt.py
@@ -84,19 +84,9 @@ def assemble_attempt(
     # can never drift apart.
     pre_judge_outcome = classify_pre_judge(result)
 
-    # Recorded on *every* attempt that produced a whole transcript, asserted only
-    # when the task said so. A timeout/infra failure may have cut the transcript
-    # short, and truncation is not symmetric: it can hide evidence, never invent
-    # it. So a *positive* observation survives as evidence, while an empty one
-    # collapses to ``None`` — a bare ``[]`` there would be a confident "the
-    # description never fired" manufactured from nothing. (Ablating the whole
-    # neighbourhood yields ``None`` too, from the detector itself: nothing
-    # installed means no choice existed to observe.)
-    #
-    # The verdict is withheld either way. A kept observation is *inadmissible*:
-    # evidence for a human reading saved results, never a judgement on an
-    # attempt the activation scoreboard already excludes by outcome. See
-    # docs/CONTEXT.md → Activation admissibility.
+    # Truncation hides an activation, never invents one: a positive observation
+    # survives a timeout/infra failure, an empty one collapses to ``None``. No
+    # verdict either way. See docs/CONTEXT.md → Activation admissibility.
     observed = activation.detect(result.transcript)
     if pre_judge_outcome is None:
         activated = observed

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -319,6 +319,27 @@ delegating case: remove a parent skill and its neighbours correctly stop firing,
 so scoring that as a miss would report the finding as a failure. What each attempt
 actually reached for is still observed and shown; only the verdict is withheld.
 
+## Activation admissibility
+
+Whether an [[activation]] observation may be **counted**, as distinct from
+whether it was **made**. The two come apart only on a truncated transcript.
+
+An `infra_error` or `timeout` attempt is *inadmissible*: the transcript may have
+been cut, so nothing it shows can enter the [[activation score]]'s denominator.
+But truncation is asymmetric — it can hide evidence, never invent it — so a
+*positive* observation is still recorded, while an empty one is written as "not
+observed" rather than as a fabricated "the description never fired". An
+inadmissible attempt therefore carries an observation and **no verdict**: the
+observation is evidence for a person reading saved results, and nothing derives
+a score from it.
+
+So there are three states, not two: *observed and admissible*, *observed but
+inadmissible*, and *not observed at all* — the last being an [[ablation|ablated]]
+neighbourhood, where no choice existed to observe.
+_Avoid_: unusable activation (an attempt that is [[usable / unusable
+attempt|unusable]] for the [[success rate|score]] may still be
+activation-admissible — a `judge_error` is).
+
 ## Skill neighbourhood
 
 The set of skills declared by an [[eval spec]] and installed for a run. Its

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -289,3 +289,38 @@ def test_a_truncated_transcript_yields_no_observation_rather_than_an_empty_set()
     assert assembled.record.outcome is Outcome.TIMEOUT
     assert assembled.record.activated is None
     assert assembled.record.activation_passed is None
+
+
+def test_a_truncated_transcript_keeps_an_activation_it_did_see():
+    """Truncation hides evidence, never invents it: a positive survives as evidence."""
+    assembled = _assemble(
+        _result(
+            timed_out=True,
+            exit_code=124,
+            error="timeout",
+            transcript=[_read_turn("/skills/tdd/SKILL.md")],
+        ),
+        activation=_detector(),
+        expected_activation=["tdd"],
+    )
+
+    assert assembled.record.outcome is Outcome.TIMEOUT
+    assert assembled.record.activated == ["tdd"]
+
+
+def test_a_kept_observation_is_evidence_and_never_a_verdict():
+    """Inadmissible by outcome: the observation rides, the verdict is withheld."""
+    assembled = _assemble(
+        _result(
+            timed_out=True,
+            exit_code=124,
+            error="timeout",
+            transcript=[_read_turn("/skills/tdd/SKILL.md")],
+        ),
+        activation=_detector(),
+        expected_activation=["tdd"],
+    )
+
+    assert assembled.record.activation_passed is None
+    assert assembled.record.activation_scored is False
+    assert assembled.record.activation_observed is False


### PR DESCRIPTION
## The context

Caliper records an **activation** for each **attempt**. An activation is the set of skills that the agent chose to load.

An attempt has an **outcome**. Two outcomes are `timeout` and `infra_error`. Both can cut the transcript short.

## The problem

Caliper read the transcript. Then caliper discarded the result and wrote `null`. It did this for every timeout. `null` means "not observed".

But sometimes caliper did see an activation before the cut. Caliper discarded this fact too. This was wrong.

## The rule

A cut can remove evidence from a transcript. A cut cannot add evidence to a transcript.

So the two directions are different:

- Caliper saw an activation. This is a fact. Keep it.
- Caliper saw no activation. The cut can hide an activation. Do not keep this. Write `null`.

## The verdict

Caliper writes no verdict for these attempts. `activation_passed` stays `null`.

A kept activation is evidence only. A person can read it in the saved results. Nothing gives it a score.

The new glossary term is **activation admissibility**. It separates two questions. Did caliper observe the activation? May caliper count the activation?

## What does not change

The **activation score** does not change. Its denominator excludes `timeout` and `infra_error` by outcome. This gate does not read the field.

The report does not change. It shows nothing new.

## What this does not give you

You cannot use a short time budget for a large activation run. A short time budget causes more timeouts. Each negative then leaves the denominator. Each positive stays. The score moves to 100 percent, and the number is false.

Write short prompts instead. Then each attempt ends normally.

## The changes

`caliper/attempt.py` holds the new branch. The comment above it gives the reason.

`tests/test_attempt.py` adds two tests. The first test shows that a positive observation survives a cut. The second test shows that a kept observation gets no verdict.

`docs/CONTEXT.md` adds the term **activation admissibility**.

`README.md` describes both directions in its saved-results section.

This change has no ADR. You can reverse it in three lines. It does not meet the "hard to reverse" rule of this repository. The code comment and the glossary hold the reason.

## The checks

`pytest` passes 414 tests. `ruff format --check .` is clean. `ruff check .` is clean. `caliper validate skills/evaluate-skill/evaluate-skill.eval.yaml` runs correctly.
