### PR TITLE
refactor(harness): a backend declares its chores, CliHarness performs them

### DIFF
--- a/caliper/harness/base.py
+++ b/caliper/harness/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import time
 from abc import ABC, abstractmethod
@@ -217,6 +218,11 @@ class CliHarness(HarnessBackend):
     stream, and assembles the ``AttemptResult``. A backend only implements the
     parts that genuinely differ between CLI agents — the command, the
     environment, and how to read that agent's stream.
+
+    Where a chore is the same for every CLI agent, the backend *declares* what
+    varies and this class performs it: ``seed_files``, ``cli_name`` and friends,
+    ``env_passthrough``. See
+    docs/adr/0020-a-backend-declares-its-chores-rather-than-performing-them.md.
     """
 
     def run(
@@ -247,6 +253,7 @@ class CliHarness(HarnessBackend):
         )
 
         self._ensure_ready(ctx)
+        self._seed_home(ctx)
         self._prepare(ctx)
         # After _prepare: a backend's skills root can depend on state _prepare
         # sets up (hermes' HERMES_HOME, pi's agent dir).
@@ -264,7 +271,7 @@ class CliHarness(HarnessBackend):
                 cleanup()
         duration = time.monotonic() - start
 
-        transcript, final_output = self._parse_stream(proc.stdout)
+        transcript, final_output = self._parse_stream_with_tail(proc.stdout)
 
         diagnostic = self._diagnose(proc, final_output)
         if diagnostic:
@@ -341,8 +348,37 @@ class CliHarness(HarnessBackend):
     def _ensure_ready(self, ctx: RunContext) -> None:
         """Raise ``HarnessConfigurationError`` if the CLI can't run. Default: skip."""
 
+    def seed_files(self, ctx: RunContext) -> list[tuple[Path, Path]]:
+        """The ``(real, isolated)`` config files to copy verbatim into the home.
+
+        Declared as *data* rather than copied by hand, because the policy is the
+        same for every CLI agent (copy verbatim, skip what isn't there) while the
+        file list is the only part that differs — including its deliberate
+        omissions: hermes leaves out SOUL.md/MEMORY.md to normalize the agent
+        (docs/adr/0005), and codex's ``config.toml`` is absent here because it is
+        rewritten rather than copied. Default: nothing to seed.
+
+        See docs/adr/0012-cli-harnesses-copy-cli-config-verbatim.md and
+        docs/adr/0020-a-backend-declares-its-chores-rather-than-performing-them.md.
+        """
+        return []
+
+    def _seed_home(self, ctx: RunContext) -> None:
+        """Copy each declared seed file that exists, creating parents as needed."""
+        for src, dst in self.seed_files(ctx):
+            if src.exists():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+
     def _prepare(self, ctx: RunContext) -> None:
-        """Seed the isolated home with auth/config before the agent runs."""
+        """Seed the isolated home with anything ``seed_files`` cannot express.
+
+        Runs after :meth:`_seed_home`, so a backend that has to *rewrite* a
+        config (codex's stripped ``config.toml``, hermes' normalized
+        ``mcp_servers``) sees the verbatim copy already in place, and so
+        claude-code can tell whether credentials were seeded before it falls
+        back to the Keychain. That order is part of the contract (docs/adr/0020).
+        """
 
     @abstractmethod
     def skills_root(self, ctx: RunContext) -> Path:
@@ -376,7 +412,36 @@ class CliHarness(HarnessBackend):
     def _environment(self, ctx: RunContext) -> dict[str, str]: ...
 
     @abstractmethod
-    def _parse_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]: ...
+    def _parse_stream(self, stdout: str) -> tuple[list[ConversationTurn], str]:
+        """Read this agent's stream into turns plus whatever it named as final.
+
+        Return ``""`` for the final output when the stream carried no explicit
+        final-answer event; :meth:`_parse_stream_with_tail` supplies the tail. A backend
+        never walks the transcript backwards itself.
+        """
+
+    def _parse_stream_with_tail(
+        self, stdout: str
+    ) -> tuple[list[ConversationTurn], str]:
+        """Parse the agent's stream, falling back to its last assistant turn.
+
+        Every CLI agent has some shape of stream that may end without naming a
+        final answer — a tool call last, a truncated run — and the answer in that
+        case is the same for all of them: the last thing the assistant said. So
+        the tail lives here rather than at the end of four ``_parse_stream``
+        implementations. Distinct from :meth:`_fallback`, which salvages raw
+        stdout when *nothing* parsed at all.
+        """
+        transcript, final_output = self._parse_stream(stdout)
+        return transcript, final_output or self._last_assistant(transcript)
+
+    @staticmethod
+    def _last_assistant(transcript: list[ConversationTurn]) -> str:
+        """The most recent non-empty assistant turn's content, or ``""``."""
+        for turn in reversed(transcript):
+            if turn.role == "assistant" and turn.content:
+                return turn.content
+        return ""
 
     def _diagnose(self, proc: ProcessResult, final_output: str) -> str | None:
         """Return a human-readable misconfiguration message, or ``None``."""
@@ -474,6 +539,76 @@ class CliHarness(HarnessBackend):
         return proc.stdout.strip()
 
     # --- shared machinery -------------------------------------------------
