### PR TITLE
refactor(scoring): a task derives its own numbers, once

### DIFF
--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Callable
 
 from rich import box
 from rich.console import Console
@@ -23,6 +24,8 @@ from caliper.schema.results import (
     TaskComparison,
     TaskResult,
     UsageTotals,
+    pass_at_k,
+    pass_hat_k,
 )
 
 console = Console()
@@ -781,8 +784,8 @@ def print_comparison(comp: RunComparison, verbose: bool = False) -> None:
         row = [name, _score_cell(tc), _delta_cell(tc)]
         if verbose:
             row += [
-                _alt_metric_cell(tc, "pass_at_k"),
-                _alt_metric_cell(tc, "pass_hat_k"),
+                _alt_metric_cell(tc, pass_at_k),
+                _alt_metric_cell(tc, pass_hat_k),
             ]
         if show_activation:
             row += [_activation_score_cell(tc), _activation_delta_cell(tc)]
@@ -809,14 +812,20 @@ def _score_cell(tc: TaskComparison) -> Text:
     )
 
 
-def _alt_metric_cell(tc: TaskComparison, metric: str) -> Text:
-    """`x% → y%` for a secondary metric (pass@k / pass^k), derived from the stored
-    per-attempt outcomes so no extra fields are needed on the model."""
-    from caliper.scoring import score_outcomes
+def _alt_metric_cell(
+    tc: TaskComparison, formula: Callable[[int, int], float | None]
+) -> Text:
+    """`x% → y%` for a secondary metric (pass@k / pass^k).
+
+    Derived from the stored per-attempt outcomes, so a comparison needs no extra
+    fields on the model — and through the same formulas ``TaskResult`` uses, so a
+    secondary column can never disagree with the run it came from.
+    """
 
     def val(outcomes: list[Outcome]) -> float | None:
