### PR TITLE
refactor(sandbox): one module owns what the agent may not touch

### DIFF
--- a/caliper/attempt.py
+++ b/caliper/attempt.py
@@ -17,25 +17,14 @@ from __future__ import annotations
 
 import time
 from dataclasses import asdict, dataclass
-from typing import Protocol
 
 from caliper.activation import ActivationDetector, check_activation
 from caliper.harness.base import AttemptResult, ConversationTurn
 from caliper.judge.base import Judge
 from caliper.outcome import classify_outcome, classify_pre_judge
+from caliper.sandbox import Sandbox
 from caliper.schema.results import AttemptRecord, Outcome, TranscriptTurn
 from caliper.schema.spec import TaskSpec
-
-
-class CheatDetector(Protocol):
-    """What this module needs of a cheat detector: violations from a transcript.
-
-    A structural seam, like :class:`caliper.judge.base.Judge` — the production
-    detector lives with the runner that configures it from
-    ``sandbox.forbidden_files``, and a test double conforms by shape.
-    """
-
-    def check(self, transcript: list[ConversationTurn]) -> list[str]: ...
 
 
 @dataclass(frozen=True)
@@ -61,7 +50,7 @@ def assemble_attempt(
     spec_dir: str,
     expected_activation: list[str] | None,
     activation: ActivationDetector,
-    cheat: CheatDetector,
+    sandbox: Sandbox,
     judge: Judge,
     retries: int = 0,
 ) -> AssembledAttempt:
@@ -132,7 +121,7 @@ def assemble_attempt(
         evidence = result.error or f"harness exited {result.exit_code}"
         return with_outcome(pre_judge_outcome, assert_evidence=evidence)
 
-    cheat_violations = cheat.check(result.transcript)
+    cheat_violations = sandbox.violations(result.transcript)
     if cheat_violations:
         return with_outcome(
             classify_outcome(result, cheat_violations, None),

--- a/caliper/runner.py
+++ b/caliper/runner.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import shutil
 import subprocess
 import tempfile
@@ -14,13 +13,12 @@ from caliper import cancel
 from caliper.activation import ActivationDetector
 from caliper.attempt import assemble_attempt
 from caliper.harness.base import (
-    ConversationTurn,
     HarnessBackend,
     HarnessConfigurationError,
 )
 from caliper.judge.base import Judge
 from caliper.retry import SpendingCapReached, invoke_with_retry
-from caliper.runstore import RunStore
+from caliper.sandbox import SpecSandbox
 from caliper.schema.results import (
     ERA_INSTALL_AND_DISCOVER,
     AttemptRecord,
@@ -74,7 +72,7 @@ class _RunEnv:
 
     harness: HarnessBackend
     judge: Judge
-    cheat: _CheatDetector
+    sandbox: SpecSandbox
     activation: ActivationDetector
     spec: EvalSpec
     spec_path: Path
@@ -186,16 +184,14 @@ def run(
         [ref.name for ref in skill_refs], harness.activation_tool_names
     )
 
-    auto_forbidden = [
-        re.escape(str(spec_path.resolve())),
-        re.escape(str(RunStore(spec_path.parent).caliper_dir.resolve())),
-    ]
-    cheat = _CheatDetector(list(spec.sandbox.forbidden_files) + auto_forbidden)
+    # Owns the whole forbidden-path rule, the spec's own entries and caliper's
+    # additions alike (docs/CONTEXT.md → Sandbox).
+    sandbox = SpecSandbox.from_spec(spec, spec_path)
 
     env = _RunEnv(
         harness=harness,
         judge=judge,
-        cheat=cheat,
+        sandbox=sandbox,
         activation=detector,
         spec=spec,
         spec_path=spec_path,
@@ -456,7 +452,7 @@ def _run_attempt(task: TaskSpec, attempt: int, env: _RunEnv) -> AttemptRecord | 
             spec_dir=str(spec_path.parent),
             expected_activation=env.expected_activation(task),
             activation=env.activation,
-            cheat=env.cheat,
+            sandbox=env.sandbox,
             judge=env.judge,
             retries=invoked.retries,
         )
@@ -491,34 +487,3 @@ def _announce(
 def _run_shell(cmd: str | None) -> None:
     if cmd:
         subprocess.run(cmd, shell=True, check=False)
-
-
-class _CheatDetector:
-    def __init__(self, patterns: list[str]) -> None:
-        self._compiled = [re.compile(p) for p in patterns]
-
-    def check(self, transcript: list[ConversationTurn]) -> list[str]:
-        violations: list[str] = []
-        for turn in transcript:
-            if turn.tool_input:
-                for value in self._extract_paths(turn.tool_input):
-                    if any(r.search(value) for r in self._compiled):
-                        violations.append(value)
-        return violations
-
-    def _extract_paths(self, obj: dict | list | str, depth: int = 0) -> list[str]:
-        if depth > 5:
-            return []
-        if isinstance(obj, str):
-            return [obj] if ("/" in obj or "." in obj) else []
-        if isinstance(obj, dict):
-            results: list[str] = []
-            for v in obj.values():
-                results.extend(self._extract_paths(v, depth + 1))
-            return results
-        if isinstance(obj, list):
-            results = []
-            for item in obj:
-                results.extend(self._extract_paths(item, depth + 1))
-            return results
-        return []

--- a/caliper/sandbox.py
+++ b/caliper/sandbox.py
@@ -1,0 +1,148 @@
+"""What the agent-under-test may not touch (docs/CONTEXT.md → Sandbox).
+
+One module owns the whole rule: which paths are off-limits, the ones caliper
+adds on the spec author's behalf, how a transcript is scanned for them, and
+which of a skill's files are too dangerous to install. The rule used to have
+three owners — the runner built the patterns and the detector, ``attempt.py``
+declared the shape it needed of that detector, and ``skills.py`` re-compiled the
+same patterns for the install.
+
+``RunContext.forbidden_files`` still crosses the harness seam as a plain list of
+strings, and deliberately: a backend declares its chores rather than performing
+them (docs/adr/0020), so what it carries stays the spec's own data. The
+*matching* is asked of this module at both ends of that wire.
+
+Two audiences, deliberately not the same list:
+
+- :meth:`SpecSandbox.violations` scans a finished transcript, and uses the
+  declared patterns **plus** the auto-forbidden ones (the spec file, caliper's
+  own directory) — the answer keys an author should not have to think to
+  declare.
+- :meth:`SpecSandbox.permits_install` filters a skill's files at install time,
+  and uses the declared patterns **alone**. The auto-forbidden entries are
+  absolute host paths; matching them against a skill's relative install paths
+  could only ever fire by accident.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from functools import cached_property
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:  # Import-time only: harness.base reaches back into skills.py,
+    # which imports this module, so the runtime import would close a cycle.
+    from caliper.harness.base import ConversationTurn
+    from caliper.schema.spec import EvalSpec
+
+# How deep into an agent-supplied ``tool_input`` the scan walks. The input is
+# arbitrary JSON the agent wrote, so the walk is bounded rather than trusted.
+_MAX_DEPTH = 5
+
+
+class Sandbox(Protocol):
+    """What grading needs of a sandbox: the violations in a transcript.
+
+    A structural seam, like :class:`caliper.judge.base.Judge` — there is one
+    production implementation (:class:`SpecSandbox`), and a test double conforms
+    by shape.
+    """
+
+    def violations(self, transcript: list[ConversationTurn]) -> list[str]: ...
+
+
+@dataclass(frozen=True)
+class SpecSandbox:
+    """The sandbox an eval spec describes, plus caliper's own additions.
+
+    ``declared`` is verbatim ``sandbox.forbidden_files`` — regexes, written by
+    the spec author. ``auto`` is what caliper forbids on every run; the entries
+    are real paths, so they are escaped into literal patterns rather than
+    honoured as regexes (a spec living at ``demo+v2.eval.yaml`` must match
+    itself, not a repetition).
+    """
+
+    declared: list[str] = field(default_factory=list)
+    auto: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_spec(cls, spec: EvalSpec, spec_path: Path) -> SpecSandbox:
+        """The sandbox for a run of ``spec``, loaded from ``spec_path``.
+
+        Two answer keys are forbidden without the author declaring them: the
+        spec file (which holds every ``expect:``) and caliper's own directory
+        under the spec's root (which holds every saved run).
+        """
+        from caliper.runstore import RunStore
+
+        return cls(
+            declared=list(spec.sandbox.forbidden_files),
+            auto=[
+                str(spec_path.resolve()),
+                str(RunStore(spec_path.parent).caliper_dir.resolve()),
+            ],
+        )
+
+    def violations(self, transcript: list[ConversationTurn]) -> list[str]:
+        """Every path in ``transcript`` that the sandbox forbids.
+
+        Reported rather than counted: the record keeps the offending paths as
+        the evidence behind a ``cheat`` outcome (docs/adr/0001).
+        """
+        patterns = self._compiled
+        found: list[str] = []
+        for turn in transcript:
+            if not turn.tool_input:
+                continue
+            for value in _paths_in(turn.tool_input):
+                if any(p.search(value) for p in patterns):
+                    found.append(value)
+        return found
+
+    def permits_install(self, rel_posix: str) -> bool:
+        """Whether a skill file at this install-relative path may be installed.
+
+        Matched twice, bare and ``./``-prefixed, because both are how a spec
+        author writes a repo-relative path and neither should silently miss.
+        """
+        return not any(
+            p.search(rel_posix) or p.search("./" + rel_posix)
+            for p in self._declared_compiled
+        )
+
+    # Compiled once per sandbox, not once per call: ``permits_install`` runs for
+    # every file of every installed skill. ``cached_property`` writes straight
+    # into the instance dict, which a frozen dataclass still permits.
+    @cached_property
+    def _declared_compiled(self) -> list[re.Pattern[str]]:
+        return [re.compile(p) for p in self.declared]
+
+    @cached_property
+    def _compiled(self) -> list[re.Pattern[str]]:
+        return self._declared_compiled + [re.compile(re.escape(p)) for p in self.auto]
+
+
+def _paths_in(obj: object, depth: int = 0) -> list[str]:
+    """Every string in ``obj`` that could name a path.
+
+    A string qualifies on containing a ``/`` or a ``.`` — deliberately loose,
+    because a missed candidate is a missed cheat, while a false candidate only
+    reaches the patterns and fails to match.
+    """
+    if depth > _MAX_DEPTH:
+        return []
+    if isinstance(obj, str):
+        return [obj] if ("/" in obj or "." in obj) else []
+    if isinstance(obj, dict):
+        found: list[str] = []
+        for value in obj.values():
+            found.extend(_paths_in(value, depth + 1))
+        return found
+    if isinstance(obj, list):
+        found = []
+        for item in obj:
+            found.extend(_paths_in(item, depth + 1))
+        return found
+    return []

--- a/caliper/skills.py
+++ b/caliper/skills.py
@@ -21,6 +21,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from caliper.sandbox import SpecSandbox
 from caliper.schema.spec import GitSkillSource
 from caliper.skillfetch import SkillFetchError, SkillFetcher
 
@@ -242,8 +243,10 @@ def install_skills(
 
     Cheat surfaces are never installed, and the exclusions apply to **every**
     ref: a neighbour's ``.eval.yaml`` is as much an answer key as the subject's.
+    Which paths those are is the sandbox's rule, not this module's — it is asked
+    rather than re-derived (docs/CONTEXT.md → Sandbox).
     """
-    forbidden = [re.compile(p) for p in forbidden_files]
+    sandbox = SpecSandbox(declared=list(forbidden_files))
 
     for ref in refs:
         dest = skills_root / ref.name
@@ -255,10 +258,7 @@ def install_skills(
                 continue
             if item.name.endswith(".eval.yaml"):
                 continue
-            rel_posix = rel.as_posix()
-            if any(
-                r.search(rel_posix) or r.search("./" + rel_posix) for r in forbidden
-            ):
+            if not sandbox.permits_install(rel.as_posix()):
                 continue
             try:
                 if item.stat().st_size > _MAX_FILE_BYTES:

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -493,6 +493,26 @@ toward the [[success rate|score]]?"; **execution noise** asks "should this be
 which is excluded from the denominator without being an error — so a correct
 trigger-probe spec never reads as broken.
 
+## Sandbox
+
+What the agent-under-test may **not** touch during a run — the sibling of the
+declared [[MCP server (declared)|mcp:]] block, which grants capabilities where
+`sandbox:` takes them away. Its `forbidden_files` are regexes the spec author
+writes; caliper adds two of its own on every run, without being asked: the
+`.eval.yaml` spec itself (which holds every `expect:`) and `.caliper/` (which
+holds every [[saved run]]). Both are answer keys.
+
+The sandbox is read at two moments, against two different lists. At **install**
+time it filters a skill's files, using the *declared* patterns alone — the
+additions are absolute host paths, and could only match a skill's relative
+install path by accident. At **grading** time it scans the finished transcript
+for forbidden paths, using declared and added patterns together; a hit is the
+evidence behind a `cheat` [[outcome]], so the offending paths are reported and
+not merely counted.
+
+A sandbox is not a claim that the agent was *contained* — nothing stops the
+read; the run observes it and grades accordingly.
+
 ## Trigger probe
 
 A task that authors `activates:` and no `expect:`/`assert:` — its whole claim is

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -29,14 +29,14 @@ class RecordingJudge:
         return self.result
 
 
-class StubCheatDetector:
+class StubSandbox:
     """Reports a fixed violation list, whatever the transcript says."""
 
-    def __init__(self, violations: list[str] | None = None) -> None:
-        self.violations = violations or []
+    def __init__(self, found: list[str] | None = None) -> None:
+        self.found = found or []
 
-    def check(self, transcript: list[ConversationTurn]) -> list[str]:
-        return list(self.violations)
+    def violations(self, transcript: list[ConversationTurn]) -> list[str]:
+        return list(self.found)
 
 
 def _task(**overrides) -> TaskSpec:
@@ -74,7 +74,7 @@ def _assemble(result: AttemptResult, **overrides):
         spec_dir="/tmp",
         expected_activation=None,
         activation=ActivationDetector([], frozenset()),
-        cheat=StubCheatDetector(),
+        sandbox=StubSandbox(),
         judge=RecordingJudge(),
     )
     kwargs.update(overrides)
@@ -182,7 +182,7 @@ def test_a_forbidden_file_read_is_a_cheat_and_skips_the_judge():
     judge = RecordingJudge()
 
     assembled = _assemble(
-        _result(), cheat=StubCheatDetector(["/x/answers.txt"]), judge=judge
+        _result(), sandbox=StubSandbox(["/x/answers.txt"]), judge=judge
     )
 
     assert assembled.record.outcome is Outcome.CHEAT
@@ -206,7 +206,7 @@ def test_a_cheat_outranks_a_missing_execution_check():
     assembled = _assemble(
         _result(),
         task=_task(expect=None, activates=["tdd"]),
-        cheat=StubCheatDetector(["/x/answers.txt"]),
+        sandbox=StubSandbox(["/x/answers.txt"]),
     )
 
     assert assembled.record.outcome is Outcome.CHEAT
@@ -258,7 +258,7 @@ def test_activation_rides_on_a_cheat_too():
         _result(transcript=[_read_turn("/skills/tdd/SKILL.md")]),
         activation=_detector(),
         expected_activation=["tdd"],
-        cheat=StubCheatDetector(["/x/answers.txt"]),
+        sandbox=StubSandbox(["/x/answers.txt"]),
     )
 
     assert assembled.record.outcome is Outcome.CHEAT

--- a/tests/test_measure_and_mark.py
+++ b/tests/test_measure_and_mark.py
@@ -34,8 +34,8 @@ from caliper.schema.spec import TaskSpec
 runner = CliRunner()
 
 
-class NoCheat:
-    def check(self, transcript: list[ConversationTurn]) -> list[str]:
+class OpenSandbox:
+    def violations(self, transcript: list[ConversationTurn]) -> list[str]:
         return []
 
 
@@ -66,7 +66,7 @@ def _assemble(task: TaskSpec, result: AttemptResult) -> AttemptRecord:
         spec_dir=".",
         expected_activation=None,
         activation=ActivationDetector([], frozenset()),
-        cheat=NoCheat(),
+        sandbox=OpenSandbox(),
         judge=SlowJudge(),
     ).record
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from caliper.harness.base import ConversationTurn
+from caliper.sandbox import SpecSandbox
+from caliper.schema.spec import EvalSpec, SandboxConfig, TaskSpec
+
+
+def _spec(forbidden: list[str] | None = None) -> EvalSpec:
+    return EvalSpec(
+        skills=[],
+        tasks=[TaskSpec(id="task-001", name="t", prompt="go", expect="it works")],
+        sandbox=SandboxConfig(forbidden_files=forbidden or []),
+    )
+
+
+def _read(path: str) -> ConversationTurn:
+    return ConversationTurn(
+        role="tool_use", content="", tool_name="Read", tool_input={"file_path": path}
+    )
+
+
+def test_declared_pattern_is_a_violation() -> None:
+    sandbox = SpecSandbox(declared=[r".*answers\.txt$"])
+    assert sandbox.violations([_read("/work/answers.txt")]) == ["/work/answers.txt"]
+
+
+def test_unmatched_path_is_not_a_violation() -> None:
+    sandbox = SpecSandbox(declared=[r".*answers\.txt$"])
+    assert sandbox.violations([_read("/work/notes.md")]) == []
+
+
+def test_turn_without_tool_input_is_ignored() -> None:
+    sandbox = SpecSandbox(declared=[r".*"])
+    turn = ConversationTurn(role="assistant", content="/work/answers.txt")
+    assert sandbox.violations([turn]) == []
+
+
+def test_nested_tool_input_is_searched() -> None:
+    sandbox = SpecSandbox(declared=[r"answers\.txt"])
+    turn = ConversationTurn(
+        role="tool_use",
+        content="",
+        tool_name="Bash",
+        tool_input={"args": {"paths": ["/work/answers.txt"]}},
+    )
+    assert sandbox.violations([turn]) == ["/work/answers.txt"]
+
+
+def test_deeply_buried_path_is_not_searched() -> None:
+    """The scan stops at depth 5 — an unbounded walk on agent-supplied input."""
+    sandbox = SpecSandbox(declared=[r"answers\.txt"])
+    buried: dict = {"a": {"b": {"c": {"d": {"e": {"f": "/work/answers.txt"}}}}}}
+    turn = ConversationTurn(
+        role="tool_use", content="", tool_name="Bash", tool_input=buried
+    )
+    assert sandbox.violations([turn]) == []
+
+
+def test_non_path_strings_are_not_candidates() -> None:
+    sandbox = SpecSandbox(declared=[r"answers"])
+    turn = ConversationTurn(
+        role="tool_use", content="", tool_name="Bash", tool_input={"note": "answers"}
+    )
+    assert sandbox.violations([turn]) == []
+
+
+def test_from_spec_forbids_the_spec_file_itself(tmp_path: Path) -> None:
+    """Reading the spec is reading the answer key, whatever the spec declared."""
+    spec_file = tmp_path / "demo.eval.yaml"
+    spec_file.write_text("name: demo\n")
+    sandbox = SpecSandbox.from_spec(_spec(), spec_file)
+
+    assert sandbox.violations([_read(str(spec_file))]) == [str(spec_file)]
+
+
+def test_from_spec_forbids_calipers_own_directory(tmp_path: Path) -> None:
+    """Last run's saved results are an answer key too."""
+    saved = tmp_path / ".caliper" / "results" / "demo" / "2026-01-01T00-00-00.json"
+    sandbox = SpecSandbox.from_spec(_spec(), tmp_path / "demo.eval.yaml")
+
+    assert sandbox.violations([_read(str(saved))]) == [str(saved)]
+
+
+def test_from_spec_keeps_the_declared_patterns(tmp_path: Path) -> None:
+    sandbox = SpecSandbox.from_spec(
+        _spec([r".*answers\.txt$"]), tmp_path / "demo.eval.yaml"
+    )
+
+    assert sandbox.violations([_read("/work/answers.txt")]) == ["/work/answers.txt"]
+
+
+def test_auto_forbidden_paths_are_literal_not_patterns(tmp_path: Path) -> None:
+    """A spec path with regex metacharacters matches itself, not a pattern."""
+    spec_file = tmp_path / "demo+v2.eval.yaml"
+    spec_file.write_text("name: demo\n")
+    sandbox = SpecSandbox.from_spec(_spec(), spec_file)
+
+    assert sandbox.violations([_read(str(spec_file))]) == [str(spec_file)]
+
+
+def test_install_permits_an_ordinary_skill_file() -> None:
+    sandbox = SpecSandbox(declared=[r".*answers\.txt$"])
+    assert sandbox.permits_install("SKILL.md")
+
+
+def test_install_refuses_a_declared_cheat_surface() -> None:
+    sandbox = SpecSandbox(declared=[r".*answers\.txt$"])
+    assert not sandbox.permits_install("src/answers.txt")
+
+
+def test_install_matches_a_dot_slash_relative_pattern() -> None:
+    """`./src/answers.txt` is how a spec author writes a repo-relative path."""
+    sandbox = SpecSandbox(declared=[r"^\./src/answers\.txt$"])
+    assert not sandbox.permits_install("src/answers.txt")
+
+
+def test_install_ignores_the_auto_forbidden_paths(tmp_path: Path) -> None:
+    """Auto-forbidden paths are absolute host paths, outside any skill directory.
+
+    Applying them to a skill's *relative* install paths could only ever match by
+    accident, so the install filters on the declared patterns alone.
+    """
+    spec_file = tmp_path / "demo.eval.yaml"
+    spec_file.write_text("name: demo\n")
+    sandbox = SpecSandbox.from_spec(_spec(), spec_file)
+
+    assert sandbox.permits_install("demo.eval.yaml")


### PR DESCRIPTION
The forbidden-path rule had three owners. The runner built the patterns and the detector, `attempt.py` declared the shape it needed of that detector, and `skills.py` re-compiled the same patterns for the install — so `sandbox:`, a first-class spec block, had no module behind it.

`caliper/sandbox.py` now owns the whole rule: the declared patterns, the two caliper adds without being asked (the spec file, `.caliper/`), the transcript scan, and the install filter. `SpecSandbox` sits behind a `Sandbox` protocol, mirroring `EvalJudge`/`Judge`, so a test double still conforms by shape.

## Two readings, two lists

The split was already the behaviour — it was just never written down anywhere one reader could see both halves:

- **Grading** scans the transcript with the declared patterns **plus** the additions.
- **Install** filters a skill's files on the declared patterns **alone**. The additions are absolute host paths; matching them against a skill's relative install path could only ever fire by accident.

## What moved

| File | Change |
| --- | --- |
| `caliper/sandbox.py` | new — the whole rule |
| `caliper/runner.py` | lost `_CheatDetector` and the `auto_forbidden` assembly (−46 lines) |
| `caliper/attempt.py` | lost the `CheatDetector` protocol it declared for someone else's implementation; the param is now `sandbox` |
| `caliper/skills.py` | asks the sandbox instead of re-compiling the patterns |
| `docs/CONTEXT.md` | new **Sandbox** entry — the term the module is named after wasn't in the glossary |

`RunContext.forbidden_files` stays a plain `list[str]` across the harness seam on purpose: a backend declares its chores rather than performing them (`docs/adr/0020`). Only the *matching* is asked of the new module, at both ends of that wire.

## Test surface

No test constructed `_CheatDetector`. The auto-forbidden rule — the thing that stops an attempt reading its own answer key — was reachable only through a full `run()`, as were the recursive path walk and its depth cap. `tests/test_sandbox.py` covers them directly, 14 tests.

536 tests pass; `ruff format` and `ruff check` clean. No behaviour change intended.