+
+    #: The binary :meth:`cli_path` looks for on ``PATH``. ``None`` for a backend
+    #: that resolves its command some other way (claude-code spawns ``claude``
+    #: through the shell's own lookup).
+    cli_name: str | None = None
+
+    #: The env var that overrides :attr:`cli_name` with an explicit path. Honored
+    #: only when it points at something that exists, so a stale export falls
+    #: through to discovery rather than failing the run with a confusing message.
+    cli_path_env_var: str | None = None
+
+    def cli_candidates(self) -> tuple[Path, ...]:
+        """Well-known install locations to try before ``PATH``. Default: none.
+
+        For an agent shipped inside an application bundle, which is where the
+        current build lives even when an older copy is on ``PATH``. Resolved at
+        call time, so a candidate may depend on state the process picks up.
+        """
+        return ()
+
+    def cli_path(self) -> str | None:
+        """Locate this backend's CLI: env-var override, then candidates, then PATH.
+
+        One order for every backend. Without it each adapter spelled the same
+        three steps itself, and they drifted — the override was checked for
+        existence in some and not others.
+        """
+        if self.cli_path_env_var:
+            configured = os.environ.get(self.cli_path_env_var)
+            if configured and Path(configured).exists():
+                return configured
+        for candidate in self.cli_candidates():
+            if candidate.exists():
+                return str(candidate)
+        return shutil.which(self.cli_name) if self.cli_name else None
+
+    #: Vars forwarded from the parent environment into an isolated run. Locale
+    #: and terminal shape are not state the agent carries between attempts, and
+    #: an agent that cannot find its scratch space fails for reasons that have
+    #: nothing to do with the skill under test.
+    env_passthrough: tuple[str, ...] = ("LANG", "LC_ALL", "TERM", "TMPDIR")
+
+    def _isolated_env(
+        self,
+        ctx: RunContext,
+        *,
+        extra: dict[str, str] | None = None,
+        path_prefixes: list[str] | None = None,
+    ) -> dict[str, str]:
+        """Build the attempt's environment: a stripped ``HOME`` plus a usable ``PATH``.
+
+        The ``HOME`` is the isolated one — that is the whole point of the
+        per-attempt home — and everything else is opt-in, so an attempt cannot
+        quietly inherit the developer's ambient state. ``ctx.extra_path`` comes
+        first (the run's own staged binaries win), then any backend prefixes,
+        then the real ``PATH`` with those entries removed so a prefix genuinely
+        takes precedence instead of merely appearing twice.
+        """
+        prefixes = list(dict.fromkeys([*ctx.extra_path, *(path_prefixes or [])]))
+        rest = [
+            part
+            for part in os.environ.get("PATH", "").split(os.pathsep)
+            if part and part not in set(prefixes)
+        ]
+        env = {
+            "HOME": ctx.isolated_home,
+            "PATH": os.pathsep.join(prefixes + rest),
+            **(extra or {}),
+        }
+        return self._passthrough(env, self.env_passthrough)
 
     def _execute(
         self,

--- a/caliper/harness/claude_code.py
+++ b/caliper/harness/claude_code.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import shutil
 import sys
 from pathlib import Path
 from typing import Callable
@@ -57,24 +56,23 @@ class ClaudeCodeHarness(CliHarness):
     def skills_root(self, ctx: RunContext) -> Path:
         return Path(ctx.isolated_home) / ".claude" / "skills"
 
-    def _prepare(self, ctx: RunContext) -> None:
-        home = Path(ctx.isolated_home)
-        (home / ".claude").mkdir(parents=True, exist_ok=True)
-
-        # Copy auth files from the real HOME so the CLI finds its credentials.
-        # Without this, the isolated HOME causes claude to fall back to
+    def seed_files(self, ctx: RunContext) -> list[tuple[Path, Path]]:
+        # Auth files from the real HOME, so the CLI finds its credentials.
+        # Without them the isolated HOME makes claude fall back to
         # ANTHROPIC_API_KEY (which may be absent or unfunded).
         real_home = Path.home()
-        for src, dst in [
+        home = Path(ctx.isolated_home)
+        return [
             (real_home / ".claude.json", home / ".claude.json"),
             (
                 real_home / ".claude" / ".credentials.json",
                 home / ".claude" / ".credentials.json",
             ),
-        ]:
-            if src.exists():
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src, dst)
+        ]
+
+    def _prepare(self, ctx: RunContext) -> None:
+        home = Path(ctx.isolated_home)
+        (home / ".claude").mkdir(parents=True, exist_ok=True)
 
         # On macOS, OAuth credentials may live in the Keychain rather than in
         # .credentials.json. Seed the isolated home so the subprocess can auth
@@ -148,11 +146,38 @@ class ClaudeCodeHarness(CliHarness):
         return config_path
 
     def _environment(self, ctx: RunContext) -> dict[str, str]:
-        return self._build_env(
-            ctx.isolated_home,
-            ctx.extra_path,
-            ctx.extras.get("has_file_credentials", False),
-        )
+        env = self._isolated_env(ctx, path_prefixes=self._path_prefixes())
+
+        # Only forward API keys when there are no file-based credentials and no
+        # Keychain credentials — avoids overriding valid OAuth auth with a
+        # potentially unfunded key.
+        if not ctx.extras.get("has_file_credentials", False):
+            for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
+                if key in os.environ:
+                    env[key] = os.environ[key]
+        return env
+
+    def _path_prefixes(self) -> list[str]:
+        """Interpreter and package-manager directories the CLI needs on ``PATH``.
+
+        The claude CLI is a Node program, so an nvm-managed Node has to be found
+        before the system one; on macOS an IDE-launched process often has a
+        stripped PATH that omits the Homebrew prefixes the agent's own tools live
+        in. Everything else about the environment is the shared isolated one.
+        """
+        prefixes: list[str] = []
+
+        nvm_node_bin = preferred_nvm_node_bin()
+        if nvm_node_bin:
+            prefixes.append(nvm_node_bin)
+
+        if sys.platform == "darwin":
+            prefixes.extend(
+                p
+                for p in ("/opt/homebrew/bin", "/opt/homebrew/sbin", "/usr/local/bin")
+                if os.path.isdir(p)
+            )
+        return prefixes
 
     def _diagnose(self, proc: ProcessResult, final_output: str) -> str | None:
         text = "\n".join(part for part in (final_output, proc.stderr) if part).strip()
@@ -220,8 +245,8 @@ class ClaudeCodeHarness(CliHarness):
         final_output: str,
         proc: ProcessResult,
     ) -> tuple[list[ConversationTurn], str]:
-        # Claude's stream-json stdout is never salvageable as a raw turn; its own
-        # last-assistant fallback in _parse_stream is the only fallback.
+        # Claude's stream-json stdout is never salvageable as a raw turn; the
+        # template's last-assistant tail is the only fallback.
         return transcript, final_output
 
     def _error_field(self, proc: ProcessResult, final_output: str) -> str | None:
@@ -315,61 +340,6 @@ class ClaudeCodeHarness(CliHarness):
             dst.parent.mkdir(parents=True, exist_ok=True)
             dst.write_text(out)
 
-    def _build_env(
-        self,
-        isolated_home: str,
-        extra_path: list[str],
-        has_file_credentials: bool = False,
-    ) -> dict[str, str]:
-        base_path = os.environ.get("PATH", "")
-        path_prefixes = []
-
-        nvm_node_bin = preferred_nvm_node_bin()
-        if nvm_node_bin:
-            path_prefixes.append(nvm_node_bin)
-
-        # On macOS, IDE-launched processes often have a stripped PATH that
-        # omits Homebrew prefixes. Prepend them when present so tools installed
-        # via Homebrew (e.g. on Apple Silicon at /opt/homebrew/bin) are found.
-        if sys.platform == "darwin":
-            homebrew_candidates = [
-                "/opt/homebrew/bin",
-                "/opt/homebrew/sbin",
-                "/usr/local/bin",
-            ]
-            path_prefixes.extend(p for p in homebrew_candidates if os.path.isdir(p))
-
-        if extra_path:
-            path_prefixes = extra_path + path_prefixes
-
-        base_parts = [p for p in base_path.split(os.pathsep) if p]
-        path_prefixes = list(dict.fromkeys(path_prefixes))
-        prefix_set = set(path_prefixes)
-        base_parts = [p for p in base_parts if p not in prefix_set]
-        additions = path_prefixes
-        if additions:
-            base_path = os.pathsep.join(additions + base_parts)
-
-        env: dict[str, str] = {
-            "HOME": isolated_home,
-            "PATH": base_path,
-        }
-
-        # macOS uses TMPDIR for the per-user secure temp directory; Node.js
-        # (and therefore the claude CLI) reads it to locate scratch space.
-        if sys.platform == "darwin" and "TMPDIR" in os.environ:
-            env["TMPDIR"] = os.environ["TMPDIR"]
-
-        # Only forward API keys when there are no file-based credentials and
-        # no Keychain credentials — avoids overriding valid OAuth auth with a
-        # potentially unfunded key.
-        if not has_file_credentials:
-            for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
-                if key in os.environ:
-                    env[key] = os.environ[key]
-
-        return env
-
     def _usage(self, proc: ProcessResult, ctx: RunContext) -> TokenUsage | None:
         """Read the ``result`` event's ``usage``. Claude's ``input_tokens`` is
         already non-cached, so the mapping is direct."""