-        # score_outcomes owns the usable-denominator rule; render its result.
-        return getattr(score_outcomes(outcomes), metric)
+        successes = sum(1 for o in outcomes if o == Outcome.PASS)
+        usable = sum(1 for o in outcomes if o.is_usable)
+        return formula(successes, usable)
 
     return _score_pair(
         _fmt_score(val(tc.a_outcomes)), _fmt_score(val(tc.b_outcomes)), "", ""

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -30,7 +30,7 @@ from caliper.schema.results import (
     TaskResult,
 )
 from caliper.schema.spec import DEFAULT_BACKEND, EvalSpec, TaskSpec, spec_name
-from caliper.scoring import aggregate_activation, aggregate_scores, score_outcomes
+from caliper.scoring import aggregate_activation, aggregate_scores
 from caliper.skillfetch import SkillFetcher
 from caliper.skills import (
     SkillRef,
@@ -247,10 +247,7 @@ def run(
     ]
     task_results.sort(key=lambda r: r.task_id)
 
-    pass_counts = {
-        r.task_id: (r.task_name, r.successes, r.usable, k) for r in task_results
-    }
-    aggregate = aggregate_scores(pass_counts)
+    aggregate = aggregate_scores(task_results, k)
     # The second scoreboard, carried alongside — never folded into avg_score.
     activation = aggregate_activation(task_results, [ref.name for ref in skill_refs])
     aggregate.avg_activation_score = activation.avg_score
@@ -383,19 +380,17 @@ def _finish_task(
     *fewer* than k records — fail-fast truncated it, or an interrupt stopped the
     run — which the metrics already handle, since every denominator is the
     usable attempts rather than k (docs/adr/0007).
+
+    Nothing is counted here: the result derives its own successes, denominator
+    and metrics from the attempts it is handed.
     """
-    attempts = sorted(records, key=lambda r: r.attempt)
-    scores = score_outcomes(a.outcome for a in attempts)
     result = TaskResult(
         task_id=task.id,
         task_name=task.name,
-        attempts=attempts,
-        successes=scores.successes,
-        unusable=scores.unusable,
-        pass_at_k=scores.pass_at_k,
+        attempts=sorted(records, key=lambda r: r.attempt),
         activation_expected=env.expected_activation(task),
     )
-    if env.on_task_done and len(attempts) < k:
+    if env.on_task_done and len(result.attempts) < k:
         env.on_task_done(result)
     return result
 

--- a/caliper/schema/results.py
+++ b/caliper/schema/results.py
@@ -255,20 +255,77 @@ class AttemptRecord(BaseModel):
         return self.outcome == Outcome.CHEAT
 
 
+def success_rate(successes: int, usable: int) -> float | None:
+    """The **raw** per-attempt success rate — Caliper's primary metric.
+
+    ``None`` when no attempt got a fair shot (``usable == 0``): a task that was
+    never measured has no rate, which is not the same claim as ``0.0``.
+
+    This and its two siblings live beside :class:`Outcome` and
+    :class:`TaskResult` because they are defined over an attempt set and
+    ``Outcome.is_usable`` is what carves that set out. ``caliper.scoring``
+    imports them for its cross-task roll-ups; nothing re-derives them. See
+    docs/adr/0007-raw-success-rate-is-the-primary-metric.md and
+    docs/CONTEXT.md → Usable / unusable attempt.
+    """
+    return successes / usable if usable > 0 else None
+
+
+def pass_at_k(successes: int, usable: int) -> float | None:
+    """P(at least one of k attempts passes) at the observed rate.
+
+    A secondary, retry-friendly view — see docs/CONTEXT.md → Success rate. The
+    denominator *and* the exponent are the **usable** attempt count, not the
+    requested k. ``None`` when no attempt got a fair shot.
+    """
+    rate = success_rate(successes, usable)
+    return None if rate is None else 1.0 - (1.0 - rate) ** usable
+
+
+def pass_hat_k(successes: int, usable: int) -> float | None:
+    """P(all k attempts pass) at the observed rate — the strict consistency view.
+
+    Same usable denominator and exponent as :func:`pass_at_k`; ``None`` when no
+    attempt got a fair shot.
+    """
+    rate = success_rate(successes, usable)
+    return None if rate is None else rate**usable
+
+
 class TaskResult(BaseModel):
+    """One task's attempts, and every number that follows from them.
+
+    Only the attempts and the task's identity are stored; ``successes``,
+    ``usable``, ``unusable`` and all four metrics are **derived**, so no two of
+    them can disagree and a hand-edited or older file cannot carry a rate
+    inconsistent with the attempts beside it. They are still serialized
+    (``computed_field``), so a saved run reads the same as it always did.
+    """
+
     task_id: str
     task_name: str
     attempts: list[AttemptRecord]
-    successes: int
-    unusable: int = 0
     # The task's `activates:` set, carried so the aggregate can compute per-skill
     # recall/precision and the report can say *what* was expected when a row
     # fails. ``None`` = the task asserted nothing.
     activation_expected: list[str] | None = None
-    # pass@k (P(≥1 of k pass)) — kept as a secondary, retry-friendly view. The
-    # *primary* metric is ``score`` (raw success rate) below. None when every
-    # attempt was unusable — the task was never fairly measured.
-    pass_at_k: float | None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def successes(self) -> int:
+        """Attempts that passed."""
+        return sum(1 for a in self.attempts if a.outcome == Outcome.PASS)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def unusable(self) -> int:
+        """Attempts where an execution check *went wrong*.
+
+        Not ``len(attempts) - usable``: ``NOT_CHECKED`` is neither usable nor
+        noise, so it leaves the denominator without being reported as an error —
+        a correct ``activates:``-only spec must never read as one.
+        """
+        return sum(1 for a in self.attempts if a.outcome.is_execution_noise)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -286,18 +343,18 @@ class TaskResult(BaseModel):
     def score(self) -> float | None:
         """The **raw success rate** over usable attempts — Caliper's primary
         metric. ``None`` when no attempt was fairly measured."""
-        # Deferred import: caliper.scoring imports this module, and the formulas
-        # deliberately live there — the one place the usable denominator is set.
-        from caliper.scoring import success_rate
-
         return success_rate(self.successes, self.usable)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def pass_at_k(self) -> float | None:
+        """pass@k: P(at least one usable attempt passes) — the retry-friendly view."""
+        return pass_at_k(self.successes, self.usable)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def pass_hat_k(self) -> float | None:
         """pass^k: P(all usable attempts pass) — the strict consistency view."""
-        from caliper.scoring import pass_hat_k
-
         return pass_hat_k(self.successes, self.usable)
 
     # --- the second scoreboard, which never merges with the first ----------
@@ -327,8 +384,6 @@ class TaskResult(BaseModel):
         ``None`` when the task asserted nothing (or nothing was measurable) —
         rendered *skipped*, never ``0%``.
         """
-        from caliper.scoring import success_rate
-
         return success_rate(self.activation_successes, self.activation_usable)
 
 

--- a/caliper/scoring.py
+++ b/caliper/scoring.py
@@ -1,114 +1,52 @@
-"""Caliper's scoring module — the one place the usable-only denominator lives.
+"""Caliper's scoring module — rolling many tasks up into a run's scoreboards.
 
-Every metric divides by *usable* attempts (those that got a fair shot), never
-by raw k — see docs/adr/0007-raw-success-rate-is-the-primary-metric.md and
-docs/CONTEXT.md → Usable / unusable attempt. ``score_outcomes`` is the seam
-where a task's attempt outcomes become counts and metrics; callers should go
-through it rather than re-deriving ``usable`` themselves.
+One task's own numbers belong to :class:`~caliper.schema.results.TaskResult`,
+which derives every one of them from its attempts; this module is what spans
+tasks. The metric *formulas* live beside that model (``success_rate`` and
+friends), so the usable-only denominator is written once and nothing here
+re-derives it — see docs/adr/0007-raw-success-rate-is-the-primary-metric.md and
+docs/CONTEXT.md → Usable / unusable attempt.
+
+Two scoreboards, deliberately never merged: the execution rate
+(``aggregate_scores``) and activation (``aggregate_activation``).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable
 
 from caliper.schema.results import (
     AggregateScore,
-    Outcome,
     SkillActivationStats,
+    TaskResult,
     TaskScore,
 )
 
-if TYPE_CHECKING:
-    from caliper.schema.results import TaskResult
 
+def aggregate_scores(task_results: list[TaskResult], k: int) -> AggregateScore:
+    """The run's execution scoreboard: one row per task, plus their average.
 
-def success_rate(successes: int, usable: int) -> float | None:
-    """The **raw** per-attempt success rate — Caliper's primary metric. ``None``
-    when no attempt got a fair shot (usable == 0)."""
-    return successes / usable if usable > 0 else None
+    Takes the results themselves rather than counts pulled out of them — each
+    task already knows its own successes, usable denominator and score, and
+    re-passing them was an invitation for the two to disagree.
 
+    A task with no usable attempts scores ``None`` and is **excluded** from the
+    average rather than dragged to 0%: it was never measured, and averaging a
+    non-measurement in would understate the skill (docs/adr/0007).
 
-def pass_at_k(successes: int, usable: int) -> float | None:
-    """P(at least one of k attempts passes) at the observed rate. A secondary,
-    retry-friendly view — see docs/CONTEXT.md → Success rate.
-
-    The denominator (and exponent) is the *usable* attempt count, not the
-    requested k. ``None`` when no attempt got a fair shot.
+    ``k`` is the run's requested depth, recorded per row so a reader can see a
+    task that ran short of it.
     """
-    if usable == 0:
-        return None
-    p = successes / usable
-    return 1.0 - (1.0 - p) ** usable
-
-
-def pass_hat_k(successes: int, usable: int) -> float | None:
-    """P(all k attempts pass) at the observed rate — the strict, consistency view.
-
-    Same *usable* denominator and exponent as ``pass_at_k``; ``None`` when no
-    attempt got a fair shot.
-    """
-    if usable == 0:
-        return None
-    return (successes / usable) ** usable
-
-
-@dataclass(frozen=True)
-class OutcomeScores:
-    """The counts and every metric for one task's attempt outcomes."""
-
-    successes: int
-    usable: int
-    unusable: int
-    score: float | None
-    pass_at_k: float | None
-    pass_hat_k: float | None
-
-
-def score_outcomes(outcomes: Iterable[Outcome]) -> OutcomeScores:
-    """Score one task's attempt outcomes.
-
-    The single step where attempts become metrics: split usable from unusable
-    once, then compute every metric over the usable denominator. All three
-    metrics are ``None`` when no attempt got a fair shot.
-    """
-    materialized = list(outcomes)
-    successes = sum(1 for o in materialized if o == Outcome.PASS)
-    usable = sum(1 for o in materialized if o.is_usable)
-    return OutcomeScores(
-        successes=successes,
-        usable=usable,
-        # Only the outcomes where an execution check *went wrong*. NOT_CHECKED is
-        # excluded from the denominator without being reported as noise: a
-        # correct activates-only spec must never read as an error.
-        unusable=sum(1 for o in materialized if o.is_execution_noise),
-        score=success_rate(successes, usable),
-        pass_at_k=pass_at_k(successes, usable),
-        pass_hat_k=pass_hat_k(successes, usable),
-    )
-
-
-def aggregate_scores(
-    task_pass_counts: dict[str, tuple[str, int, int, int]],
-) -> AggregateScore:
-    """
-    task_pass_counts: {task_id: (task_name, successes, usable, k)}
-
-    ``score`` is the raw success rate over the *usable* attempts (those that got a
-    fair shot). A task with no usable attempts scores ``None`` and is excluded
-    from the aggregate average rather than dragged to 0%.
-    """
-    per_task: list[TaskScore] = []
-    for task_id, (task_name, successes, usable, k) in task_pass_counts.items():
-        per_task.append(
-            TaskScore(
-                task_id=task_id,
-                task_name=task_name,
-                k=k,
-                successes=successes,
-                score=success_rate(successes, usable),
-            )
+    per_task = [
+        TaskScore(
+            task_id=task.task_id,
+            task_name=task.task_name,
+            k=k,
+            successes=task.successes,
+            score=task.score,
         )
+        for task in task_results
+    ]
 
     scored = [t.score for t in per_task if t.score is not None]
     avg = sum(scored) / len(scored) if scored else 0.0
@@ -142,7 +80,7 @@ class ObservedActivation:
 
 
 def observed_activations(
-    task_results: list["TaskResult"], declared: list[str] | None = None
+    task_results: list[TaskResult], declared: list[str] | None = None
 ) -> list[ObservedActivation]:
     """Per-skill activation counts over attempts where activation was *observed*.
 
@@ -174,7 +112,7 @@ def observed_activations(
 
 
 def aggregate_activation(
-    task_results: list["TaskResult"], declared: list[str] | None = None
+    task_results: list[TaskResult], declared: list[str] | None = None
 ) -> ActivationAggregate:
     """Roll up the second scoreboard over the tasks that asserted ``activates:``.
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -207,7 +207,8 @@ in only one run is **unmatched**.
 The **primary metric**: the raw per-attempt success rate, `successes / usable`
 (how often a *single* run works), computed over [[usable / unusable
 attempt|usable]] attempts only. It is `TaskResult.score` and the aggregate
-`avg_score`, and it is what every table headline, the `Δ`, and [[regression in a
+`avg_score` — a task derives every one of its own numbers from its attempts, so
+no two of them can disagree — and it is what every table headline, the `Δ`, and [[regression in a
 comparison|regression]] are computed on. Chosen over pass@k because Caliper tests
 *reliability*: pass@k (below) is a code-generation metric that rewards retries and
 flatters flaky skills (`1/3 → 70.4%`), which is the wrong question when a skill

--- a/docs/adr/0007-raw-success-rate-is-the-primary-metric.md
+++ b/docs/adr/0007-raw-success-rate-is-the-primary-metric.md
@@ -31,9 +31,31 @@ and all-pass lenses are one flag away.
   both drift with k).
 - `AggregateScore.avg_pass_at_k` → `avg_score`; `TaskResult` gains a computed
   `score` (primary) and `pass_hat_k`, keeping `pass_at_k` as a stored secondary.
+  *(Amended: `pass_at_k` is computed too — see the amendment below.)*
 - Raw rate and pass@k are monotonic at equal *usable* counts, so the regression
   sign is unchanged in the common case — but they can disagree when the two sides
   have different unusable counts, which is another reason the raw score (not a
   k-dependent transform) is the canonical basis for the delta and regression.
 - Old results JSON still loads (the removed `avg_pass_at_k` field is ignored; the
-  score recomputes from `successes`/`usable`).
+  score recomputes). *(Amended: it recomputes from the attempts, not from a
+  stored `successes` — see below.)*
+
+## Amendment: every number a task reports is derived from its attempts
+
+`TaskResult` kept `successes`, `unusable` and `pass_at_k` as **stored** fields
+while `usable`, `score` and `pass_hat_k` were computed — an asymmetry with no
+reason behind it. The runner filled the stored three from `score_outcomes` while
+the model derived the other three from `self.attempts`, so `usable`, `score` and
+`pass_hat_k` were each computed twice from two different inputs, and a
+hand-edited or older file could carry a `pass_at_k` that disagreed with the
+`score` printed beside it.
+
+All six are now derived from the attempts, and `score_outcomes` is deleted. The
+rule this ADR is about is unchanged — every denominator is still usable attempts
+— but there is one derivation of it instead of two, and no stored count can
+contradict the attempt list it sits next to. The metric formulas moved to
+`caliper/schema/results.py`, beside the `Outcome.is_usable` that carves out the
+denominator; `caliper/scoring.py` keeps the roll-ups across tasks.
+
+The numbers are still **serialized**, so a saved run reads exactly as before; the
+stored values are simply ignored on load.

--- a/docs/render_readme_samples.py
+++ b/docs/render_readme_samples.py
@@ -232,9 +232,6 @@ def _run_example() -> RunResults:
                 (3, 8.4, 26_300, 431),
             )
         ],
-        successes=3,
-        unusable=0,
-        pass_at_k=1.0,
         activation_expected=["commit-writer"],
     )
     subject = TaskResult(
@@ -284,9 +281,6 @@ def _run_example() -> RunResults:
                 ),
             )
         ],
