### PR TITLE
refactor(cli): one module owns the exit-code contract

### DIFF
--- a/caliper/commands/compare.py
+++ b/caliper/commands/compare.py
@@ -6,6 +6,7 @@ from typing import Annotated
 import typer
 from rich.console import Console
 
+from caliper.commands.diagnosis import BadInput, fail
 from caliper.compare import IncomparableRunsError, diff_runs
 from caliper.reporter import comparison_to_json, print_comparison
 from caliper.runstore import RunStore, UnreadableRun
@@ -19,17 +20,20 @@ _STORE = RunStore()
 def _resolve(ref: str) -> Path:
     path = _STORE.resolve(ref)
     if path is None:
-        console.print(f"[bold red]Error:[/bold red] No results found for {ref!r}")
-        raise typer.Exit(1)
+        fail(BadInput(f"No results found for {ref!r}"))
     return path
 
 
-def _load_run(ref: str, path: Path) -> RunResults:
+def _load_run(path: Path) -> RunResults:
+    """One saved run, or the diagnosis for a file that will not parse.
+
+    The reference the user typed is not carried in: ``UnreadableRun`` names the
+    file itself, which is what a reader has to go and look at.
+    """
     try:
         return _STORE.load(path)
     except UnreadableRun as exc:
-        console.print(f"[bold red]Error parsing results ({ref}):[/bold red] {exc}")
-        raise typer.Exit(1)
+        fail(exc)
 
 
 def _refuse_self_diff(a: str, a_path: Path, b: str, b_path: Path) -> None:
@@ -49,15 +53,17 @@ def _refuse_self_diff(a: str, a_path: Path, b: str, b_path: Path) -> None:
     """
     if a_path.resolve() != b_path.resolve():
         return
-    console.print(
-        f"[bold red]Refusing to compare:[/bold red] {a!r} and {b!r} are the same "
-        f"run ({a_path.stem}).\n\n"
-        "A bare spec name always resolves to that spec's latest run, so naming "
-        "one twice diffs a run against itself — every delta zero, nothing "
-        "flagged. Name two distinct runs; address the older side by its path:\n"
-        f"  caliper compare {_STORE.spec_dir('<spec>') / '<timestamp>.json'} {b}"
+    fail(
+        BadInput(
+            f"{a!r} and {b!r} are the same run ({a_path.stem}).\n\n"
+            "A bare spec name always resolves to that spec's latest run, so "
+            "naming one twice diffs a run against itself — every delta zero, "
+            "nothing flagged. Name two distinct runs; address the older side by "
+            "its path:\n"
+            f"  caliper compare {_STORE.spec_dir('<spec>') / '<timestamp>.json'} {b}",
+            title="Refusing to compare",
+        )
     )
-    raise typer.Exit(1)
 
 
 # Deliberately no gate flag and no verdict exit code: `has_regression` fires on
@@ -83,13 +89,14 @@ def compare_cmd(
 ) -> None:
     a_path, b_path = _resolve(a), _resolve(b)
     _refuse_self_diff(a, a_path, b, b_path)
+    # Loaded before the try, not inside it: ``_load_run`` exits through ``fail``,
+    # and ``typer.Exit`` is a RuntimeError — so a load that failed here would be
+    # caught by any except clause wide enough to name one.
+    run_a, run_b = _load_run(a_path), _load_run(b_path)
     try:
-        comparison = diff_runs(_load_run(a, a_path), _load_run(b, b_path))
+        comparison = diff_runs(run_a, run_b)
     except IncomparableRunsError as exc:
-        # A hard stop, unlike the k/spec/neighbourhood warnings: a cross-era diff
-        # looks entirely normal and would be believed (docs/adr/0013).
-        console.print(f"[bold red]Refusing to compare:[/bold red] {exc}")
-        raise typer.Exit(1)
+        fail(exc)
 
     if fmt == "json":
         console.print_json(comparison_to_json(comparison))

--- a/caliper/commands/diagnosis.py
+++ b/caliper/commands/diagnosis.py
@@ -1,0 +1,164 @@
+"""Every way a caliper command can fail, and what it exits with.
+
+The README publishes an exit-code contract, and CI reads it: ``2`` means *the
+eval could not run* (a broken pipeline) where ``3`` will mean *the skill did not
+clear the bar* (the answer you asked for). The contract used to live nowhere —
+each command re-derived its own mapping from failure to panel to code, and
+``run`` re-inspected a ``RunAborted``'s cause with ``isinstance`` to pick a
+title. Eighteen ``typer.Exit`` sites across five command modules, one rule
+between them.
+
+The table below is now that rule. A command raises or catches, then calls
+:func:`fail`, which is the only place a *failure* names a code. One exit stays
+at its call site — ``run``'s ``ExitCode.INTERRUPTED`` — because a saved partial
+run is not a failure and has nothing to render; it takes its number from the
+same enum. Two exceptions carry the two ordinary
+verdicts on a request — :class:`BadInput` (the caller's spec, path or reference
+is wrong) and :class:`CannotRun` (caliper cannot get far enough to answer) — and
+the domain's own exceptions are mapped as they arrive.
+
+Deliberately **not** in here: ``update-cli``. Its exits report a declined
+confirmation, a missing npm, and npm's own return code — user-interaction
+outcomes that have nothing to do with whether an eval ran. Folding them in would
+make one table answer two unrelated questions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import NoReturn
+
+import typer
+from pydantic import ValidationError
+from rich.console import Console
+from rich.panel import Panel
+
+from caliper.compare import IncomparableRunsError
+from caliper.harness.base import HarnessConfigurationError
+from caliper.retry import SpendingCapReached
+from caliper.runner import RunAborted
+from caliper.runstore import UnreadableRun
+from caliper.skills import SkillResolutionError
+
+console = Console()
+
+
+class ExitCode(IntEnum):
+    """The published contract (README → Exit codes)."""
+
+    OK = 0
+    # Bad input: the spec, the path or the run reference is wrong.
+    BAD_INPUT = 1
+    # Could not run: a misconfigured backend, an exhausted account, a retired
+    # flag. To CI this is a broken pipeline, not a failing skill.
+    CANNOT_RUN = 2
+    # Reserved for a *pre-registered* bar that a clean run did not clear —
+    # the one verdict worth failing a pipeline on. Nothing raises it yet;
+    # named here so the reservation is visible rather than only documented.
+    BAR_NOT_MET = 3
+    # Ctrl-C. The shell's own convention, so a script does not read a partial
+    # run as a complete one.
+    INTERRUPTED = 130
+
+
+class CommandError(Exception):
+    """A failure a command states itself, rather than one it caught.
+
+    The subclass *is* the exit code, so no call site ever names one. A ``title``
+    is carried only when the body earns a panel — a multi-line explanation with
+    something to act on; a one-line statement of fact prints as one line.
+    """
+
+    code: ExitCode
+
+    def __init__(self, body: str, *, title: str | None = None) -> None:
+        super().__init__(body)
+        self.body = body
+        self.title = title
+
+
+class BadInput(CommandError):
+    """The request was wrong: a missing file, an invalid spec, a bad reference."""
+
+    code = ExitCode.BAD_INPUT
+
+
+class CannotRun(CommandError):
+    """Caliper could not get far enough to answer the question asked."""
+
+    code = ExitCode.CANNOT_RUN
+
+
+@dataclass(frozen=True)
+class Diagnosis:
+    """What to show, and what to exit with."""
+
+    body: str
+    code: ExitCode
+    # ``None`` renders one red line; a title renders a bordered panel.
+    title: str | None = None
+
+
+def diagnose(exc: Exception) -> Diagnosis:
+    """The rendering and exit code for one failure — the whole table."""
+    if isinstance(exc, RunAborted):
+        # Two causes reach here, and they read very differently to whoever has
+        # to act: one is an account to top up, the other a machine to fix. The
+        # cause carries both its own message and its own code; this only says
+        # that a run was already in flight when it happened.
+        cause = diagnose(exc.cause)
+        return Diagnosis(
+            body=cause.body,
+            code=cause.code,
+            title=f"Run stopped: {cause.title or 'failed'}",
+        )
+    if isinstance(exc, (BadInput, CannotRun)):
+        code = ExitCode.BAD_INPUT if isinstance(exc, BadInput) else ExitCode.CANNOT_RUN
+        return Diagnosis(body=exc.body, code=code, title=exc.title)
+    if isinstance(exc, SkillResolutionError):
+        return Diagnosis(str(exc), ExitCode.BAD_INPUT, title="Invalid skills")
+    if isinstance(exc, ValidationError):
+        return Diagnosis(str(exc), ExitCode.BAD_INPUT, title="Validation failed")
+    if isinstance(exc, IncomparableRunsError):
+        # A hard stop, unlike the k/spec/neighbourhood warnings: a cross-era diff
+        # looks entirely normal and would be believed (docs/adr/0013).
+        return Diagnosis(str(exc), ExitCode.BAD_INPUT, title="Refusing to compare")
+    if isinstance(exc, UnreadableRun):
+        return Diagnosis(f"Error parsing results: {exc}", ExitCode.BAD_INPUT)
+    if isinstance(exc, SpendingCapReached):
+        return Diagnosis(str(exc), ExitCode.CANNOT_RUN, title="Spending cap reached")
+    if isinstance(exc, HarnessConfigurationError):
+        return Diagnosis(
+            str(exc), ExitCode.CANNOT_RUN, title="Backend configuration error"
+        )
+    # Unmapped: caliper's own fault, not the caller's input. `2` rather than `1`
+    # so a CI job reads it as a broken pipeline and stops, which is what an
+    # unhandled failure is.
+    return Diagnosis(str(exc), ExitCode.CANNOT_RUN, title="Unexpected error")
+
+
+def fail(exc: Exception) -> NoReturn:
+    """Render ``exc`` and exit with its code.
+
+    ``NoReturn`` so a caller can treat it as the end of a branch — the name that
+    was being assigned when it fired stays correctly unbound afterwards.
+
+    **Never call this inside a broad ``except``.** It leaves through
+    ``typer.Exit``, which subclasses ``RuntimeError``, so an enclosing
+    ``except Exception`` (or ``except RuntimeError``) swallows the exit and
+    turns a diagnosed failure into some other code path. Where a helper that
+    can ``fail`` is used inside a ``try``, hoist the call out of it.
+    """
+    diagnosis = diagnose(exc)
+    if diagnosis.title:
+        console.print(
+            Panel(
+                diagnosis.body,
+                title=f"[bold red]{diagnosis.title}[/bold red]",
+                border_style="red",
+            )
+        )
+    else:
+        console.print(f"[bold red]Error:[/bold red] {diagnosis.body}")
+    raise typer.Exit(diagnosis.code)