@@ -440,12 +410,6 @@ class ClaudeCodeHarness(CliHarness):
 
             elif etype == "result":
                 final_output = event.get("result", "")
-
-        if not final_output and transcript:
-            for turn in reversed(transcript):
-                if turn.role == "assistant" and turn.content:
-                    final_output = turn.content
-                    break
 
         return transcript, final_output
 

--- a/caliper/harness/codex.py
+++ b/caliper/harness/codex.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -29,10 +27,15 @@ class CodexHarness(CliHarness):
         self._model = model
 
     supports_mcp = True
+    cli_name = "codex"
+    cli_path_env_var = "CODEX_CLI_PATH"
 
     @property
     def name(self) -> str:
         return "codex"
+
+    def cli_candidates(self) -> tuple[Path, ...]:
+        return (CODEX_APP_CLI,)
 
     def _ensure_ready(self, ctx: RunContext) -> None:
         if not self._cli_available():
@@ -47,8 +50,20 @@ class CodexHarness(CliHarness):
     def skills_root(self, ctx: RunContext) -> Path:
         return Path(ctx.isolated_home) / ".codex" / "skills"
 
+    def seed_files(self, ctx: RunContext) -> list[tuple[Path, Path]]:
+        real = Path.home() / ".codex"
+        codex_home = Path(ctx.isolated_home) / ".codex"
+        # config.toml is deliberately absent: it is rewritten rather than copied
+        # (see ``_materialize_config``), so seeding it verbatim would leak the
+        # user's ambient model pin and MCP servers into the attempt.
+        return [(real / "auth.json", codex_home / "auth.json")]
+
     def _prepare(self, ctx: RunContext) -> None:
-        self._copy_codex_config(ctx)
+        self._materialize_config(
+            ctx,
+            Path(ctx.isolated_home) / ".codex",
+            Path.home() / ".codex" / "config.toml",
+        )
 
     def _command(
         self, ctx: RunContext
@@ -57,7 +72,7 @@ class CodexHarness(CliHarness):
         # and caliper no longer invents one: the skill is installed at
         # .codex/skills/<name>/ and the agent discovers it (docs/adr/0013).
         full_prompt = ctx.prompt
-        codex = self._codex_command() or "codex"
+        codex = self.cli_path() or "codex"
         cmd = [
             codex,
             "exec",
@@ -73,10 +88,10 @@ class CodexHarness(CliHarness):
         return cmd, full_prompt, None
 
     def _environment(self, ctx: RunContext) -> dict[str, str]:
-        return self._build_env(ctx.isolated_home, ctx.extra_path)
+        return self._isolated_env(ctx)
 
     def _cli_available(self) -> bool:
-        codex = self._codex_command()
+        codex = self.cli_path()
         return codex is not None and self._version_ok(codex, timeout=5)
 
     def _usage(self, proc: ProcessResult, ctx: RunContext) -> TokenUsage | None:
@@ -185,12 +200,6 @@ class CodexHarness(CliHarness):
                 )
             )
 
-        if not final_output and transcript:
-            for turn in reversed(transcript):
-                if turn.role == "assistant" and turn.content:
-                    final_output = turn.content
-                    break
-
         return transcript, final_output
 
     @staticmethod
@@ -245,31 +254,12 @@ class CodexHarness(CliHarness):
             )
         return turns
 
-    def _build_env(self, isolated_home: str, extra_path: list[str]) -> dict[str, str]:
-        path = os.environ.get("PATH", "")
-        if extra_path:
-            path = os.pathsep.join(extra_path) + os.pathsep + path
-
-        env = {
-            "HOME": isolated_home,
-            "PATH": path,
-        }
-        return self._passthrough(env, ("LANG", "LC_ALL", "TERM", "TMPDIR"))
-
-    def _codex_command(self) -> str | None:
-        configured = os.environ.get("CODEX_CLI_PATH")
-        if configured and Path(configured).exists():
-            return configured
-        if CODEX_APP_CLI.exists():
-            return str(CODEX_APP_CLI)
-        return shutil.which("codex")
-
     # --- bare prompt call (the judge's half of the seam) -------------------
 
     def _prompt_command(
         self, prompt: str, model: str | None, extras: dict
     ) -> tuple[list[str], str | None, Callable[[], None] | None]:
-        codex = self._codex_command()
+        codex = self.cli_path()
         if not codex:
             raise HarnessConfigurationError("codex CLI not found")
 
@@ -315,17 +305,6 @@ class CodexHarness(CliHarness):
         # Codex doesn't surface the resolved model in this mode, so we can only
         # report the one that was requested (None when its own default ran).
         return PromptResult(text=raw, resolved_model=model, error=None)