-        successes=2,
-        unusable=0,
-        pass_at_k=1.0,
         activation_expected=["commit-writer"],
     )
     # A release-notes request belongs to the changelog-writer neighbour. Cheap:
@@ -311,9 +305,6 @@ def _run_example() -> RunResults:
                 (3, 3.9, 4_400, 143, ["commit-writer"]),
             )
         ],
-        successes=0,
-        unusable=0,
-        pass_at_k=None,
         activation_expected=["changelog-writer"],
     )
     task_results = [message, subject, probe]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,29 @@ import pytest
 
 from caliper import cancel
 from caliper.harness.base import RunContext
+from caliper.schema.results import AttemptRecord, Outcome, TaskResult
+
+
+def task_result(
+    *outcomes: Outcome,
+    task_id: str = "task-001",
+    name: str = "One",
+    expected: list[str] | None = None,
+) -> TaskResult:
+    """A task result built from nothing but its attempt outcomes.
+
+    Which is all a task result needs: it derives every count and metric from the
+    attempts it is handed, so a test states the outcomes and nothing else.
+    """
+    return TaskResult(
+        task_id=task_id,
+        task_name=name,
+        attempts=[
+            AttemptRecord(attempt=i, output="", duration_seconds=0.0, outcome=outcome)
+            for i, outcome in enumerate(outcomes, start=1)
+        ],
+        activation_expected=expected,
+    )
 
 
 def run_context(**overrides) -> RunContext:

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -243,9 +243,6 @@ def _saved(*, skills: list[str], ablated: list[str]) -> RunResults:
                         attempt=1, output="", duration_seconds=1.0, outcome=Outcome.PASS
                     )
                 ],