--- a/caliper/commands/list_cmd.py
+++ b/caliper/commands/list_cmd.py
@@ -8,6 +8,7 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
+from caliper.commands.diagnosis import BadInput, fail
 from caliper.reporter import UNUSABLE_GLYPH
 from caliper.runstore import RunStore, UnreadableRun
 from caliper.schema.results import RunResults
@@ -107,8 +108,7 @@ def _list_specs(store: RunStore) -> None:
 
 def _list_runs(store: RunStore, spec_name: str) -> None:
     if not store.has_spec(spec_name):
-        console.print(f"[bold red]Error:[/bold red] No results for spec {spec_name!r}")
-        raise typer.Exit(1)
+        fail(BadInput(f"No results for spec {spec_name!r}"))
 
     runs = store.runs(spec_name)
     if not runs:

--- a/caliper/commands/report.py
+++ b/caliper/commands/report.py
@@ -5,6 +5,7 @@ from typing import Annotated, Optional
 import typer
 from rich.console import Console
 
+from caliper.commands.diagnosis import BadInput, fail
 from caliper.reporter import print_results
 from caliper.runstore import RunStore, UnreadableRun
 from caliper.schema.results import UsageTotals
@@ -28,16 +29,12 @@ def report_cmd(
 ) -> None:
     results_path = _STORE.resolve(spec_or_file, run)
     if results_path is None:
-        console.print(
-            f"[bold red]Error:[/bold red] No results found for {spec_or_file!r}"
-        )
-        raise typer.Exit(1)
+        fail(BadInput(f"No results found for {spec_or_file!r}"))
 
     try:
         results = _STORE.load(results_path)
     except UnreadableRun as exc:
-        console.print(f"[bold red]Error parsing results:[/bold red] {exc}")
-        raise typer.Exit(1)
+        fail(exc)
 
     if fmt == "json":
         # Derive the run usage totals on the fly (never persisted on RunResults —

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -6,10 +6,11 @@ from pathlib import Path
 from typing import Iterator, Optional
 
 import typer