-
-    def _copy_codex_config(self, ctx: RunContext) -> None:
-        codex_home = Path(ctx.isolated_home) / ".codex"
-        real_codex_home = Path.home() / ".codex"
-
-        auth_src = real_codex_home / "auth.json"
-        if auth_src.exists():
-            codex_home.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(auth_src, codex_home / "auth.json")
-
-        self._materialize_config(ctx, codex_home, real_codex_home / "config.toml")
 
     def _materialize_config(
         self, ctx: RunContext, codex_home: Path, real_config: Path

--- a/caliper/harness/hermes.py
+++ b/caliper/harness/hermes.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import shutil
 from pathlib import Path
 from typing import Callable
 
@@ -43,6 +41,8 @@ class HermesHarness(CliHarness):
     """
 
     supports_mcp = True
+    cli_name = "hermes"
+    cli_path_env_var = "HERMES_CLI_PATH"
     # Hermes advertises installed skills to the model as name + truncated
     # description and exposes the model's choice as a named skill_view call —
     # the shape that makes a description measurable.
@@ -65,18 +65,22 @@ class HermesHarness(CliHarness):
                 "the hermes binary, then rerun caliper."
             )
 
-    def _prepare(self, ctx: RunContext) -> None:
+    def seed_files(self, ctx: RunContext) -> list[tuple[Path, Path]]:
         # Isolate Hermes' whole home per attempt (parallel-safe; never mutates
         # the user's real ~/.hermes). Seeding only auth/config — not SOUL.md or
         # MEMORY.md — is what neutralizes the agent; --ignore-rules on the
         # command completes the strip.
-        hermes_home = Path(ctx.isolated_home) / ".hermes"
         real_home = Path.home() / ".hermes"
+        hermes_home = self._hermes_home(ctx)
+        return [(real_home / name, hermes_home / name) for name in _SEED_FILES]
+
+    @staticmethod
+    def _hermes_home(ctx: RunContext) -> Path:
+        return Path(ctx.isolated_home) / ".hermes"
+
+    def _prepare(self, ctx: RunContext) -> None:
+        hermes_home = self._hermes_home(ctx)
         hermes_home.mkdir(parents=True, exist_ok=True)
-        for filename in _SEED_FILES:
-            src = real_home / filename
-            if src.exists():
-                shutil.copy2(src, hermes_home / filename)
         ctx.extras["hermes_home"] = str(hermes_home)
 
         self._configure_mcp(ctx, hermes_home)
@@ -157,37 +161,27 @@ class HermesHarness(CliHarness):
         return ["/bin/sh", "-c", script], None, None
 
     def _environment(self, ctx: RunContext) -> dict[str, str]:
-        path = os.environ.get("PATH", "")
-        if ctx.extra_path:
-            path = os.pathsep.join(ctx.extra_path) + os.pathsep + path
-
-        env = {
-            "HOME": ctx.isolated_home,
-            "PATH": path,
-            "HERMES_HOME": ctx.extras["hermes_home"],
-            "CALIPER_HERMES": self._hermes_command() or "hermes",
-            "CALIPER_PROMPT": ctx.prompt,
-        }
-        return self._passthrough(env, ("LANG", "LC_ALL", "TERM", "TMPDIR"))
+        return self._isolated_env(
+            ctx,
+            extra={
+                "HERMES_HOME": ctx.extras["hermes_home"],
+                "CALIPER_HERMES": self.cli_path() or "hermes",
+                "CALIPER_PROMPT": ctx.prompt,
+            },
+        )
 
     def _cli_available(self) -> bool:
-        hermes = self._hermes_command()
+        hermes = self.cli_path()
         return hermes is not None and self._version_ok(
             hermes, timeout=15, args=("--version",)
         )
-
-    def _hermes_command(self) -> str | None:
-        configured = os.environ.get("HERMES_CLI_PATH")
-        if configured and Path(configured).exists():
-            return configured
-        return shutil.which("hermes")
 
     # --- bare prompt call (the judge's half of the seam) -------------------
 
     def _prompt_command(
         self, prompt: str, model: str | None, extras: dict
     ) -> tuple[list[str], str | None, Callable[[], None] | None]:
-        hermes = self._hermes_command()
+        hermes = self.cli_path()
         if not hermes:
             raise HarnessConfigurationError("hermes CLI not found")
 
@@ -241,12 +235,6 @@ class HermesHarness(CliHarness):
             elif role == "user":
                 if text.strip():
                     transcript.append(ConversationTurn(role="user", content=text))
-
-        if not final_output:
-            for turn in reversed(transcript):
-                if turn.role == "assistant" and turn.content:
-                    final_output = turn.content
-                    break
 
         return transcript, final_output
 

--- a/caliper/harness/pi.py
+++ b/caliper/harness/pi.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import shutil
 from pathlib import Path
 from typing import Callable
 
@@ -41,6 +39,9 @@ class PiHarness(CliHarness):
         "caliper, run them on the claude-code backend (--model claude-code)."
     )
 
+    cli_name = "pi"
+    cli_path_env_var = "PI_CLI_PATH"
+
     @property
     def name(self) -> str:
         return "pi"
@@ -54,22 +55,36 @@ class PiHarness(CliHarness):
                 "`PI_CLI_PATH` to the pi binary, then rerun caliper."
             )
 
-    def _prepare(self, ctx: RunContext) -> None:
-        # pi reads auth/settings from its config dir. We copy the real config
+    def seed_files(self, ctx: RunContext) -> list[tuple[Path, Path]]:
+        # pi reads auth/settings from its config dir. The real config is copied
         # verbatim into a per-attempt directory (parallel-safe; never mutates
-        # the user's real ~/.pi) and point pi at it via PI_CODING_AGENT_DIR.
+        # the user's real ~/.pi) that PI_CODING_AGENT_DIR then points pi at.
         # The config's default model/provider is preserved on purpose; the
         # spec's `--model` overrides it when set. See issue #10 for why this
         # differs from codex (which strips its config default).
-        ctx.extras["agent_dir"] = self._copy_pi_config(ctx.isolated_home)
+        real = Path.home() / ".pi" / "agent"
+        agent_dir = self._agent_dir(ctx)
+        return [
+            (real / name, agent_dir / name) for name in ("auth.json", "settings.json")
+        ]
+
+    @staticmethod
+    def _agent_dir(ctx: RunContext) -> Path:
+        """The per-attempt config dir pi is pointed at via PI_CODING_AGENT_DIR.
+
+        Derived from the isolated home rather than stashed in ``ctx.extras``:
+        it is a function of the context, so there is nothing for a hook to
+        remember between them.
+        """
+        return Path(ctx.isolated_home) / ".pi" / "agent"
 
     def skills_root(self, ctx: RunContext) -> Path:
-        return Path(ctx.extras["agent_dir"]) / "skills"
+        return self._agent_dir(ctx) / "skills"
 
     def _command(
         self, ctx: RunContext
     ) -> tuple[list[str], str | None, Callable[[], None] | None]:
-        pi = self._pi_command() or "pi"
+        pi = self.cli_path() or "pi"
         cmd = [
             pi,
             "--print",
@@ -92,12 +107,12 @@ class PiHarness(CliHarness):
         return cmd, None, None
 
     def _environment(self, ctx: RunContext) -> dict[str, str]:
-        return self._build_env(
-            ctx.isolated_home, ctx.extras["agent_dir"], ctx.extra_path
+        return self._isolated_env(
+            ctx, extra={"PI_CODING_AGENT_DIR": str(self._agent_dir(ctx))}
         )
 
     def _cli_available(self) -> bool:
-        pi = self._pi_command()
+        pi = self.cli_path()
         return pi is not None and self._version_ok(pi, timeout=10)
 
     def _usage(self, proc: ProcessResult, ctx: RunContext) -> TokenUsage | None:
@@ -184,12 +199,6 @@ class PiHarness(CliHarness):
                     transcript.append(ConversationTurn(role="assistant", content=text))
                     final_output = text
 
-        if not final_output and transcript:
-            for turn in reversed(transcript):
-                if turn.role == "assistant" and turn.content:
-                    final_output = turn.content
-                    break
-
         return transcript, final_output
 
     def _flatten_text(self, content: object) -> str:
@@ -211,32 +220,12 @@ class PiHarness(CliHarness):
             return result
         return ""
 
-    def _build_env(
-        self, isolated_home: str, agent_dir: Path, extra_path: list[str]
-    ) -> dict[str, str]:
-        path = os.environ.get("PATH", "")
-        if extra_path:
-            path = os.pathsep.join(extra_path) + os.pathsep + path
-
-        env = {
-            "HOME": isolated_home,
-            "PATH": path,
-            "PI_CODING_AGENT_DIR": str(agent_dir),
-        }
-        return self._passthrough(env, ("LANG", "LC_ALL", "TERM", "TMPDIR"))
-
-    def _pi_command(self) -> str | None:
-        configured = os.environ.get("PI_CLI_PATH")
-        if configured and Path(configured).exists():
-            return configured
-        return shutil.which("pi")
-
     # --- bare prompt call (the judge's half of the seam) -------------------
 
     def _prompt_command(
         self, prompt: str, model: str | None, extras: dict
     ) -> tuple[list[str], str | None, Callable[[], None] | None]:
-        pi = self._pi_command()
+        pi = self.cli_path()
         if not pi:
             raise HarnessConfigurationError("pi CLI not found")
 
@@ -250,18 +239,8 @@ class PiHarness(CliHarness):
 
     def _prompt_text(self, proc: ProcessResult) -> str:
         # The answer is the last assistant message of pi's JSON event stream —
-        # the same stream _parse_stream already reads for attempt runs.
-        return self._parse_stream(proc.stdout)[1]
-
-    def _copy_pi_config(self, isolated_home: str) -> Path:
-        agent_dir = Path(isolated_home) / ".pi" / "agent"
-        real_agent_dir = Path.home() / ".pi" / "agent"
-        for filename in ("auth.json", "settings.json"):
-            src = real_agent_dir / filename
-            if src.exists():
-                agent_dir.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src, agent_dir / filename)
-        return agent_dir
+        # the same stream an attempt run reads, tail and all.
+        return self._parse_stream_with_tail(proc.stdout)[1]
 
     def _diagnose(self, proc: ProcessResult, final_output: str) -> str | None:
         if proc.returncode == 0:

--- a/docs/adr/0020-a-backend-declares-its-chores-rather-than-performing-them.md
+++ b/docs/adr/0020-a-backend-declares-its-chores-rather-than-performing-them.md
@@ -1,0 +1,72 @@
+# A backend declares its chores rather than performing them
+
+Four CLI backends each hand-rolled the same three chores: seeding the isolated
+home with the user's real config, locating the CLI binary, and building the
+attempt's environment. A fourth thing — recovering the final answer from the
+last assistant turn when the stream never named one — was copied verbatim into
+all four stream parsers.
+
+`CliHarness` was already a template method owning the expensive parts (spawn,
+timeout, cancellation, usage safety). It simply stopped one hook short each
+time, so `_prepare` and `_environment` were "do it yourself" where
+[0009](0009-mcp-secrets-interpolated-at-the-harness-boundary.md)'s
+`resolve_servers` had already shown the better shape: the base does the work,
+the backend contributes the one fact that differs.
+
+## Data, not code
+
+The chores are now declared:
+
+| Hook | The backend says | The base does |
+|---|---|---|
+| `seed_files(ctx)` | which `(real, isolated)` files to copy | copies each one that exists, creating parents |
+| `cli_name` / `cli_path_env_var` / `cli_candidates()` | what the binary is called and where else to look | env-var override → candidates → `PATH` |
+| `env_passthrough` (+ `_isolated_env`) | any extra vars, any extra `PATH` prefixes | isolated `HOME`, deduplicated `PATH`, allowlisted passthrough |
+| `_parse_stream` | this agent's turns | supplies the last-assistant tail |
+
+The reason the chores stayed duplicated for so long is that each backend has an
+*exception* — and an exception looks like a reason to keep your own copy. Every
+one of them turned out to be expressible as data:
+
+- codex omits `config.toml` from `seed_files` because it **rewrites** that file
+  rather than copying it (stripping `model =` and the user's ambient
+  `[mcp_servers*]`); the copy-verbatim policy of
+  [0012](0012-cli-harnesses-copy-cli-config-verbatim.md) is unchanged for
+  everything it does seed.
+- hermes omits `SOUL.md` and `MEMORY.md` from `seed_files`; that omission *is*
+  the neutralization of a stateful agent
+  ([0005](0005-hermes-backend-normalized-to-neutral-agent.md)), and it now reads
+  as a list rather than as a loop you have to notice.
+- claude-code contributes `PATH` prefixes (nvm's Node, Homebrew) and forwards
+  API keys only when no file credentials were seeded.
+
+## Ordering is part of the contract
+
+`_seed_home` runs **before** `_prepare`. A backend that has to rewrite a config
+must see the verbatim copy already in place, and claude-code's Keychain fallback
+must be able to test whether `.credentials.json` was seeded before deciding to
+shell out for it. Reversing the two would silently break both, so the order is
+stated in `run` and in `_prepare`'s docstring rather than left to be discovered.
+
+## Costs accepted
+
+**claude-code's environment changed.** It previously forwarded `TMPDIR` alone,
+and only on macOS; it now forwards `LANG`, `LC_ALL`, `TERM`, `TMPDIR` like every
+other backend. That is a real behaviour change made deliberately: a backend
+differing from its siblings for no recorded reason is the thing this record is
+against, and locale/terminal shape is not state an agent carries between
+attempts. It is also the reason to look here first if claude-code's stream ever
+parses differently — though its `--output-format stream-json` should be
+indifferent to `TERM`.
+
+**`PATH` is deduplicated now.** The old spelling was `extra_path + PATH`
+verbatim, so an entry already on `PATH` appeared twice and the earlier
+occurrence was not necessarily the staged one. The base removes prefix entries
+from the tail, which is what makes `extra_path` actually take precedence.
+
+**`_ensure_ready`'s message was left alone.** Templating it was considered and
+rejected: the three messages share a shape but not a subject — codex's talks
+about API billing and names no env var, while pi's and hermes' name an install
+command and a `*_CLI_PATH`. A template would flatten user-facing prose that
+exists to be read at the moment a run fails, which is the wrong thing to
+economize. Two near-matches out of three is not a shared implementation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,27 @@ from typing import Callable
 import pytest
 
 from caliper import cancel
+from caliper.harness.base import RunContext
+
+
+def run_context(**overrides) -> RunContext:
+    """A ``RunContext`` with everything a hook needs already filled in.
+
+    Shared so a test that cares about one field (the isolated home, the extra
+    path) says only that field, and so the conformance suite can hand the same
+    context to all four adapters.
+    """
+    fields = {
+        "task_id": "task-001",
+        "attempt": 1,
+        "prompt": "Hello",
+        "skill_refs": [],
+        "model": None,
+        "timeout": 12,
+        "isolated_home": "/tmp/caliper-test-home",
+        "extra_path": [],
+    }
+    return RunContext(**{**fields, **overrides})
 
 
 class _FakePopen:

--- a/tests/test_claude_harness.py
+++ b/tests/test_claude_harness.py
@@ -11,7 +11,7 @@ from caliper.harness.claude_code import ClaudeCodeHarness
 from caliper.schema.spec import McpServer
 from caliper.skills import resolve_skills
 
-from conftest import patch_cli_calls
+from conftest import patch_cli_calls, run_context
 
 
 def _ok_stream(cmd: list[str]) -> subprocess.CompletedProcess:
@@ -136,9 +136,8 @@ def test_claude_harness_prefers_even_major_nvm_node(monkeypatch, tmp_path) -> No
     monkeypatch.setattr("caliper.harness.claude_code.Path.home", lambda: tmp_path)
     monkeypatch.setenv("PATH", f"/opt/homebrew/bin:{node_22_bin}:/usr/bin")
 
-    env = ClaudeCodeHarness()._build_env(
-        isolated_home=str(tmp_path / "home"),
-        extra_path=[],
+    env = ClaudeCodeHarness()._environment(
+        run_context(isolated_home=str(tmp_path / "home"))
     )
 
     assert env["PATH"].split(":")[0] == str(node_22_bin)

--- a/tests/test_cli_harness.py
+++ b/tests/test_cli_harness.py
@@ -1,0 +1,253 @@
+"""What every CLI-agent backend does the same way.
+
+These are the chores :class:`CliHarness` owns — seeding the isolated home,
+locating the CLI, building the environment, and reading the stream's tail. Each
+claim is made once here and parameterized over the four backends, so a fifth
+inherits the suite by existing rather than by copying assertions.
+
+The adapters' own test files still carry claims of their own that overlap these
+(hermes asserts its neutral seeding to pin docs/adr/0005, for one) — those are
+kept deliberately: they test the *backend's* stance, not the shared chore, and
+would need writing again the day the shared implementation grew an exception.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from caliper.harness.base import CliHarness, ConversationTurn
+from caliper.harness.claude_code import ClaudeCodeHarness
+from caliper.harness.codex import CodexHarness
+from caliper.harness.hermes import HermesHarness
+from caliper.harness.pi import PiHarness
+
+from conftest import run_context
+
+ALL_BACKENDS = [ClaudeCodeHarness, CodexHarness, HermesHarness, PiHarness]
+
+# The three backends that locate their binary through ``cli_path``. claude-code
+# is absent on purpose: it spawns a bare ``claude`` and leaves the lookup to the
+# shell, so it declares no ``cli_name``.
+DISCOVERING_BACKENDS = [CodexHarness, HermesHarness, PiHarness]
+
+
+def _prepared(harness: CliHarness, tmp_path: Path):
+    """Run the home-preparation half of the template and return the context."""
+    ctx = run_context(isolated_home=str(tmp_path / "home"))
+    Path(ctx.isolated_home).mkdir(parents=True, exist_ok=True)
+    harness._seed_home(ctx)
+    harness._prepare(ctx)
+    return ctx
+
+
+@pytest.fixture(autouse=True)
+def _no_keychain(monkeypatch):
+    """No backend shells out to the macOS Keychain during these tests."""
+    monkeypatch.setattr(CliHarness, "_capture_output", lambda *a, **k: None)
+
+
+# --- seeding the isolated home ----------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_seeds_declared_files_verbatim(backend, monkeypatch, tmp_path) -> None:
+    """Every declared seed file that exists is copied byte-for-byte (ADR-0012)."""
+    real_home = tmp_path / "real"
+    monkeypatch.setattr(Path, "home", lambda: real_home)
+
+    harness = backend()
+    ctx = run_context(isolated_home=str(tmp_path / "home"))
+    for src, _dst in harness.seed_files(ctx):
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text(f"contents of {src.name}")
+
+    harness._seed_home(ctx)
+
+    seeds = harness.seed_files(ctx)
+    assert seeds, f"{harness.name} declares no seed files"
+    for src, dst in seeds:
+        assert dst.read_text() == f"contents of {src.name}"
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_seeding_skips_files_the_user_does_not_have(
+    backend, monkeypatch, tmp_path
+) -> None:
+    """A missing real config is not an error — the CLI falls back to its own."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "empty")
+
+    harness = backend()
+    ctx = run_context(isolated_home=str(tmp_path / "home"))
+    harness._seed_home(ctx)
+
+    assert not any(dst.exists() for _src, dst in harness.seed_files(ctx))
+
+
+# --- locating the CLI --------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", DISCOVERING_BACKENDS)
+def test_cli_path_env_var_overrides_discovery(backend, monkeypatch, tmp_path) -> None:
+    harness = backend()
+    override = tmp_path / "custom-cli"
+    override.write_text("")
+    monkeypatch.setenv(harness.cli_path_env_var, str(override))
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "/usr/bin/x")
+
+    assert harness.cli_path() == str(override)
+
+
+@pytest.mark.parametrize("backend", DISCOVERING_BACKENDS)
+def test_stale_cli_path_falls_through_to_discovery(
+    backend, monkeypatch, tmp_path
+) -> None:
+    """A pointer at a binary that is gone must not fail the run by itself.
+
+    The override names a path, not an intent to fail: an export left over from a
+    reinstall should let discovery proceed rather than produce "CLI not found"
+    while the CLI sits on PATH.
+    """
+    harness = backend()
+    monkeypatch.setenv(harness.cli_path_env_var, str(tmp_path / "deleted"))
+    monkeypatch.setattr(backend, "cli_candidates", lambda _self: ())
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "/usr/bin/x")
+
+    assert harness.cli_path() == "/usr/bin/x"
+
+
+@pytest.mark.parametrize("backend", DISCOVERING_BACKENDS)
+def test_cli_path_is_none_when_nothing_is_installed(backend, monkeypatch) -> None:
+    harness = backend()
+    monkeypatch.delenv(harness.cli_path_env_var, raising=False)
+    monkeypatch.setattr(backend, "cli_candidates", lambda _self: ())
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: None)
+
+    assert harness.cli_path() is None
+
+
+# --- the attempt's environment -----------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_home_points_at_the_isolated_home(backend, monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "real")
+    harness = backend()
+    ctx = _prepared(harness, tmp_path)
+
+    assert harness._environment(ctx)["HOME"] == ctx.isolated_home
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_extra_path_wins_over_the_real_path(backend, monkeypatch, tmp_path) -> None:
+    """The run's own staged binaries come first, and only once.
+
+    ``extra_path`` is how a run puts a shim ahead of the real tool; an entry that
+    is already on PATH has to move to the front rather than merely appear twice,
+    or the shim never runs.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "real")
+    monkeypatch.setenv("PATH", f"/usr/bin{os.pathsep}/staged{os.pathsep}/bin")
+
+    harness = backend()
+    ctx = _prepared(harness, tmp_path)
+    ctx.extra_path = ["/staged"]
+
+    parts = harness._environment(ctx)["PATH"].split(os.pathsep)
+    assert parts[0] == "/staged"
+    assert parts.count("/staged") == 1
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_locale_and_scratch_space_are_forwarded(backend, monkeypatch, tmp_path) -> None:
+    """Locale and TMPDIR ride along; nothing else is inherited by default."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "real")
+    monkeypatch.setenv("LANG", "en_GB.UTF-8")
+    monkeypatch.setenv("TMPDIR", "/scratch")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "leaked")
+
+    harness = backend()
+    env = harness._environment(_prepared(harness, tmp_path))
+
+    assert env["LANG"] == "en_GB.UTF-8"
+    assert env["TMPDIR"] == "/scratch"
+    assert "AWS_SECRET_ACCESS_KEY" not in env
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_skills_root_lives_inside_the_isolated_home(
+    backend, monkeypatch, tmp_path
+) -> None:
+    """Install-and-discover stages the neighbourhood where only this attempt sees it."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "real")
+    harness = backend()
+    ctx = _prepared(harness, tmp_path)
+
+    assert harness.skills_root(ctx).is_relative_to(Path(ctx.isolated_home))
+
+
+# --- reading the stream ------------------------------------------------------
+
+
+class _StubHarness(CliHarness):
+    """A backend that parses nothing, so the base's own tail is what is measured."""
+
+    def __init__(self, transcript, final_output="") -> None:
+        self._transcript = transcript
+        self._final_output = final_output
+
+    name = "stub"
+
+    def skills_root(self, ctx):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+    def _command(self, ctx):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+    def _environment(self, ctx):  # pragma: no cover - unused here
+        raise NotImplementedError
+
+    def _parse_stream(self, stdout):
+        return self._transcript, self._final_output
+
+
+def test_stream_tail_recovers_the_last_assistant_turn() -> None:
+    """A stream that ends on a tool call still has a final answer: the last thing said."""
+    harness = _StubHarness(
+        [
+            ConversationTurn(role="assistant", content="first"),
+            ConversationTurn(role="assistant", content="second"),
+            ConversationTurn(role="tool_use", content="[tool: shell] ls"),
+        ]
+    )
+
+    assert harness._parse_stream_with_tail("")[1] == "second"
+
+
+def test_stream_tail_defers_to_an_explicit_final_answer() -> None:
+    harness = _StubHarness(
+        [ConversationTurn(role="assistant", content="chatter")],
+        final_output="the answer",
+    )
+
+    assert harness._parse_stream_with_tail("")[1] == "the answer"
+
+
+def test_stream_tail_ignores_empty_and_non_assistant_turns() -> None:
+    harness = _StubHarness(
+        [
+            ConversationTurn(role="assistant", content="real"),
+            ConversationTurn(role="assistant", content=""),
+            ConversationTurn(role="user", content="a question"),
+        ]
+    )
+
+    assert harness._parse_stream_with_tail("")[1] == "real"
+
+
+def test_stream_tail_is_empty_when_the_agent_never_spoke() -> None:
+    harness = _StubHarness([ConversationTurn(role="tool_use", content="[tool: shell]")])
+
+    assert harness._parse_stream_with_tail("")[1] == ""

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -47,7 +47,7 @@ def test_codex_installs_the_skill_and_leaves_the_prompt_alone(
         assert kwargs["cwd"] == str(tmp_path)
         return subprocess.CompletedProcess(cmd, 0, stdout="VALID\n", stderr="")
 
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", fake_which)
+    monkeypatch.setattr("caliper.harness.base.shutil.which", fake_which)
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
@@ -87,7 +87,7 @@ def test_codex_cli_omits_model_when_unspecified(monkeypatch, tmp_path) -> None:
             )
         return subprocess.CompletedProcess(cmd, 0, stdout="OK\n", stderr="")
 
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _name: "codex")
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
@@ -148,7 +148,7 @@ def test_codex_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
         stdout = "\n".join(json.dumps(event) for event in events)
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _name: "codex")
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
@@ -203,7 +203,7 @@ def test_codex_json_stream_keeps_unknown_tool_items(monkeypatch, tmp_path) -> No
         stdout = "\n".join(json.dumps(event) for event in events)
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _name: "codex")
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
@@ -231,9 +231,9 @@ def test_codex_prefers_app_bundled_cli(monkeypatch, tmp_path) -> None:
     app_cli.write_text("")
 
     monkeypatch.setattr("caliper.harness.codex.CODEX_APP_CLI", app_cli)
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "old-codex")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _name: "old-codex")
 