-                successes=1,
-                unusable=0,
-                pass_at_k=1.0,
             )
         ],
         aggregate=AggregateScore(avg_score=1.0, per_task=[]),

--- a/tests/test_activation_report.py
+++ b/tests/test_activation_report.py
@@ -36,9 +36,6 @@ def task(attempts, expected=None, name="t"):
         task_id="task-001",
         task_name=name,
         attempts=attempts,
-        successes=sum(1 for a in attempts if a.outcome == Outcome.PASS),
-        unusable=sum(1 for a in attempts if not a.outcome.is_usable),
-        pass_at_k=None,
         activation_expected=expected,
     )
 
@@ -240,9 +237,6 @@ def _act_task(name, expected, passed_flags):
             )
             for i, p in enumerate(passed_flags)
         ],
-        successes=0,
-        unusable=0,
-        pass_at_k=None,
         activation_expected=expected,
     )
 
@@ -309,9 +303,6 @@ def test_execution_headline_is_skipped_when_nothing_was_measured():
                     activation_passed=True,
                 )
             ],
-            successes=0,
-            unusable=0,
-            pass_at_k=None,
             activation_expected=[],
         )
     ]

--- a/tests/test_activation_scoring.py
+++ b/tests/test_activation_scoring.py
@@ -34,9 +34,6 @@ def task(
         task_id="task-001",
         task_name=name,
         attempts=attempts,
-        successes=sum(1 for a in attempts if a.outcome == Outcome.PASS),
-        unusable=sum(1 for a in attempts if not a.outcome.is_usable),
-        pass_at_k=None,
         activation_expected=expected,
     )
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -329,9 +329,6 @@ def _one_attempt_run(k: int = 3) -> RunResults:
                         outcome=Outcome.PASS,
                     )
                 ],
-                successes=1,
-                unusable=0,
-                pass_at_k=1.0,
             )
         ],
         aggregate=AggregateScore(avg_score=1.0, per_task=[]),

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from caliper.compare import diff_runs
+from caliper.reporter import print_comparison
 from caliper.schema.results import (
     AggregateScore,
     AttemptRecord,
@@ -12,8 +13,10 @@ from caliper.schema.results import (
     SkillSnapshot,
     TaskResult,
     TaskScore,
+    pass_at_k,
+    pass_hat_k,
+    success_rate,
 )
-from caliper.scoring import pass_at_k, success_rate
 
 
 def _attempt(i: int, outcome: Outcome) -> AttemptRecord:
@@ -21,16 +24,11 @@ def _attempt(i: int, outcome: Outcome) -> AttemptRecord:
 
 
 def _task(name: str, outcomes: list[Outcome], task_id: str = "task-000") -> TaskResult:
-    usable = sum(1 for o in outcomes if o.is_usable)
-    successes = sum(1 for o in outcomes if o == Outcome.PASS)
-    score = pass_at_k(successes, usable) if usable > 0 else None
+    # Hand it the attempts and it derives its own counts and metrics.
     return TaskResult(
         task_id=task_id,
         task_name=name,
         attempts=[_attempt(i + 1, o) for i, o in enumerate(outcomes)],
-        successes=successes,
-        unusable=len(outcomes) - usable,
-        pass_at_k=score,
     )
 
 
@@ -39,8 +37,8 @@ def _run(tasks: list[TaskResult], *, spec: str = "demo", k: int = 5) -> RunResul
         TaskScore(
             task_id=t.task_id,
             task_name=t.task_name,
-            k=k,
             successes=t.successes,
+            k=k,
             score=t.pass_at_k,
         )
         for t in tasks
@@ -203,3 +201,39 @@ def test_matching_specs_and_k_produce_no_warnings() -> None:
     assert not comp.spec_mismatch
     assert not comp.k_mismatch
     assert comp.warnings == []
+
+
+# --- the verbose columns ------------------------------------------------------
+
+
+def test_verbose_comparison_renders_the_secondary_metric_columns(capsys) -> None:
+    """``compare --verbose`` adds pass@k / pass^k, derived from the stored outcomes.
+
+    Rendered nowhere else, so nothing else would catch this path breaking — which
+    is how a dead import of a deleted scorer survived a green suite.
+    """
+    a = _run([_task("alpha", [P, P, F, F])])
+    b = _run([_task("alpha", [P, P, P, F])])
+
+    print_comparison(diff_runs(a, b), verbose=True)
+
+    out = capsys.readouterr().out
+    assert "pass@k" in out
+    assert "pass^k" in out
+
+
+def test_the_secondary_columns_agree_with_the_task_metrics() -> None:
+    """A comparison column can never disagree with the run it came from."""
+    task = _task("alpha", [P, P, F, INF])
+    comp = diff_runs(_run([task]), _run([task]))
+    tc = comp.matched[0]
+
+    assert pass_at_k(*_counts(tc.b_outcomes)) == task.pass_at_k
+    assert pass_hat_k(*_counts(tc.b_outcomes)) == task.pass_hat_k
+
+
+def _counts(outcomes: list[Outcome]) -> tuple[int, int]:
+    return (
+        sum(1 for o in outcomes if o == Outcome.PASS),
+        sum(1 for o in outcomes if o.is_usable),
+    )

--- a/tests/test_compare_cli.py
+++ b/tests/test_compare_cli.py
@@ -53,9 +53,6 @@ def _write_run(
                         attempt=1, output="", duration_seconds=1.0, outcome=Outcome.PASS
                     )
                 ],