+from pydantic import ValidationError
 from rich.console import Console
-from rich.panel import Panel
 
 from caliper import cancel
+from caliper.commands.diagnosis import BadInput, CannotRun, ExitCode, fail
 from caliper.harness.base import HarnessConfigurationError
 from caliper.skillfetch import SkillFetcher
 from caliper.skills import SkillResolutionError
@@ -21,7 +22,6 @@ from caliper.reporter import (
     print_results,
     update_progress,
 )
-from caliper.retry import SpendingCapReached
 from caliper.runstore import RunStore
 from caliper.runner import run, AttemptEvent, RunAborted
 from caliper.schema.results import Outcome, RunResults, TaskResult
@@ -127,8 +127,8 @@ def run_cmd(
     # reading. See
     # docs/adr/0015-ablation-names-its-subject-at-the-invocation.md.
     if baseline:
-        console.print(
-            Panel(
+        fail(
+            CannotRun(
                 "`--baseline` has been retired.\n\n"
                 "It ran a second, no-skill arm inside every invocation, re-paying "
                 "for a number that cannot move when the skill changes: the "
@@ -138,21 +138,23 @@ def run_cmd(
                 "  caliper compare <that-run> <your-run>\n\n"
                 "Name every declared skill to get the bare agent. The saved arm "
                 "is reusable across every later iteration of the skill.",
-                title="[bold red]Retired flag[/bold red]",
-                border_style="red",
+                title="Retired flag",
             )
         )
-        raise typer.Exit(2)
 
     if not spec_file.exists():
-        console.print(f"[bold red]Error:[/bold red] File not found: {spec_file}")
-        raise typer.Exit(1)
+        fail(BadInput(f"File not found: {spec_file}"))
 
     try:
         spec = load_spec(spec_file)
+    except ValidationError as exc:
+        # A schema failure gets the table's panel — the same verdict `validate`
+        # reaches, rather than a second opinion in a different shape.
+        fail(exc)
     except Exception as exc:
-        console.print(f"[bold red]Invalid spec:[/bold red] {exc}")
-        raise typer.Exit(1)
+        # A YAML syntax error, or a retired key (ADR 0004). Not a schema
+        # verdict, so it stays a one-line statement of what is wrong.
+        fail(BadInput(f"Invalid spec: {exc}"))
 
     # The engine is a runtime axis, not a spec field (ADR 0004): resolve it here
     # from the flags, defaulting to claude-code. The resolved (backend, model)
@@ -259,24 +261,8 @@ def run_cmd(
                 on_attempt_done=on_attempt_done,
                 on_task_done=on_task_done,
             )
-        except SkillResolutionError as exc:
-            console.print(
-                Panel(
-                    str(exc),
-                    title="[bold red]Invalid skills:[/bold red]",
-                    border_style="red",
-                )
-            )
-            raise typer.Exit(1)
-        except HarnessConfigurationError as exc:
-            console.print(
-                Panel(
-                    str(exc),
-                    title="[bold red]Backend configuration error[/bold red]",
-                    border_style="red",
-                )
-            )
-            raise typer.Exit(2)
+        except (SkillResolutionError, HarnessConfigurationError) as exc:
+            fail(exc)
         except RunAborted as exc:
             # A fatal error mid-run. The attempts that already ran are on the
             # exception, and they get saved and rendered exactly like any other
@@ -286,26 +272,11 @@ def run_cmd(
     _save_and_report(results, spec_file, output, verbose)
 
     if aborted is not None:
-        # Two causes reach here (see the runner's job wrapper), and they read
-        # very differently to whoever has to act on them: one is a machine to
-        # fix, the other is an account to top up.
-        title = (
-            "Spending cap reached"
-            if isinstance(aborted.cause, SpendingCapReached)
-            else "Backend configuration error"
-        )
-        console.print(
-            Panel(
-                str(aborted.cause),
-                title=f"[bold red]Run stopped: {title}[/bold red]",
-                border_style="red",
-            )
-        )
-        raise typer.Exit(2)
+        # Which of the two causes it was, and what that exits with, is the
+        # diagnosis table's call — not this module's.
+        fail(aborted)
     if results.run.interrupted:
-        # 130 is the shell's own convention for SIGINT, so a script that stopped
-        # a run does not read the partial results as a completed one.
-        raise typer.Exit(130)
+        raise typer.Exit(ExitCode.INTERRUPTED)
 
 
 def _save_and_report(

--- a/caliper/commands/validate.py
+++ b/caliper/commands/validate.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.panel import Panel
 
+from caliper.commands.diagnosis import BadInput, fail
 from caliper.schema.spec import load_spec, spec_name
 from caliper.skillfetch import SkillFetcher
 from caliper.skills import (
@@ -29,23 +30,18 @@ def validate_cmd(
     spec_file: Path = typer.Argument(..., help="Path to .eval.yaml spec file"),
 ) -> None:
     if not spec_file.exists():
-        console.print(f"[bold red]Error:[/bold red] File not found: {spec_file}")
-        raise typer.Exit(1)
+        fail(BadInput(f"File not found: {spec_file}"))
 
     try:
         spec = load_spec(spec_file)
     except ValidationError as exc:
-        console.print(
-            Panel(
-                _format_validation_errors(exc),
-                title="[bold red]Validation failed[/bold red]",
-                border_style="red",
-            )
-        )
-        raise typer.Exit(1)
+        # Rendered here rather than by the diagnosis table: the per-field
+        # `loc → msg` layout is what makes a spec author's error actionable, and
+        # it is worth more than the generic pydantic string every other command
+        # would get.
+        fail(BadInput(_format_validation_errors(exc), title="Validation failed"))
     except Exception as exc:
-        console.print(f"[bold red]Error parsing YAML:[/bold red] {exc}")
-        raise typer.Exit(1)
+        fail(BadInput(f"Error parsing YAML: {exc}"))
 
     # Resolve the neighbourhood here too: a lone slash-command .md, a missing
     # frontmatter name:, or two skills claiming one name are all things
@@ -63,14 +59,7 @@ def validate_cmd(
         # connectivity reason.
         validate_activates(spec.tasks, refs, closed=not fetcher.unresolved)
     except SkillResolutionError as exc:
-        console.print(
-            Panel(
-                str(exc),
-                title="[bold red]Validation failed[/bold red]",
-                border_style="red",
-            )
-        )
-        raise typer.Exit(1)
+        fail(BadInput(str(exc), title="Validation failed"))
 
     name = spec_name(spec_file)
     n_tasks = len(spec.tasks)

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -493,6 +493,22 @@ toward the [[success rate|score]]?"; **execution noise** asks "should this be
 which is excluded from the denominator without being an error — so a correct
 trigger-probe spec never reads as broken.
 
+## Exit code
+
+What a `caliper` command tells the shell, and the one part of the CLI a CI job
+reads instead of looking at. `0` ran, `1` the request was wrong (a missing spec,
+an invalid one, a reference naming no run), `2` caliper could not run the eval
+(a misconfigured backend, an exhausted account), `130` a Ctrl-C whose partial
+run was saved. `3` is **reserved**: a clean run that did not clear a
+*pre-registered* bar.
+
+The distinction `2` and `3` draw is the one CI needs — *the eval could not run*
+is a broken pipeline, *the skill did not clear the bar* is the answer you asked
+for — so it is a contract, not an implementation detail, and a failure's code is
+decided in one place rather than at each command. A [[regression]] in `compare`
+is deliberately **not** an exit code: the any-below rule fires on noise about as
+often as on a real change at small k.
+
 ## Sandbox
 
 What the agent-under-test may **not** touch during a run — the sibling of the

--- a/tests/test_compare_cli.py
+++ b/tests/test_compare_cli.py
@@ -133,3 +133,22 @@ def test_list_names_which_run_was_the_control_arm(monkeypatch, tmp_path) -> None
     assert result.exit_code == 0, result.output
     assert "ablated" in result.output
     assert "my-skill" in result.output
+
+
+def test_an_unreadable_side_is_diagnosed_not_swallowed(monkeypatch, tmp_path) -> None:
+    """A corrupt file on either side is diagnosed, not rendered as a diff.
+
+    Covers the load path itself. It does *not* pin the fact that the loads
+    happen before ``compare_cmd``'s ``try`` — with the narrow
+    ``except IncomparableRunsError`` there today, both arrangements pass. That
+    hoist is defence against widening the clause later, and the reason lives in
+    a comment beside it.
+    """
+    ablated, full = _two_runs(tmp_path)
+    full.write_text("not json at all")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["compare", str(ablated), str(full)])
+
+    assert result.exit_code == 1
+    assert "parsing results" in result.output

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import typer
+from pydantic import BaseModel, ValidationError
+
+from caliper.commands.diagnosis import (
+    BadInput,
+    CannotRun,
+    ExitCode,
+    diagnose,
+    fail,
+)
+from caliper.compare import IncomparableRunsError
+from caliper.harness.base import HarnessConfigurationError
+from caliper.retry import SpendingCapReached
+from caliper.runner import RunAborted
+from caliper.runstore import UnreadableRun
+from caliper.schema.results import AggregateScore, RunMeta, RunResults
+from caliper.skills import SkillResolutionError
+
+
+def _validation_error() -> ValidationError:
+    class Model(BaseModel):
+        n: int
+
+    with pytest.raises(ValidationError) as caught:
+        Model(n="not a number")
+    return caught.value
+
+
+def _results() -> RunResults:
+    return RunResults(
+        run=RunMeta(
+            spec="demo",
+            timestamp=datetime.now(tz=timezone.utc),
+            k=1,
+            backend="claude-code",
+        ),
+        skill_snapshots=[],
+        task_results=[],
+        aggregate=AggregateScore(avg_score=0.0, per_task=[]),
+    )
+
+
+def test_bad_input_exits_one() -> None:
+    assert diagnose(BadInput("File not found: x")).code is ExitCode.BAD_INPUT
+
+
+def test_cannot_run_exits_two() -> None:
+    assert diagnose(CannotRun("The flag is retired")).code is ExitCode.CANNOT_RUN
+
+
+def test_unresolvable_skills_are_bad_input() -> None:
+    """A neighbourhood that will not resolve is the author's spec, not the box."""
+    diagnosis = diagnose(SkillResolutionError("no such skill"))
+
+    assert diagnosis.code is ExitCode.BAD_INPUT
+    assert diagnosis.body == "no such skill"
+
+
+def test_an_invalid_spec_is_bad_input() -> None:
+    assert diagnose(_validation_error()).code is ExitCode.BAD_INPUT
+
+
+def test_an_unreadable_run_is_bad_input() -> None:
+    exc = UnreadableRun(Path("demo/2026-01-01.json"), ValueError("not json"))
+    assert diagnose(exc).code is ExitCode.BAD_INPUT
+
+
+def test_a_misconfigured_backend_cannot_run() -> None:
+    """The eval could not run — a broken pipeline, not a failing skill."""
+    diagnosis = diagnose(HarnessConfigurationError("claude CLI not found"))
+
+    assert diagnosis.code is ExitCode.CANNOT_RUN
+    assert diagnosis.title == "Backend configuration error"
+
+
+def test_a_spending_cap_cannot_run() -> None:
+    diagnosis = diagnose(SpendingCapReached("out of credit"))
+
+    assert diagnosis.code is ExitCode.CANNOT_RUN
+    assert diagnosis.title == "Spending cap reached"
+
+
+def test_an_aborted_run_reports_its_cause() -> None:
+    """The run's own title says it stopped; the cause says what to go fix."""
+    aborted = RunAborted(SpendingCapReached("out of credit"), _results())
+    diagnosis = diagnose(aborted)
+
+    assert diagnosis.code is ExitCode.CANNOT_RUN
+    assert diagnosis.title == "Run stopped: Spending cap reached"
+    assert diagnosis.body == "out of credit"
+
+
+def test_an_aborted_run_distinguishes_its_two_causes() -> None:
+    """One is an account to top up, the other a machine to fix."""
+    aborted = RunAborted(HarnessConfigurationError("expired"), _results())
+
+    assert diagnose(aborted).title == "Run stopped: Backend configuration error"
+
+
+def test_incomparable_runs_are_a_hard_stop_on_bad_input() -> None:
+    """A cross-era diff looks entirely normal and would be believed (adr/0013)."""
+    diagnosis = diagnose(IncomparableRunsError("different eras"))
+
+    assert diagnosis.code is ExitCode.BAD_INPUT
+    assert diagnosis.title == "Refusing to compare"
+
+
+def test_an_unknown_failure_is_not_silently_bad_input() -> None:
+    """An unmapped exception is caliper's own fault, not the caller's input."""
+    diagnosis = diagnose(RuntimeError("boom"))
+
+    assert diagnosis.code is ExitCode.CANNOT_RUN
+
+
+def test_a_title_makes_it_a_panel() -> None:
+    assert diagnose(BadInput("body", title="Validation failed")).title == (
+        "Validation failed"
+    )
+
+
+def test_no_title_renders_as_one_line() -> None:
+    assert diagnose(BadInput("File not found: x")).title is None
+
+
+def test_fail_raises_typer_exit_with_the_code() -> None:
+    with pytest.raises(typer.Exit) as caught:
+        fail(CannotRun("nope"))
+
+    assert caught.value.exit_code == ExitCode.CANNOT_RUN
+
+
+def test_the_reserved_bar_code_is_named() -> None:
+    """Documented in the README's exit-code table; nothing raises it yet."""
+    assert ExitCode.BAR_NOT_MET == 3
+
+
+def test_the_interrupt_code_is_named() -> None:
+    assert ExitCode.INTERRUPTED == 130


### PR DESCRIPTION
The README publishes an exit-code contract and CI reads it — `2` means *the eval could not run*, `3` will mean *the skill did not clear the bar* — but no module held it. Five command modules each re-derived their own mapping from failure to panel to exit code, and `run` re-inspected a `RunAborted`'s cause with `isinstance` to pick a title.

`caliper/commands/diagnosis.py` is now that table. `diagnose(exc)` returns the body, the title and the code; `fail(exc)` renders and exits. **Eighteen `typer.Exit` sites across five modules become two**: `fail`, and `run`'s `ExitCode.INTERRUPTED`, which stays at its call site because a saved partial run is not a failure and has nothing to render — it takes its number from the same enum. No *failure* names a code any more: `BadInput` and `CannotRun` carry theirs on the subclass, and the domain's own exceptions are mapped as they arrive.

| failure | title | code |
| --- | --- | --- |
| `BadInput` | caller's | `1` |
| `SkillResolutionError` | Invalid skills | `1` |
| `ValidationError` | Validation failed | `1` |
| `IncomparableRunsError` | Refusing to compare | `1` |
| `UnreadableRun` | — | `1` |
| `CannotRun` | caller's | `2` |
| `SpendingCapReached` | Spending cap reached | `2` |
| `HarnessConfigurationError` | Backend configuration error | `2` |
| `RunAborted` | Run stopped: *(its cause's)* | *(its cause's)* |
| anything unmapped | Unexpected error | `2` |

## `fail` must not be called inside a broad `except`

It leaves through `typer.Exit`, which subclasses `RuntimeError` — so an enclosing `except Exception` (or `except RuntimeError`) would swallow the exit and turn a diagnosed failure into some other code path. `compare` now loads both runs *before* its `try` rather than inside it, and `fail`'s docstring says why. The clause there is narrow today, so this is defence against widening it later, not a live bug.

## Changes beyond the refactor

Three renderings improved because the table decides rather than the call site. None were asked for; listing them rather than folding them in silently:

- `caliper run` on a schema-invalid spec gets the same panel `validate` already gave it, instead of a one-line pydantic dump.
- The self-diff refusal and a cross-era `compare` get the panel their multi-line bodies were always written for.
- `compare._load_run` lost its `ref` argument, so a parse failure names the file path rather than which of the two positionals it was. The path identifies the file; the argument name is gone.

No exit code changed. `ExitCode.BAR_NOT_MET = 3` is named but unraised — the README's reservation is now visible in code.

## Out of scope

`update-cli` keeps its own exits. They report a declined confirmation, a missing npm, and npm's own return code — user-interaction outcomes with nothing to say about whether an eval ran. Folding them in would make one table answer two unrelated questions.

## Test surface

Exit codes were assertable only by invoking the CLI and reading `result.exit_code`. `diagnose` is a pure function over an exception, so `tests/test_diagnosis.py` covers the contract in 16 direct tests — including the reserved `3`. `test_compare_cli.py` gains coverage of the unreadable-side load path.

553 tests pass; `ruff format` and `ruff check` clean. `docs/CONTEXT.md` gains an **Exit code** entry.