-    assert CodexHarness()._codex_command() == str(app_cli)
+    assert CodexHarness().cli_path() == str(app_cli)
 
 
 def test_codex_config_copy_strips_top_level_model(monkeypatch, tmp_path) -> None:
@@ -268,7 +268,9 @@ def test_codex_config_copy_strips_top_level_model(monkeypatch, tmp_path) -> None
         extra_path=[],
         mcp_servers=None,
     )
-    CodexHarness()._copy_codex_config(ctx)
+    harness = CodexHarness()
+    harness._seed_home(ctx)
+    harness._prepare(ctx)
 
     copied = (isolated_home / ".codex" / "config.toml").read_text()
     assert 'model = "gpt-5.5"' not in copied
@@ -278,7 +280,7 @@ def test_codex_config_copy_strips_top_level_model(monkeypatch, tmp_path) -> None
 
 
 def test_codex_fails_clearly_when_cli_is_not_runnable(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex.exe")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _name: "codex.exe")
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
@@ -305,7 +307,7 @@ def test_codex_fails_clearly_when_cli_is_not_runnable(monkeypatch, tmp_path) -> 
 def test_codex_fails_clearly_when_cli_requires_newer_version(
     monkeypatch, tmp_path
 ) -> None:
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _name: "codex")
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
@@ -385,7 +387,7 @@ def _run_codex_mcp(monkeypatch, tmp_path, mcp_servers, *, home=None):
 
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.delenv("CODEX_CLI_PATH", raising=False)
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _n: "codex")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "codex")
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )

--- a/tests/test_hermes_harness.py
+++ b/tests/test_hermes_harness.py
@@ -35,7 +35,7 @@ def _fake_home(tmp_path):
 def _install(monkeypatch, home, on_run):
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.delenv("HERMES_CLI_PATH", raising=False)
-    monkeypatch.setattr("caliper.harness.hermes.shutil.which", lambda _n: "hermes")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "hermes")
     patch_cli_calls(monkeypatch, on_run)
 
 
@@ -474,7 +474,7 @@ def test_hermes_run_captures_token_usage_end_to_end(monkeypatch, tmp_path) -> No
 
 
 def test_hermes_missing_cli_raises_configuration_error(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("caliper.harness.hermes.shutil.which", lambda _n: None)
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: None)
     monkeypatch.delenv("HERMES_CLI_PATH", raising=False)
 
     with pytest.raises(HarnessConfigurationError, match="hermes CLI is not available"):

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -260,7 +260,7 @@ def test_claude_judge_extracts_concrete_model_from_envelope(
 
 
 def _codex_cli_present(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: "codex.cmd")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _name: "codex.cmd")
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
@@ -308,7 +308,7 @@ def test_codex_judge_uses_output_last_message(monkeypatch, tmp_path) -> None:
 
 
 def test_codex_missing_cli_errors(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("caliper.harness.codex.shutil.which", lambda _name: None)
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _name: None)
     monkeypatch.setattr(
         "caliper.harness.codex.CODEX_APP_CLI", tmp_path / "missing-codex"
     )