-                successes=1,
-                unusable=0,
-                pass_at_k=1.0,
             )
         ],
         aggregate=AggregateScore(avg_score=1.0, scored_tasks=1, per_task=[]),

--- a/tests/test_measure_and_mark.py
+++ b/tests/test_measure_and_mark.py
@@ -115,9 +115,6 @@ def _task_result(judge_seconds: list[float | None]) -> TaskResult:
             )
             for i, js in enumerate(judge_seconds)
         ],
-        successes=len(judge_seconds),
-        unusable=0,
-        pass_at_k=1.0,
     )
 
 
@@ -161,9 +158,6 @@ def _run(interrupted: bool, *, spec: str = "demo", successes: int = 2) -> RunRes
                     )
                     for i in range(4)
                 ],
-                successes=successes,
-                unusable=0,
-                pass_at_k=1.0,
             )
         ],
         aggregate=AggregateScore(avg_score=successes / 4, per_task=[]),

--- a/tests/test_not_checked.py
+++ b/tests/test_not_checked.py
@@ -7,7 +7,8 @@ from caliper.reporter import _is_trigger_only, _status_cell
 from caliper.runner import run
 from caliper.schema.results import AttemptRecord, Outcome, TaskResult
 from caliper.schema.spec import EvalSpec, TaskSpec
-from caliper.scoring import score_outcomes
+
+from conftest import task_result
 
 
 # --- classification -------------------------------------------------------
@@ -70,15 +71,14 @@ def test_not_checked_is_neither_usable_nor_noise():
 
 
 def test_not_checked_does_not_inflate_the_unusable_count():
-    scores = score_outcomes([Outcome.NOT_CHECKED] * 3)
-    assert scores.usable == 0
-    assert scores.unusable == 0
-    assert scores.score is None
+    task = task_result(*[Outcome.NOT_CHECKED] * 3)
+    assert task.usable == 0
+    assert task.unusable == 0
+    assert task.score is None
 
 
 def test_judge_errors_are_still_counted_as_noise():
-    scores = score_outcomes([Outcome.JUDGE_ERROR, Outcome.PASS])
-    assert scores.unusable == 1
+    assert task_result(Outcome.JUDGE_ERROR, Outcome.PASS).unusable == 1
 
 
 def test_usable_is_derived_not_subtracted():
@@ -97,9 +97,6 @@ def test_usable_is_derived_not_subtracted():
                 attempt=3, output="", duration_seconds=1.0, outcome=Outcome.PASS
             ),
         ],
-        successes=1,
-        unusable=0,
-        pass_at_k=None,
     )
     assert tr.usable == 1
     assert tr.score == 1.0
@@ -197,9 +194,6 @@ def _trigger_task() -> TaskResult:
             )
             for n in (1, 2)
         ],
-        successes=0,
-        unusable=0,
-        pass_at_k=None,
         activation_expected=[],
     )
 
@@ -231,9 +225,6 @@ def test_a_trigger_probes_tokens_are_not_reported_as_wasted_spend():
                 usage=TokenUsage(input_tokens=24000, output_tokens=10),
             )
         ],
-        successes=0,
-        unusable=0,
-        pass_at_k=None,
     )
     totals = UsageTotals.from_task_results([tr])
     assert totals.unusable_attempts == 0
@@ -258,9 +249,6 @@ def test_trigger_only_survives_one_timeout_among_k():
                 attempt=2, output="", duration_seconds=1.0, outcome=Outcome.TIMEOUT
             ),
         ],
-        successes=0,
-        unusable=1,
-        pass_at_k=None,
         activation_expected=[],
     )
     assert _is_trigger_only(tr) is True
@@ -279,9 +267,6 @@ def test_a_task_with_a_real_verdict_is_not_trigger_only():
                 attempt=2, output="", duration_seconds=1.0, outcome=Outcome.NOT_CHECKED
             ),
         ],
-        successes=1,
-        unusable=0,
-        pass_at_k=None,
     )
     assert _is_trigger_only(tr) is False
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -92,8 +92,6 @@ def _make_task(
         task_id=task_id,
         task_name=f"Task {task_id}",
         attempts=[attempt],
-        successes=1 if passed else 0,
-        pass_at_k=1.0 if passed else 0.0,
     )
 
 
@@ -102,8 +100,8 @@ def _make_results(task_results: list[TaskResult]) -> RunResults:
         TaskScore(
             task_id=tr.task_id,
             task_name=tr.task_name,
-            k=1,
             successes=tr.successes,
+            k=1,
             score=tr.pass_at_k,
         )
         for tr in task_results
@@ -278,9 +276,6 @@ def test_aborted_unusable_task_is_reported_as_aborted() -> None:
                 assert_evidence="spending cap",
             )
         ],
-        successes=0,
-        unusable=1,
-        pass_at_k=None,
     )
     results = RunResults(
         run=RunMeta(
@@ -297,8 +292,8 @@ def test_aborted_unusable_task_is_reported_as_aborted() -> None:
                 TaskScore(
                     task_id=task.task_id,
                     task_name=task.task_name,
+                    successes=task.successes,
                     k=3,
-                    successes=0,
                     score=None,
                 )
             ],
@@ -337,9 +332,6 @@ def test_early_stopped_task_with_usable_pass_is_not_reported_as_aborted() -> Non
                 assert_evidence="spending cap",
             ),
         ],
-        successes=1,
-        unusable=2,
-        pass_at_k=1.0,
     )
     results = RunResults(
         run=RunMeta(
@@ -356,8 +348,8 @@ def test_early_stopped_task_with_usable_pass_is_not_reported_as_aborted() -> Non
                 TaskScore(
                     task_id=task.task_id,
                     task_name=task.task_name,
+                    successes=task.successes,
                     k=5,
-                    successes=1,
                     score=1.0,
                 )
             ],

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -235,9 +235,6 @@ def test_run_cli_saves_the_run_beside_its_spec(monkeypatch, tmp_path) -> None:
                         outcome=Outcome.PASS,
                     )
                 ],
-                successes=1,
-                unusable=0,
-                pass_at_k=1.0,
             )
         ],
         aggregate=AggregateScore(avg_score=1.0, per_task=[]),

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,46 +1,29 @@
+"""The metric formulas, and the run-level roll-up over many tasks.
+
+One task's own numbers are :class:`TaskResult`'s and are tested in
+``tests/test_task_metrics.py``; this file covers the formulas themselves and
+what ``aggregate_scores`` does across tasks.
+"""
+
 from __future__ import annotations
 
-from caliper.schema.results import Outcome
-from caliper.scoring import (
-    aggregate_scores,
+from caliper.schema.results import (
+    Outcome,
+    TaskResult,
     pass_at_k,
     pass_hat_k,
-    score_outcomes,
     success_rate,
 )
+from caliper.scoring import aggregate_scores
+
+from conftest import task_result
 
 
-def test_score_is_raw_rate_over_usable_only() -> None:
-    # 3 pass, 1 task_fail, 1 infra_error at k=5 -> usable=4, successes=3.
-    agg = aggregate_scores({"t1": ("Task", 3, 4, 5)})
-    score = agg.per_task[0].score
-    # The primary score is the raw success rate over usable attempts.
-    assert score == success_rate(3, 4) == 0.75
-    # The infra attempt left the denominator: rate is over 4 usable, not 5.
-    assert score != success_rate(3, 5)
+def _task(task_id: str, name: str, *outcomes: Outcome) -> TaskResult:
+    return task_result(*outcomes, task_id=task_id, name=name)
 
 
-def test_all_unusable_scores_none_and_is_excluded_from_average() -> None:
-    agg = aggregate_scores(
-        {
-            "t1": ("Throttled", 0, 0, 5),  # every attempt unusable
-            "t2": ("Clean", 5, 5, 5),  # perfect
-        }
-    )
-    by_id = {t.task_id: t for t in agg.per_task}
-    assert by_id["t1"].score is None
-    # The fully-unusable task must not drag the average toward 0.
-    assert agg.avg_score == by_id["t2"].score == 1.0
-
-
-def test_average_ignores_none_scores() -> None:
-    agg = aggregate_scores(
-        {
-            "t1": ("A", 2, 4, 4),
-            "t2": ("B", 0, 0, 4),  # excluded
-        }
-    )
-    assert agg.avg_score == success_rate(2, 4) == 0.5
+# --- the formulas ------------------------------------------------------------
 
 
 def test_pass_at_k_and_pass_hat_k_are_secondary_views() -> None:
@@ -49,47 +32,78 @@ def test_pass_at_k_and_pass_hat_k_are_secondary_views() -> None:
     assert pass_hat_k(1, 3) == (1 / 3) ** 3  # ~0.037, strict
     assert pass_hat_k(3, 3) == 1.0
     assert pass_at_k(0, 3) == 0.0
-    # No usable attempt -> no metric, uniformly across all three views.
+
+
+def test_no_usable_attempt_yields_no_metric_at_all() -> None:
+    """Uniformly ``None``, never ``0.0`` — a task never measured has no rate."""
+    assert success_rate(0, 0) is None
     assert pass_at_k(0, 0) is None
     assert pass_hat_k(0, 0) is None
-    assert success_rate(0, 0) is None
 
 
-def test_score_outcomes_uses_usable_denominator_everywhere() -> None:
-    # 3 pass, 1 task_fail, 1 infra_error: usable=4 — the infra attempt leaves
-    # every denominator at once.
-    scores = score_outcomes(
+# --- the run-level roll-up ---------------------------------------------------
+
+
+def test_score_is_the_raw_rate_over_usable_only() -> None:
+    # 3 pass, 1 task_fail, 1 infra_error -> usable=4, successes=3.
+    agg = aggregate_scores(
         [
-            Outcome.PASS,
-            Outcome.PASS,
-            Outcome.PASS,
-            Outcome.TASK_FAIL,
-            Outcome.INFRA_ERROR,
-        ]
+            _task(
+                "t1",
+                "Task",
+                Outcome.PASS,
+                Outcome.PASS,
+                Outcome.PASS,
+                Outcome.TASK_FAIL,
+                Outcome.INFRA_ERROR,
+            )
+        ],
+        k=5,
     )
 
-    assert (scores.successes, scores.usable, scores.unusable) == (3, 4, 1)
-    assert scores.score == success_rate(3, 4) == 0.75
-    assert scores.pass_at_k == pass_at_k(3, 4)
-    assert scores.pass_hat_k == pass_hat_k(3, 4)
+    # The infra attempt left the denominator: the rate is over 4, not 5.
+    assert agg.per_task[0].score == success_rate(3, 4) == 0.75
 
 
-def test_score_outcomes_cheat_counts_as_usable_failure() -> None:
-    # A cheat got a fair shot: it stays in the denominator as a non-success.
-    scores = score_outcomes([Outcome.PASS, Outcome.CHEAT])
-    assert (scores.successes, scores.usable, scores.unusable) == (1, 2, 0)
-    assert scores.score == 0.5
+def test_a_fully_unusable_task_scores_none_and_leaves_the_average_alone() -> None:
+    agg = aggregate_scores(
+        [
+            _task("t1", "Throttled", Outcome.INFRA_ERROR, Outcome.TIMEOUT),
+            _task("t2", "Clean", Outcome.PASS, Outcome.PASS),
+        ],
+        k=2,
+    )
+
+    by_id = {t.task_id: t for t in agg.per_task}
+    assert by_id["t1"].score is None
+    # The unmeasured task must not drag the average toward 0.
+    assert agg.avg_score == by_id["t2"].score == 1.0
+    assert agg.scored_tasks == 1
 
 
-def test_score_outcomes_all_unusable_yields_no_metrics() -> None:
-    scores = score_outcomes([Outcome.TIMEOUT, Outcome.JUDGE_ERROR])
-    assert (scores.successes, scores.usable, scores.unusable) == (0, 0, 2)
-    assert scores.score is None
-    assert scores.pass_at_k is None
-    assert scores.pass_hat_k is None
+def test_average_ignores_none_scores() -> None:
+    agg = aggregate_scores(
+        [
+            _task("t1", "A", Outcome.PASS, Outcome.TASK_FAIL),
+            _task("t2", "B", Outcome.JUDGE_ERROR),  # excluded
+        ],
+        k=2,
+    )
+
+    assert agg.avg_score == success_rate(1, 2) == 0.5
 
 
-def test_score_outcomes_empty() -> None:
-    scores = score_outcomes([])
-    assert (scores.successes, scores.usable, scores.unusable) == (0, 0, 0)
-    assert scores.score is None
+def test_every_row_records_the_runs_requested_depth() -> None:
+    """A task that ran short of k is visible as such, not silently rescaled."""
+    agg = aggregate_scores([_task("t1", "Cut short", Outcome.PASS)], k=5)
+
+    assert agg.per_task[0].k == 5
+    assert agg.per_task[0].successes == 1
+
+
+def test_no_tasks_averages_to_zero_rather_than_none() -> None:
+    """An empty run is 0.0%, which is what `list` renders; it is never saved."""
+    agg = aggregate_scores([], k=3)
+
+    assert agg.avg_score == 0.0
+    assert agg.per_task == []

--- a/tests/test_skill_drift.py
+++ b/tests/test_skill_drift.py
@@ -60,9 +60,6 @@ def _run(snapshots: list[SkillSnapshot], *, offset: int = 0) -> RunResults:
                         attempt=1, output="", duration_seconds=1.0, outcome=Outcome.PASS
                     )
                 ],