@@ -338,7 +338,7 @@ ERROR: {"type":"error","status":400,"error":{"type":"invalid_request_error","mes
 
 def _hermes_cli_present(monkeypatch) -> None:
     monkeypatch.setattr(
-        "caliper.harness.hermes.shutil.which", lambda _: "/usr/bin/hermes"
+        "caliper.harness.base.shutil.which", lambda _: "/usr/bin/hermes"
     )
     monkeypatch.delenv("HERMES_CLI_PATH", raising=False)
 
@@ -395,7 +395,7 @@ def test_hermes_judge_reports_cli_error_as_errored(monkeypatch, tmp_path) -> Non
 
 
 def test_hermes_judge_missing_cli_errors(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("caliper.harness.hermes.shutil.which", lambda _: None)
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _: None)
     monkeypatch.delenv("HERMES_CLI_PATH", raising=False)
 
     result = HermesHarness().run_prompt("anything", cwd=str(tmp_path))
@@ -422,7 +422,7 @@ def _pi_stream(text: str) -> str:
 
 def test_pi_backend_is_a_valid_judge(monkeypatch, tmp_path) -> None:
     """Regression: `--judge-model pi` must dispatch, not report 'Unknown judge backend'."""
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _: "/usr/bin/pi")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _: "/usr/bin/pi")
     monkeypatch.delenv("PI_CLI_PATH", raising=False)
     calls = _spawn(
         monkeypatch,
@@ -445,7 +445,7 @@ def test_pi_backend_is_a_valid_judge(monkeypatch, tmp_path) -> None:
 
 
 def test_pi_judge_reports_cli_error_as_errored(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _: "/usr/bin/pi")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _: "/usr/bin/pi")
     monkeypatch.delenv("PI_CLI_PATH", raising=False)
     _spawn(monkeypatch, returncode=1, stderr="not logged in")
 
@@ -456,7 +456,7 @@ def test_pi_judge_reports_cli_error_as_errored(monkeypatch, tmp_path) -> None:
 
 
 def test_pi_judge_missing_cli_errors(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _: None)
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _: None)
     monkeypatch.delenv("PI_CLI_PATH", raising=False)
 
     result = PiHarness().run_prompt("anything", cwd=str(tmp_path))