-                successes=1,
-                unusable=0,
-                pass_at_k=1.0,
             )
         ],
         aggregate=AggregateScore(total_tasks=1, avg_score=1.0, per_task=[]),

--- a/tests/test_task_metrics.py
+++ b/tests/test_task_metrics.py
@@ -1,0 +1,100 @@
+"""Everything a task's result derives from its own attempts.
+
+These numbers used to be computed twice — once by ``score_outcomes`` on the way
+in, once by ``TaskResult`` on the way out — from two different inputs, and three
+of the six were then thrown away. There is one derivation now, and this is it.
+"""
+
+from __future__ import annotations
+
+from caliper.schema.results import Outcome, TaskResult
+
+from conftest import task_result as _task
+
+
+def test_counts_split_usable_from_noise() -> None:
+    # 3 pass, 1 task_fail, 1 infra_error: the infra attempt leaves every
+    # denominator at once.
+    task = _task(
+        Outcome.PASS,
+        Outcome.PASS,
+        Outcome.PASS,
+        Outcome.TASK_FAIL,
+        Outcome.INFRA_ERROR,
+    )
+
+    assert (task.successes, task.usable, task.unusable) == (3, 4, 1)
+
+
+def test_every_metric_shares_the_usable_denominator() -> None:
+    task = _task(Outcome.PASS, Outcome.TASK_FAIL, Outcome.INFRA_ERROR)
+
+    assert task.score == 0.5
+    assert task.pass_at_k == 1 - 0.5**2
+    assert task.pass_hat_k == 0.5**2
+
+
+def test_a_cheat_is_a_usable_failure() -> None:
+    """It got a fair shot: it stays in the denominator as a non-success."""
+    task = _task(Outcome.PASS, Outcome.CHEAT)
+
+    assert (task.successes, task.usable, task.unusable) == (1, 2, 0)
+    assert task.score == 0.5
+
+
+def test_a_trigger_probe_leaves_the_denominator_without_being_noise() -> None:
+    """``NOT_CHECKED`` is neither usable nor an error.
+
+    A correct ``activates:``-only spec authored no execution check, so there was
+    nothing to grade — it must not read as something having gone wrong.
+    """
+    task = _task(Outcome.NOT_CHECKED, Outcome.NOT_CHECKED)
+
+    assert (task.successes, task.usable, task.unusable) == (0, 0, 0)
+    assert task.score is None
+
+
+def test_all_unusable_yields_no_metrics() -> None:
+    task = _task(Outcome.TIMEOUT, Outcome.JUDGE_ERROR)
+
+    assert (task.successes, task.usable, task.unusable) == (0, 0, 2)
+    assert task.score is None
+    assert task.pass_at_k is None
+    assert task.pass_hat_k is None
+
+
+def test_a_task_with_no_attempts_has_no_metrics() -> None:
+    task = _task()
+
+    assert (task.successes, task.usable, task.unusable) == (0, 0, 0)
+    assert task.score is None
+
+
+def test_the_metrics_are_serialized_so_a_saved_run_reads_the_same() -> None:
+    """Derived, but still written: a reader of the JSON needs the numbers."""
+    dumped = _task(Outcome.PASS, Outcome.TASK_FAIL).model_dump()
+
+    assert dumped["successes"] == 1
+    assert dumped["usable"] == 2
+    assert dumped["unusable"] == 0
+    assert dumped["score"] == 0.5
+    assert dumped["pass_at_k"] == 0.75
+    assert dumped["pass_hat_k"] == 0.25
+
+
+def test_a_saved_run_cannot_carry_counts_that_contradict_its_attempts() -> None:
+    """The stored numbers are ignored on load; the attempts are the record.
+
+    Before, ``successes`` and ``pass_at_k`` were stored while ``score`` was
+    derived, so a hand-edited or older file could report a rate that disagreed
+    with the attempts printed beside it.
+    """
+    honest = _task(Outcome.PASS, Outcome.TASK_FAIL)
+    tampered = honest.model_dump()
+    tampered["successes"] = 99
+    tampered["score"] = 1.0
+
+    reloaded = TaskResult.model_validate(tampered)
+
+    assert reloaded.successes == 1
+    assert reloaded.score == 0.5

--- a/tests/test_transcript_persistence.py
+++ b/tests/test_transcript_persistence.py
@@ -87,9 +87,6 @@ def test_run_results_transcript_round_trips_through_json() -> None:
                         ],
                     )
                 ],
-                successes=0,
-                unusable=1,
-                pass_at_k=None,
             )
         ],
         aggregate=AggregateScore(avg_score=0.0, per_task=[]),

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -228,9 +228,6 @@ def test_usage_totals_sum_all_attempts_and_break_out_unusable() -> None:
                     Outcome.TIMEOUT, 30.0, TokenUsage(input_tokens=40, output_tokens=0)
                 ),
             ],
-            successes=1,
-            unusable=1,
-            pass_at_k=1.0,
         )
     ]
     totals = UsageTotals.from_task_results(tasks)
@@ -255,9 +252,6 @@ def test_usage_totals_tokens_unreported_when_no_backend_data() -> None:
             task_id="task-001",
             task_name="alpha",
             attempts=[_att(Outcome.PASS, 5.0, None)],
-            successes=1,
-            unusable=0,
-            pass_at_k=1.0,
         )
     ]
     totals = UsageTotals.from_task_results(tasks)
@@ -312,9 +306,6 @@ def _task_with_tokens(name: str, per_attempt_tokens: int, dur: float) -> TaskRes
             _att(Outcome.PASS, dur, TokenUsage(input_tokens=per_attempt_tokens)),
             _att(Outcome.PASS, dur, TokenUsage(input_tokens=per_attempt_tokens)),
         ],
-        successes=2,
-        unusable=0,
-        pass_at_k=1.0,
     )
 
 
@@ -400,9 +391,6 @@ def test_an_ablated_run_shows_observations_on_a_passing_task(capsys) -> None:
                 activated=["keeper"],
             )
         ],
-        successes=1,
-        unusable=0,
-        pass_at_k=1.0,
     )
     results = _run([passing], k=1)
     results.run.ablated = ["subject"]
@@ -440,9 +428,6 @@ def test_failure_details_still_show_why_an_attempt_failed(capsys) -> None:
         task_id="task-001",
         task_name="alpha",
         attempts=[_att(Outcome.PASS, 3.0, None), fail, _att(Outcome.PASS, 3.0, None)],
-        successes=2,
-        unusable=0,
-        pass_at_k=0.963,
     )
     print_results(_run([task], k=3))
     out = capsys.readouterr().out
@@ -454,9 +439,6 @@ def test_print_results_per_task_tokens_dash_when_unreported(capsys) -> None:
         task_id="task-001",
         task_name="alpha",
         attempts=[_att(Outcome.PASS, 3.0, None)],
-        successes=1,
-        unusable=0,
-        pass_at_k=1.0,
     )
     print_results(_run([task]))
     out = capsys.readouterr().out


### PR DESCRIPTION
## What

`TaskResult` kept `successes`, `unusable` and `pass_at_k` as **stored** fields while `usable`, `score` and `pass_hat_k` were **computed** — an asymmetry with no reason behind it. The runner filled the stored three from `score_outcomes` while the model derived the other three from `self.attempts`, so:

- `usable`, `score` and `pass_hat_k` were each computed **twice, from two different inputs** (an outcome iterable vs. the attempt list);
- three of `score_outcomes`' six fields were computed and thrown away at its one production call site;
- a hand-edited or older results file could carry a `pass_at_k` that disagreed with the `score` printed beside it.

Worse, it closed an import cycle. `results` imported `scoring` for the formulas through **three deferred imports** written specifically to hide the fact that `scoring` imports `results`:

```python
@property
def score(self) -> float | None:
    # Deferred import: caliper.scoring imports this module ...
    from caliper.scoring import success_rate
```

## The change

All six numbers derive from the attempts. `OutcomeScores` and `score_outcomes` are deleted; `_finish_task` hands `TaskResult` its attempts and nothing else.

The formulas move to `schema/results.py`, beside the `Outcome.is_usable` that carves out the denominator — so `results` never imports `scoring` and the cycle is gone rather than hidden. `scoring.py` keeps only what genuinely spans tasks, and `aggregate_scores` now takes the results themselves instead of a `dict[task_id, (name, successes, usable, k)]` clump rebuilt from them.

**Direction note:** the review card sanctioned either direction ("either the formulas move onto the model … or the models stay dumb"). I took the first. The second would have made every number storable and therefore able to drift from the attempts — which is the property three docstrings in this file already argue for keeping.

## Compatibility

**The serialized shape is unchanged.** The numbers are still `computed_field`s, so a saved run reads exactly as before (identical key set, verified against `main`) and an older file loads fine. What changes is that its *stored* counts are ignored on load: the attempts are the record. There's a test for that.

No CLI flag, spec field, or judge behaviour change, and the results JSON keys are identical, so no README / REFERENCE update is owed.

## A live bug this surfaced

`caliper/reporter.py:_alt_metric_cell` held a function-local `from caliper.scoring import score_outcomes`. Because the import was inside the function, nothing failed at module load and the suite stayed green — but **`caliper compare --verbose` would have raised `ImportError`** at runtime. The secondary columns were rendered nowhere else and covered by nothing. Fixed, and now tested, including that the columns agree with the task metrics they came from.

## Docs

- `docs/adr/0007` gains an amendment: two of its recorded consequences (`pass_at_k` is a stored secondary; the score recomputes from stored `successes`) are no longer true. The rule the ADR is about — every denominator is usable attempts — is unchanged.
- `docs/render_readme_samples.py` had dead `successes=`/`pass_at_k=` kwargs that pydantic was silently ignoring; removed. Re-ran it — the committed SVGs are byte-identical.

## Tests

**522 pass, was 513.** `tests/test_task_metrics.py` is new and owns the per-task derivation that `score_outcomes` used to hold; `test_scoring.py` now covers the formulas and the cross-task roll-up only. A shared `task_result(*outcomes)` builder in `conftest.py` replaces three near-identical local ones — which is the point of the change: state the outcomes, and the result works out the rest.