--- a/tests/test_pi_harness.py
+++ b/tests/test_pi_harness.py
@@ -33,7 +33,7 @@ def test_pi_installs_the_skill_and_passes_no_preload_flag(
             return _version(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "pi")
     patch_cli_calls(monkeypatch, fake_run)
 
     PiHarness().run(
@@ -76,7 +76,7 @@ def test_pi_omits_model_and_skill_when_unspecified(monkeypatch, tmp_path) -> Non
             return _version(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "pi")
     patch_cli_calls(monkeypatch, fake_run)
 
     PiHarness().run(
@@ -135,7 +135,7 @@ def test_pi_json_stream_captures_tool_calls(monkeypatch, tmp_path) -> None:
         stdout = "\n".join(json.dumps(e) for e in events)
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "pi")
     patch_cli_calls(monkeypatch, fake_run)
 
     result = PiHarness().run(
@@ -205,7 +205,7 @@ def test_pi_run_captures_token_usage_end_to_end(monkeypatch, tmp_path) -> None:
         stdout = "\n".join(json.dumps(e) for e in events)
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "pi")
     patch_cli_calls(monkeypatch, fake_run)
 
     result = PiHarness().run(
@@ -229,7 +229,7 @@ def test_pi_run_captures_token_usage_end_to_end(monkeypatch, tmp_path) -> None:
 
 
 def test_pi_missing_cli_raises_configuration_error(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: None)
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: None)
     monkeypatch.delenv("PI_CLI_PATH", raising=False)
 
     with pytest.raises(HarnessConfigurationError, match="pi CLI is not available"):
@@ -252,7 +252,7 @@ def test_pi_auth_failure_raises_configuration_error(monkeypatch, tmp_path) -> No
             cmd, 1, stdout="", stderr="Error: not authenticated. Please run /login."
         )
 
-    monkeypatch.setattr("caliper.harness.pi.shutil.which", lambda _n: "pi")
+    monkeypatch.setattr("caliper.harness.base.shutil.which", lambda _n: "pi")
     patch_cli_calls(monkeypatch, fake_run)
 
     with pytest.raises(HarnessConfigurationError, match="authentication"):

--- a/tests/test_prompt_failure.py
+++ b/tests/test_prompt_failure.py
@@ -74,9 +74,6 @@ def test_claude_prompt_output_classifies_in_harness_not_downstream(
         return subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr="")
 
     patch_cli_calls(monkeypatch, fake_run)
-    monkeypatch.setattr(
-        "caliper.harness.claude_code.shutil.which", lambda _name: "claude"
-    )
 
     result = ClaudeCodeHarness(model=DEFAULT_JUDGE_MODEL).run_prompt(
         "anything", cwd="."
@@ -103,9 +100,6 @@ def test_claude_prompt_output_unclassified_is_error_passes_text_through(
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     patch_cli_calls(monkeypatch, fake_run)
-    monkeypatch.setattr(
-        "caliper.harness.claude_code.shutil.which", lambda _name: "claude"
-    )
 
     result = ClaudeCodeHarness().run_prompt("anything", cwd=".")
 
@@ -129,9 +123,6 @@ def test_eval_judge_surfaces_classified_model_unavailable(
         return subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr="")
 
     patch_cli_calls(monkeypatch, fake_run)
-    monkeypatch.setattr(
-        "caliper.harness.claude_code.shutil.which", lambda _name: "claude"
-    )
 
     result = EvalJudge(backend="claude-code").evaluate(
         task=_task(expect="x"),


### PR DESCRIPTION
## What

The four CLI adapters each hand-rolled the same three chores — seeding the isolated home, locating the CLI binary, building the attempt's environment — and copied the "no final output? take the last assistant turn" tail verbatim into all four stream parsers. `CliHarness` was already a template method owning spawn/timeout/cancel/usage safety; it just stopped one hook short each time.

Each chore moves under the seam, with the backend declaring only what varies:

| Hook | Backend declares | `CliHarness` does |
|---|---|---|
| `seed_files(ctx)` | `(real, isolated)` pairs | copies what exists, creates parents |
| `cli_name` / `cli_path_env_var` / `cli_candidates()` | binary name + extra locations | env override → candidates → `PATH` |
| `env_passthrough`, `_isolated_env()` | extra vars, extra `PATH` prefixes | isolated `HOME`, deduped `PATH`, allowlist |
| `_parse_stream` | this agent's turns | `_parse_stream_with_tail` supplies the tail |

This is the shape `resolve_servers` already established for MCP: the base does the work, the backend contributes the one fact that differs.

## Why the chores stayed duplicated

Each backend has an *exception*, and an exception looks like a reason to keep your own copy. All of them turned out to be expressible as data:

- codex omits `config.toml` from `seed_files` because it **rewrites** that file (stripping `model =` and ambient `[mcp_servers*]`). ADR-0012's copy-verbatim policy is unchanged for everything it does seed.
- hermes' omission of `SOUL.md`/`MEMORY.md` **is** the neutralization of a stateful agent (ADR-0005) — now a list rather than a loop you have to notice.
- claude-code contributes `PATH` prefixes (nvm Node, Homebrew) and forwards API keys only when no file credentials were seeded.

ADRs 0005, 0009, 0011, 0012 are all preserved; none is reopened.

## Two deliberate behaviour changes

Both recorded in the new ADR-0020:

- **claude-code's environment.** It previously forwarded `TMPDIR` alone, and only on macOS. It now forwards `LANG`/`LC_ALL`/`TERM`/`TMPDIR` like every other backend. A backend differing from its siblings for no recorded reason is the thing this change is against — but it is also the first place to look if claude-code's stream ever parses differently, though `--output-format stream-json` should be indifferent to `TERM`.
- **`PATH` is deduplicated.** The old spelling was `extra_path + PATH` verbatim, so an entry already on `PATH` appeared twice and the earlier occurrence was not necessarily the staged one. The base now removes prefix entries from the tail, which is what makes `extra_path` actually take precedence.

## Ordering is part of the contract

`_seed_home` runs **before** `_prepare`: a backend that rewrites a config must see the verbatim copy already in place, and claude-code's Keychain fallback must be able to tell whether `.credentials.json` was seeded before shelling out for it.

## Tests

Adds `tests/test_cli_harness.py` — one conformance suite parameterized over the four backends covering seeding, discovery, environment, skills root, and the tail. **496 pass, was 459.**

It is added coverage, not a replacement: the per-adapter MCP translation, diagnosis, and usage tests are genuinely backend-specific and stay. Where an adapter's test overlaps the suite (hermes pinning its neutral seeding for ADR-0005), that is deliberate — it tests the backend's stance, not the shared chore.

## Not done, on purpose

`_ensure_ready`'s message stayed per-adapter. The three share a shape but not a subject: codex's names no env var and talks about API billing, while pi's and hermes' name an install command and a `*_CLI_PATH`. Templating would flatten prose that exists to be read at the moment a run fails. Recorded as a rejected option in the ADR.

## Docs

`docs/adr/0020-a-backend-declares-its-chores-rather-than-performing-them.md`. No CLI flag, spec field, judge behaviour, or results-schema change, so README and the two skill REFERENCEs need no update.