### PR TITLE
fix(runstore): every command discovers the same results root

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ caliper run my-skill.eval.yaml --k 3          # --ablate <skill> for a run to di
 
 ![caliper run of commit-writer at k=3. Three rows: 'Writes a conventional commit message' passes 3/3 (100.0%, 80K tokens) with a green tick in the act column; 'Keeps the subject line under 72 characters' 2/3 (66.7%, PARTIAL, 84K tokens) with a green tick; 'A release summary belongs to changelog-writer' shows no execution score, a red cross in the act column, and reads 'trigger only'. Score 83.3% over 2 tasks scored. Activation 77.8% over 3 asserted tasks. A per-skill table shows, for each skill, how many of the 9 attempts wanted it and how often it fired: commit-writer was wanted on 6 of 9, fired on 6/6 of those (100.0%) but also on 2/3 of the attempts that did not want it (66.7%); changelog-writer was wanted on 3 of 9, fired on only 1/3 (33.3%), and never fired unwanted (0/6, 0.0%). commit-writer is taking prompts that belong to changelog-writer. Failure panels below show the assertion error and the attempts where commit-writer activated on the changelog prompt](docs/assets/run-output.svg)
 
-The report ends with the per-task failure panels: for each attempt that didn't pass, the output plus the assertion or autorater reason *why*. Full results are also saved as JSON under `.caliper/results/<spec>/` for you to inspect or `caliper compare` later. `--verbose` adds `pass@k` and `pass^k` columns (both derived from the raw rate) and a panel for every task.
+The report ends with the per-task failure panels: for each attempt that didn't pass, the output plus the assertion or autorater reason *why*. Full results are also saved as JSON under `.caliper/results/<spec>/` at the project's [results root](#where-results-are-saved), for you to inspect or `caliper compare` later. `--verbose` adds `pass@k` and `pass^k` columns (both derived from the raw rate) and a panel for every task.
 
 ### Not sure what to put in a spec?
 
@@ -340,9 +340,8 @@ skills:                         # installed where the agent looks for skills,
 sandbox:
   extra_path:
     - ./bin                     # prepended to PATH inside each attempt
-  forbidden_files:
-    - ".*\\.eval\\.yaml$"       # prevents agent from reading the spec
-    - "./.caliper/.*"           # prevents agent from reading saved results
+  forbidden_files:            # extra patterns; the spec itself and any
+    - "./answers/.*"          #   .caliper/ directory are always forbidden
 
 mcp:                            # optional: MCP servers the agent may use
   weather:                      # server name → a mcp__weather__<tool> call in the transcript
@@ -548,6 +547,32 @@ When both `expect` and `assert` are present, both must pass.
 | `caliper report <spec-or-result>` | Re-render saved results |
 | `caliper compare <A> <B>` | Diff two saved runs of the same eval, task by task. Each side is a spec name (that spec's **latest** run) or a results-JSON path; they must be two distinct runs |
 | `caliper update-cli [backend]` | Check or update installed agent CLI versions |
+
+### Where results are saved
+
+Runs are saved under a **results root** — a directory with a `.caliper/` in it —
+and every command resolves the same one: the nearest `.caliper/` at or above
+your working directory, without leaving the git repository. The first run of a
+project creates it at the repository root.
+
+```
+my-project/            <- .caliper/results/<spec>/<run id>.json lands here
+├── .git/
+├── .caliper/
+└── evals/
+    └── my.eval.yaml   <- `caliper run` from here finds the root above
+```
+
+So `caliper run evals/my.eval.yaml` and `caliper report my` agree wherever in
+the project you run them from. To give a subdirectory its own separate history —
+a package in a monorepo with its own eval suite — create the marker yourself:
+
+```bash
+mkdir .caliper
+```
+
+The nearest root wins, so everything under that directory then files its runs
+there. See [docs/adr/0022](docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md).
 
 ### `caliper run` flags
 

--- a/caliper/commands/compare.py
+++ b/caliper/commands/compare.py
@@ -14,29 +14,29 @@ from caliper.schema.results import RunResults
 
 console = Console()
 
-_STORE = RunStore()
 
-
-def _resolve(ref: str) -> Path:
-    path = _STORE.resolve(ref)
+def _resolve(store: RunStore, ref: str) -> Path:
+    path = store.resolve(ref)
     if path is None:
-        fail(BadInput(f"No results found for {ref!r}"))
+        fail(BadInput(store.no_results(ref)))
     return path
 
 
-def _load_run(path: Path) -> RunResults:
+def _load_run(store: RunStore, path: Path) -> RunResults:
     """One saved run, or the diagnosis for a file that will not parse.
 
     The reference the user typed is not carried in: ``UnreadableRun`` names the
     file itself, which is what a reader has to go and look at.
     """
     try:
-        return _STORE.load(path)
+        return store.load(path)
     except UnreadableRun as exc:
         fail(exc)
 
 
-def _refuse_self_diff(a: str, a_path: Path, b: str, b_path: Path) -> None:
+def _refuse_self_diff(
+    store: RunStore, a: str, a_path: Path, b: str, b_path: Path
+) -> None:
     """Refuse two references that name the same saved run.
 
     ``compare`` addresses runs but cannot *qualify* them: a bare spec name always
@@ -60,7 +60,7 @@ def _refuse_self_diff(a: str, a_path: Path, b: str, b_path: Path) -> None:
             "naming one twice diffs a run against itself — every delta zero, "
             "nothing flagged. Name two distinct runs; address the older side by "
             "its path:\n"
-            f"  caliper compare {_STORE.spec_dir('<spec>') / '<timestamp>.json'} {b}",
+            f"  caliper compare {store.spec_dir('<spec>') / '<timestamp>.json'} {b}",
             title="Refusing to compare",
         )
     )
@@ -87,12 +87,15 @@ def compare_cmd(
         bool, typer.Option("--verbose", "-v", help="Also show pass@k and pass^k")
     ] = False,
 ) -> None:
-    a_path, b_path = _resolve(a), _resolve(b)
-    _refuse_self_diff(a, a_path, b, b_path)
+    # One root for both sides: a bare spec name is resolved against it, so
+    # discovering per reference could address two different projects.
+    store = RunStore.discover()
+    a_path, b_path = _resolve(store, a), _resolve(store, b)
+    _refuse_self_diff(store, a, a_path, b, b_path)
     # Loaded before the try, not inside it: ``_load_run`` exits through ``fail``,
     # and ``typer.Exit`` is a RuntimeError — so a load that failed here would be
     # caught by any except clause wide enough to name one.
-    run_a, run_b = _load_run(a_path), _load_run(b_path)
+    run_a, run_b = _load_run(store, a_path), _load_run(store, b_path)
     try:
         comparison = diff_runs(run_a, run_b)
     except IncomparableRunsError as exc:

--- a/caliper/commands/list_cmd.py
+++ b/caliper/commands/list_cmd.py
@@ -60,11 +60,12 @@ def list_cmd_fn(
     spec: Annotated[
         Optional[str], typer.Argument(help="Spec name to list runs for")
     ] = None,
-    directory: Annotated[
-        Path, typer.Option("--dir", help="Directory to search")
-    ] = Path("."),
 ) -> None:
-    store = RunStore(directory)
+    # No `--dir`: the results root is discovered, the same way for every command
+    # (docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md). A flag
+    # that pointed the listing at a root `report` and `compare` could not follow
+    # was the asymmetry discovery removes. To read another project, work from it.
+    store = RunStore.discover()
 
     if spec:
         _list_runs(store, spec)
@@ -76,7 +77,8 @@ def _list_specs(store: RunStore) -> None:
     specs = store.specs()
     if not specs:
         console.print(
-            "[dim]No evaluation results found. Run [bold]caliper run[/bold] first.[/dim]"
+            f"[dim]No evaluation results under {store.root}. "
+            "Run [bold]caliper run[/bold] first.[/dim]"
         )
         return
 
@@ -108,7 +110,7 @@ def _list_specs(store: RunStore) -> None:
 
 def _list_runs(store: RunStore, spec_name: str) -> None:
     if not store.has_spec(spec_name):
-        fail(BadInput(f"No results for spec {spec_name!r}"))
+        fail(BadInput(store.no_results(spec_name)))
 
     runs = store.runs(spec_name)
     if not runs:

--- a/caliper/commands/report.py
+++ b/caliper/commands/report.py
@@ -12,8 +12,6 @@ from caliper.schema.results import UsageTotals
 
 console = Console()
 
-_STORE = RunStore()
-
 
 def report_cmd(
     spec_or_file: Annotated[
@@ -27,12 +25,13 @@ def report_cmd(
     ] = "table",
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
-    results_path = _STORE.resolve(spec_or_file, run)
+    store = RunStore.discover()
+    results_path = store.resolve(spec_or_file, run)
     if results_path is None:
-        fail(BadInput(f"No results found for {spec_or_file!r}"))
+        fail(BadInput(store.no_results(spec_or_file)))
 
     try:
-        results = _STORE.load(results_path)
+        results = store.load(results_path)
     except UnreadableRun as exc:
         fail(exc)
 

--- a/caliper/commands/run.py
+++ b/caliper/commands/run.py
@@ -300,9 +300,9 @@ def _save_and_report(
         console.print("[dim]Nothing ran — no results saved.[/dim]")
         return
 
-    # Rooted at the spec's own directory, so a run's results land beside the
-    # spec that produced them (docs/CONTEXT.md → Saved run).
-    saved_path = RunStore(spec_file.parent).save(results)
+    # The same root every reading command resolves, discovered the same way
+    # (docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md).
+    saved_path = RunStore.discover().save(results)
     if output:
         Path(output).write_text(results.model_dump_json(indent=2))
 

--- a/caliper/runstore.py
+++ b/caliper/runstore.py
@@ -15,13 +15,13 @@ The run id is the run's timestamp; see
 docs/adr/0021-a-run-is-addressed-by-its-timestamp.md for what that buys and
 costs.
 
-**The root is the caller's choice, and the callers disagree.** ``run`` roots the
-store at the *spec file's parent*, so results land beside the spec that produced
-them; the reading commands root it at the working directory (``list --dir``
-makes that explicit). Those agree only when caliper is invoked from the spec's
-own directory — a genuine defect, left alone here because settling it means
-deciding where results belong, not who knows the path. Concentrating the layout
-does mean there is now one line to change when it is settled.
+**Every command resolves the same root, by discovering it.** ``run`` used to
+root the store at the spec file's parent while the reading commands rooted
+theirs at the working directory, so ``caliper run evals/my.eval.yaml`` filed a
+run that ``caliper report my`` could not find. Both sides now call
+:meth:`RunStore.discover`, which walks up from the working directory for the
+nearest ``.caliper/``. See
+docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md.
 """
 
 from __future__ import annotations
@@ -30,6 +30,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from caliper.schema.results import RunResults
+
+#: Caliper's own directory, and the marker that says "a results root is here".
+CALIPER_DIR = ".caliper"
+
+#: Where runs are filed within it.
+RESULTS_DIR = "results"
 
 #: The run id: a UTC timestamp that sorts lexicographically, so "latest" needs
 #: no parsing and a directory listing is already in run order.
@@ -56,6 +62,38 @@ class RunStore:
 
     root: Path = Path(".")
 
+    @classmethod
+    def discover(cls, start: Path | None = None) -> RunStore:
+        """The results root that governs ``start`` (default: the working directory).
+
+        The nearest ``.caliper/`` at or above ``start`` wins, so a package inside
+        a monorepo that has deliberately been given its own root keeps its own
+        eval history rather than pooling it with the repo's. The walk stops at
+        the enclosing git repository: caliper will not reach past a repo
+        boundary to adopt a root belonging to some unrelated parent — a stray
+        ``.caliper/`` in ``$HOME`` must not silently become every repo's store.
+
+        When no root exists yet, one is *named* (not created — ``save`` does
+        that) at the repository root, falling back to ``start`` outside a
+        repository. Deliberately not ``start`` itself: the first run of a
+        project would otherwise plant the root wherever the caller happened to
+        be standing, and every later run from elsewhere in the same project
+        would create a second one. Nothing about that is visible until a
+        ``report`` comes up empty.
+
+        The escape hatch is the marker itself: ``mkdir .caliper`` in a directory
+        makes it a results root, and nearest-wins does the rest.
+        """
+        start = (start or Path.cwd()).resolve()
+        repo_root: Path | None = None
+        for directory in (start, *start.parents):
+            if (directory / CALIPER_DIR).is_dir():
+                return cls(directory)
+            if (directory / ".git").exists():
+                repo_root = directory
+                break
+        return cls(repo_root or start)
+
     @property
     def caliper_dir(self) -> Path:
         """Caliper's own directory under this root — everything it writes.
@@ -63,15 +101,42 @@ class RunStore:
         The run sandbox forbids the agent-under-test from reading it: a skill
         that opens last run's results is reading the answer key.
         """
-        return self.root / ".caliper"
+        return self.root / CALIPER_DIR
 
     @property
     def results_dir(self) -> Path:
-        return self.caliper_dir / "results"
+        return self.caliper_dir / RESULTS_DIR
 
     def spec_dir(self, spec: str) -> Path:
         """Where this spec's runs are filed. May not exist yet."""
         return self.results_dir / spec
+
+    def no_results(self, ref: str) -> str:
+        """Why a reference did not resolve, as a message that names the root.
+
+        Two failures reach a reader as the same empty answer, and they need
+        different fixes: the spec name is wrong, or the command is being run
+        somewhere other than the project. The second is the one a bare "no
+        results for 'x'" hides — it reads as a typo. Both name the root that was
+        searched, because a *discovered* root is the one thing the caller cannot
+        see (docs/CONTEXT.md → Results root).
+        """
+        if not self.has_any_results():
+            return (
+                f"No evaluation results under {self.root}.\n\n"
+                "Run `caliper run` first, or work from the directory you ran it in."
+            )
+        return f"No results found for {ref!r} under {self.root}"
+
+    def has_any_results(self) -> bool:
+        """Whether caliper has ever saved a run under this root.
+
+        Separates two failures a reader hits with the same symptom: an unknown
+        spec name, and a results root that has never been written to at all —
+        which usually means the command was run somewhere other than the project
+        (docs/CONTEXT.md → Results root).
+        """
+        return self.results_dir.is_dir()
 
     def has_spec(self, spec: str) -> bool:
         """Whether this spec has ever been run here, even if every run was deleted.

--- a/caliper/sandbox.py
+++ b/caliper/sandbox.py
@@ -15,9 +15,8 @@ them (docs/adr/0020), so what it carries stays the spec's own data. The
 Two audiences, deliberately not the same list:
 
 - :meth:`SpecSandbox.violations` scans a finished transcript, and uses the
-  declared patterns **plus** the auto-forbidden ones (the spec file, caliper's
-  own directory) — the answer keys an author should not have to think to
-  declare.
+  declared patterns **plus** the auto-forbidden ones (the spec file, any saved
+  results) — the answer keys an author should not have to think to declare.
 - :meth:`SpecSandbox.permits_install` filters a skill's files at install time,
   and uses the declared patterns **alone**. The auto-forbidden entries are
   absolute host paths; matching them against a skill's relative install paths
@@ -37,9 +36,30 @@ if TYPE_CHECKING:  # Import-time only: harness.base reaches back into skills.py,
     from caliper.harness.base import ConversationTurn
     from caliper.schema.spec import EvalSpec
 
+from caliper.runstore import CALIPER_DIR, RESULTS_DIR
+
 # How deep into an agent-supplied ``tool_input`` the scan walks. The input is
 # arbitrary JSON the agent wrote, so the walk is bounded rather than trusted.
 _MAX_DEPTH = 5
+
+#: Any saved run, wherever it is filed — a real regex, unlike the ``auto``
+#: entries, and the only forbidden rule that is not a resolved path.
+#:
+#: It cannot be one. The results root is *discovered* rather than fixed
+#: (docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md), so resolving
+#: it would forbid the one location this run happens to write to and leave every
+#: other readable: an older root, another checkout's, the one a monorepo sibling
+#: owns. Reading last run's results is reading the answer key wherever they are.
+#:
+#: Narrow on both sides on purpose. It matches ``.caliper/results/`` and not
+#: ``.caliper`` alone, because a task may legitimately *write a caliper spec*
+#: whose text contains ``./.caliper/.*`` — grill-skill's own eval does, and a
+#: bare marker flagged those attempts as cheats when the pattern was declared by
+#: hand. The leading boundary keeps ``.caliper-mcp.json``, the MCP config the
+#: harness writes into the agent's own home, out of it.
+SAVED_RESULTS = (
+    rf"(?<![\w.-]){re.escape(CALIPER_DIR)}[/\\]{re.escape(RESULTS_DIR)}[/\\]"
+)
 
 
 class Sandbox(Protocol):
@@ -58,10 +78,12 @@ class SpecSandbox:
     """The sandbox an eval spec describes, plus caliper's own additions.
 
     ``declared`` is verbatim ``sandbox.forbidden_files`` — regexes, written by
-    the spec author. ``auto`` is what caliper forbids on every run; the entries
-    are real paths, so they are escaped into literal patterns rather than
-    honoured as regexes (a spec living at ``demo+v2.eval.yaml`` must match
-    itself, not a repetition).
+    the spec author. ``auto`` is the *paths* caliper forbids on every run; the
+    entries are real paths, so they are escaped into literal patterns rather
+    than honoured as regexes (a spec living at ``demo+v2.eval.yaml`` must match
+    itself, not a repetition). :data:`SAVED_RESULTS` is forbidden on top of
+    both, always: it is a rule about a directory *shape*, not a location, so
+    there is no path for it to be an entry of.
     """
 
     declared: list[str] = field(default_factory=list)
@@ -72,17 +94,14 @@ class SpecSandbox:
         """The sandbox for a run of ``spec``, loaded from ``spec_path``.
 
         Two answer keys are forbidden without the author declaring them: the
-        spec file (which holds every ``expect:``) and caliper's own directory
-        under the spec's root (which holds every saved run).
+        spec file, which holds every ``expect:``, and any saved run — the
+        latter via :data:`SAVED_RESULTS` rather than a path, because the results
+        root is discovered and a run may be filed under one this call never
+        resolved.
         """
-        from caliper.runstore import RunStore
-
         return cls(
             declared=list(spec.sandbox.forbidden_files),
-            auto=[
-                str(spec_path.resolve()),
-                str(RunStore(spec_path.parent).caliper_dir.resolve()),
-            ],
+            auto=[str(spec_path.resolve())],
         )
 
     def violations(self, transcript: list[ConversationTurn]) -> list[str]:
@@ -121,7 +140,11 @@ class SpecSandbox:
 
     @cached_property
     def _compiled(self) -> list[re.Pattern[str]]:
-        return self._declared_compiled + [re.compile(re.escape(p)) for p in self.auto]
+        return [
+            *self._declared_compiled,
+            *(re.compile(re.escape(p)) for p in self.auto),
+            re.compile(SAVED_RESULTS),
+        ]
 
 
 def _paths_in(obj: object, depth: int = 0) -> list[str]:

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -163,12 +163,31 @@ is the *only* thing `report`, `compare` and `list` ever read — none of them
 re-runs anything — so a run is measured once and read back as often as you like.
 An [[interrupted run]] is a saved run like any other.
 
+A saved run belongs to a [[results root]], not to the folder its spec sits in.
+
 Its **run id** names it uniquely among that spec's runs and orders it against
 them (see [[0021-a-run-is-addressed-by-its-timestamp]]).
 
 A **run reference** is how a caller names a saved run: either a direct path, or a
 spec name, which always means that spec's *latest* run. See [[run comparison
 (`compare`)]] for why an [[ablation]] pair has to name its control arm by path.
+
+## Results root
+
+The directory whose `.caliper/` holds a project's [[saved run]]s. Every command
+resolves the same one, so a run that `caliper run` writes is a run that
+`report`, `compare` and `list` can find.
+
+A results root governs the directories beneath it: the *nearest* one at or above
+where caliper is invoked wins, which is what lets a package inside a larger
+repository keep an eval history of its own. Marking a directory as one is how a
+caller chooses — there is no flag.
+
+_Avoid_: project root (a results root need not be the whole project's, and the
+name invites the assumption that caliper decides where a project begins).
+
+See [[0022-saved-runs-live-at-a-discovered-results-root]] for how one is found
+and why runs belong to a root rather than to a spec file.
 
 ## Run comparison (`compare`)
 
@@ -515,13 +534,19 @@ What the agent-under-test may **not** touch during a run — the sibling of the
 declared [[MCP server (declared)|mcp:]] block, which grants capabilities where
 `sandbox:` takes them away. Its `forbidden_files` are regexes the spec author
 writes; caliper adds two of its own on every run, without being asked: the
-`.eval.yaml` spec itself (which holds every `expect:`) and `.caliper/` (which
-holds every [[saved run]]). Both are answer keys.
+`.eval.yaml` spec itself (which holds every `expect:`) and any saved results
+directory. Both are answer keys.
+
+The two additions are not the same *kind* of thing. The spec is a path this run
+resolved. Saved results are a directory **shape**, matched wherever they are
+filed: a [[results root]] is discovered, so a run may be filed under one this
+run never resolved — an older root, a sibling package's — and a resolved path
+would forbid one and leave the rest readable.
 
 The sandbox is read at two moments, against two different lists. At **install**
 time it filters a skill's files, using the *declared* patterns alone — the
-additions are absolute host paths, and could only match a skill's relative
-install path by accident. At **grading** time it scans the finished transcript
+additions are absolute host paths or shapes no skill file has, and could only
+match a skill's relative install path by accident. At **grading** time it scans the finished transcript
 for forbidden paths, using declared and added patterns together; a hit is the
 evidence behind a `cheat` [[outcome]], so the offending paths are reported and
 not merely counted.

--- a/docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md
+++ b/docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md
@@ -1,0 +1,124 @@
+# Saved runs live at a discovered results root
+
+Every command — the one that writes runs and the three that read them —
+resolves the same **results root** by calling `RunStore.discover()`: the nearest
+`.caliper/` at or above the working directory, bounded by the enclosing git
+repository. When no root exists yet, one is named at the repository root
+(falling back to the working directory outside a repository).
+
+Before this, `run` alone rooted its store at the *spec file's parent*, so
+results landed beside the spec. `report` and `compare` rooted theirs at the
+working directory, and `list` at `--dir` (default `.`). Those agree only when
+you happen to invoke caliper from the spec's own directory; anywhere else a run
+was written where nothing would look for it, and `caliper report <spec>`
+answered "No results found" for a run that existed on disk. The consolidation in
+`caliper/runstore.py` concentrated the layout but deliberately left the root
+alone, because it is a question about where results *belong* rather than about
+who knows the path.
+
+## Why a root, and why discovered
+
+**Results are a property of the project, not of the spec file.** A run's value is
+comparative — `compare` diffs two of them, `list` ranks a project's specs side by
+side (docs/CONTEXT.md → Saved run). Filing runs beside each spec scatters that
+history across every folder a spec happens to live in: a repo with `evals/`,
+`skills/foo/`, and a root-level spec would grow three unrelated `.caliper/`
+directories, and no single `list` could show them together.
+
+**The reader addresses a run without knowing where its spec is.** A run reference
+is a spec *name* (docs/CONTEXT.md → Saved run), not a path. Keeping results
+beside the spec would mean `report my-skill` had to find `my.eval.yaml` first —
+by searching the tree, or by making every caller pass a spec path where a name
+works today.
+
+**Discovery is what users already expect.** Walking up for a marker directory is
+how `git`, `npm`, `pytest` and `ruff` all behave. Rooting at the working
+directory alone would be simpler to state, but it keeps the failure this record
+exists to remove: `caliper report my-skill` from `evals/` in the same project
+that just ran it would still come up empty. Discovery removes the failure rather
+than relocating it.
+
+## The rules, and why each one
+
+**Nearest wins.** A package inside a monorepo that has been given its own
+`.caliper/` keeps its own eval history rather than pooling it with the repo's.
+Two packages with independent eval suites should not share a `list`.
+
+**The walk stops at the git repository.** Without a boundary, a stray `.caliper/`
+in `$HOME` would silently become the store for every repo below it — a failure
+that is invisible until someone wonders why two projects' runs are interleaved.
+This puts a git dependency in the resolution path, which is not otherwise about
+git; caliper already reads git for skill snapshots, so the repo boundary is not
+a foreign concept here. Outside a repository, discovery falls back to the
+working directory.
+
+**A missing root is named at the repo root, not at the working directory.**
+Otherwise the *first* `caliper run` of a project plants the root wherever the
+caller happened to be standing, and every later run from elsewhere in the same
+project creates a second one. Nothing about that is visible until a `report`
+comes up empty — which is this record's original bug, re-created on day one.
+
+**`mkdir .caliper` is the escape hatch.** The marker is the control: creating one
+in a subdirectory makes it a results root, and nearest-wins does the rest.
+
+## What this costs
+
+**`list --dir` is removed outright**, not deprecated. With discovery it pointed
+the listing at a root that `report` and `compare` could not follow, which is the
+asymmetry this record removes; and the escape hatch above covers the case it
+served. This departs from the precedent in
+[[0015-ablation-names-its-subject-at-the-invocation]], where `--baseline` was
+kept parseable for one release so an outside caller would get a real
+explanation instead of typer's bare "No such option". The departure is
+deliberate: `--dir` is a reader's convenience with an obvious substitute (work
+from the project), where `--baseline` silently changed what a scripted caller
+paid for and what it measured.
+
+**Where a run lands depends on the enclosing project**, so the same spec run
+from two checkouts keeps two histories. That is the intended reading of
+"results belong to the project", but it does mean a run is not addressable from
+outside the project that produced it, except by path.
+
+**Runs already filed beside a spec are not migrated.** They are still found when
+caliper is invoked from that spec's directory, since the walk finds
+`evals/.caliper/` immediately — so the change reads as "runs moved root", not
+"runs vanished". Moving them is a `mv` into the project's root; a run file is
+self-describing, so relocating it changes nothing about how it reads back.
+
+**The sandbox now forbids a *shape*, not a path.** `SpecSandbox.from_spec`
+resolved `RunStore(spec_path.parent).caliper_dir` into its `auto` list, which
+this record makes impossible: a discovered root is not a path a single call can
+resolve, and the one it picked would have been forbidden while every other stayed
+readable — an older root, a monorepo sibling's, another checkout's.
+`sandbox.SAVED_RESULTS` is a real regex applied on every run, alongside the
+escaped `auto` paths rather than among them. The rule is now stated as it was
+always meant: an agent under test never reads a caliper results directory,
+wherever it is.
+
+The pattern deliberately matches `.caliper/results/` rather than `.caliper`
+alone. The cheat detector inspects every string in an attempt's tool input, so a
+bare marker flags a task that legitimately *writes a caliper spec* — grill-skill's
+own eval writes specs whose text contains `./.caliper/.*`, and that spec file
+carries a comment recording the false cheat flag it caused when the pattern was
+listed by hand. The narrower form keeps the answer key forbidden while leaving
+"writes about caliper" alone.
+
+## Alternatives considered
+
+**Root at the working directory, no discovery.** One line in each caller and no
+walk, but `report` from a subdirectory of the project still fails, so the
+mismatch moves rather than closes.
+
+**Always the repository root, ignoring any nearer `.caliper/`.** Simpler to state
+and immune to the coin flip, but wrong for a monorepo whose packages have
+independent eval suites.
+
+**A `--results-dir` flag or a project config file.** Answers the question by
+declining to: every caller still has to pass the same value, and a mismatched
+flag reproduces exactly this bug with more surface area. A default would still
+have to be chosen, and it would be this one.
+
+**Results beside the spec, with readers resolving spec names by search.** The
+honest version of "results belong to the spec", but it makes every read a
+filesystem walk, gives ambiguous answers when two specs share a name, and still
+cannot produce a single cross-project `list`.

--- a/skills/evaluate-skill/REFERENCE.md
+++ b/skills/evaluate-skill/REFERENCE.md
@@ -175,8 +175,13 @@ trajectory by running `hermes -z` then `hermes sessions export`.
 ## Results storage
 
 Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.json`
-alongside the spec file. Each result includes a full skill snapshot (content + git SHA
-of the skill file and any referenced scripts) for reproducibility. Each attempt
+under the project's **results root** — the nearest `.caliper/` at or above your
+working directory, bounded by the git repo. `run`, `report`, `compare` and
+`list` all resolve the same root, so a run saved from a spec's own subdirectory
+is findable by `caliper report <spec-name>` from anywhere in the project.
+
+Each result includes a full skill snapshot (content + git SHA of the skill file
+and any referenced scripts) for reproducibility. Each attempt
 records its `outcome` (see above), an optional `usage` block (token counts), an
 optional `transcript` array (ordered turns with `tool_name`/`tool_input`/`tool_output`
 when present), and per-task results include an `unusable` count; a task with no usable

--- a/skills/evaluate-skill/evaluate-skill.eval.yaml
+++ b/skills/evaluate-skill/evaluate-skill.eval.yaml
@@ -4,9 +4,10 @@ skills:
 # The engine (backend + model) is a runtime axis, not a spec field — run this
 # eval with `--model codex --judge-model codex` (or any other engine).
 
-sandbox:
-  forbidden_files:
-    - "./.caliper/.*"
+# No explicit sandbox.forbidden_files: caliper auto-forbids this spec and any
+# .caliper/results/ directory. Listing "./.caliper/.*" by hand risks a false
+# cheat flag, because these tasks legitimately WRITE caliper specs whose text
+# contains that very pattern — see the same note in grill-skill.eval.yaml.
 
 tasks:
   - name: Validates a well-formed spec and reports it as valid

--- a/skills/evaluate-skill/references/evals/claude-code-smoke/claude-code-smoke.eval.yaml
+++ b/skills/evaluate-skill/references/evals/claude-code-smoke/claude-code-smoke.eval.yaml
@@ -3,8 +3,7 @@ skills:
 
 sandbox:
   forbidden_files:
-    - ".*\\.eval\\.yaml$"
-    - "./.caliper/.*"
+    - ".*\\.eval\\.yaml$"    # .caliper/results/ is auto-forbidden already
 
 tasks:
   - name: Writes the smoke output file

--- a/skills/evaluate-skill/references/examples/simple.eval.yaml
+++ b/skills/evaluate-skill/references/examples/simple.eval.yaml
@@ -3,8 +3,7 @@ skills:
 
 sandbox:
   forbidden_files:
-    - ".*\\.eval\\.yaml$"
-    - "./.caliper/.*"
+    - ".*\\.eval\\.yaml$"    # .caliper/results/ is auto-forbidden already
 
 tasks:
   # The prompt never names the skill: it is installed, not preloaded, so the

--- a/skills/grill-skill/REFERENCE.md
+++ b/skills/grill-skill/REFERENCE.md
@@ -106,9 +106,8 @@ skills:                   # installed at the agent's own skills root, never
     path: skills/tdd/SKILL.md   # optional — defaults to SKILL.md at the root
 
 sandbox:
-  forbidden_files:
-    - ".*\\.eval\\.yaml$"
-    - "./.caliper/.*"
+  forbidden_files:               # extra patterns only — the spec itself and any
+    - "./answers/.*"             #   .caliper/ directory are forbidden already
 
 # Optional — only if the skill needs MCP tools. claude-code, hermes, codex backends.
 mcp:
@@ -221,8 +220,12 @@ The skill engine (`--model`) and judge engine (`--judge-model`) are chosen indep
 ## Results storage
 
 Results are saved automatically to `.caliper/results/<spec-name>/<timestamp>.json`
-alongside the spec file. Each attempt records its `outcome`, optional `usage`, and
-optional `transcript` (ordered turns with `tool_name`/`tool_input`/`tool_output` when present)
+under the project's **results root** — the nearest `.caliper/` at or above your
+working directory, bounded by the git repo. `run`, `report`, `compare` and
+`list` all resolve the same root, so a run saved from a spec's own subdirectory
+is findable by `caliper report <spec-name>` from anywhere in the project.
+
+Each attempt records its `outcome`, optional `usage`, and optional `transcript` (ordered turns with `tool_name`/`tool_input`/`tool_output` when present)
 so saved runs remain inspectable after the fact — including which MCP tools fired.
 Older JSON without `transcript` still loads (`null`). `report` and `compare` do not
 render the transcript; it is stored for later analysis.

--- a/skills/grill-skill/grill-skill.eval.yaml
+++ b/skills/grill-skill/grill-skill.eval.yaml
@@ -5,7 +5,7 @@ skills:
 # runs on whatever `--model` / `--judge-model` select (default claude-code).
 
 # No explicit sandbox.forbidden_files: caliper already auto-forbids the eval
-# spec and .caliper/ by absolute path. Listing "./.caliper/.*" here caused a
+# spec and any .caliper/results/ directory. Listing "./.caliper/.*" here caused a
 # false cheat flag, because these grill-skill tasks legitimately WRITE caliper
 # specs whose text contains that very pattern.
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -336,6 +336,9 @@ def _one_attempt_run(k: int = 3) -> RunResults:
 
 
 def test_run_cli_exits_130_and_saves_an_interrupted_run(monkeypatch, tmp_path) -> None:
+    # `run` roots its store at the cwd (docs/adr/0022), so the run this asserts
+    # on lands under tmp_path only if that is where caliper is invoked from.
+    monkeypatch.chdir(tmp_path)
     spec_file = tmp_path / "sample.eval.yaml"
     spec_file.write_text(
         "tasks:\n  - name: One\n    prompt: Do it\n    assert: 'assert True'\n"
@@ -357,6 +360,9 @@ def test_run_cli_exits_130_and_saves_an_interrupted_run(monkeypatch, tmp_path) -
 
 
 def test_run_cli_saves_before_reporting_a_fatal_error(monkeypatch, tmp_path) -> None:
+    # `run` roots its store at the cwd (docs/adr/0022), so the run this asserts
+    # on lands under tmp_path only if that is where caliper is invoked from.
+    monkeypatch.chdir(tmp_path)
     spec_file = tmp_path / "sample.eval.yaml"
     spec_file.write_text(
         "tasks:\n  - name: One\n    prompt: Do it\n    assert: 'assert True'\n"

--- a/tests/test_measure_and_mark.py
+++ b/tests/test_measure_and_mark.py
@@ -191,20 +191,27 @@ def _save(tmp_path: Path, results: RunResults, stem: str) -> None:
     (out / f"{stem}.json").write_text(results.model_dump_json())
 
 
-def test_list_marks_an_interrupted_run(tmp_path) -> None:
+def test_list_marks_an_interrupted_run(monkeypatch, tmp_path) -> None:
     _save(tmp_path, _run(interrupted=True), "2026-07-03T10-00-00Z")
+    monkeypatch.chdir(tmp_path)
 
-    result = runner.invoke(app, ["list", "demo", "--dir", str(tmp_path)])
+    result = runner.invoke(app, ["list", "demo"])
 
+    assert result.exit_code == 0, result.stdout
     assert "⊘" in result.stdout
     assert "stopped early" in result.stdout
 
 
-def test_list_is_unmarked_when_every_run_completed(tmp_path) -> None:
+def test_list_is_unmarked_when_every_run_completed(monkeypatch, tmp_path) -> None:
     _save(tmp_path, _run(interrupted=False), "2026-07-03T10-00-00Z")
+    monkeypatch.chdir(tmp_path)
 
-    result = runner.invoke(app, ["list", "demo", "--dir", str(tmp_path)])
+    result = runner.invoke(app, ["list", "demo"])
 
+    # Asserted on a run that actually rendered: this test only checks an
+    # *absence*, so a listing that failed to find anything would pass it.
+    assert result.exit_code == 0, result.stdout
+    assert "2026-07-03T10-00-00Z" in result.stdout
     assert "stopped early" not in result.stdout
 
 

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 
 from typer.testing import CliRunner
 
@@ -200,25 +201,12 @@ def test_run_cli_collects_repeated_ablate_flags(monkeypatch, tmp_path) -> None:
     assert calls["ablate"] == ["grilling", "docs"]
 
 
-def test_run_cli_saves_the_run_beside_its_spec(monkeypatch, tmp_path) -> None:
-    """`run` hands the finished run to the store, rooted at the spec's directory.
-
-    Where the file lands is the store's business, but *which* root the CLI picks
-    is the CLI's — and it is the one thing that differs from every reading
-    command (see caliper/runstore.py).
-    """
-    spec_dir = tmp_path / "evals"
-    spec_dir.mkdir()
-    spec_file = spec_dir / "sample.eval.yaml"
-    spec_file.write_text(
-        "skills:\n  - ./SKILL.md\n"
-        "tasks:\n  - name: One\n    prompt: Do it\n    assert: assert True\n"
-    )
-    # One real attempt: a run where nothing ran is deliberately not saved.
-    finished = RunResults(
+def _finished(timestamp: datetime) -> RunResults:
+    """A one-attempt run: a run where nothing ran is deliberately not saved."""
+    return RunResults(
         run=RunMeta(
             spec="sample",
-            timestamp=datetime(2026, 7, 3, 12, 30, 0, tzinfo=timezone.utc),
+            timestamp=timestamp,
             k=1,
             backend="claude-code",
         ),
@@ -240,6 +228,8 @@ def test_run_cli_saves_the_run_beside_its_spec(monkeypatch, tmp_path) -> None:
         aggregate=AggregateScore(avg_score=1.0, per_task=[]),
     )
 
+
+def _stub_a_run(monkeypatch, finished: RunResults) -> None:
     monkeypatch.setattr("caliper.commands.run.get_harness", lambda *a, **k: object())
     monkeypatch.setattr("caliper.commands.run.EvalJudge", lambda *a, **k: object())
     monkeypatch.setattr(
@@ -250,12 +240,88 @@ def test_run_cli_saves_the_run_beside_its_spec(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("caliper.commands.run.print_results", lambda *a, **k: None)
     monkeypatch.setattr("caliper.commands.run.run", lambda **kwargs: finished)
 
-    result = runner.invoke(app, ["run", str(spec_file)])
+
+def _project(root: Path) -> Path:
+    """A git project with its spec in a subdirectory, and no results root yet."""
+    (root / ".git").mkdir(parents=True)
+    spec_dir = root / "evals"
+    spec_dir.mkdir()
+    (spec_dir / "sample.eval.yaml").write_text(
+        "skills:\n  - ./SKILL.md\n"
+        "tasks:\n  - name: One\n    prompt: Do it\n    assert: assert True\n"
+    )
+    return spec_dir
+
+
+def test_run_cli_saves_the_run_at_the_discovered_root(monkeypatch, tmp_path) -> None:
+    """`run` files the run at the results root, not beside the spec file.
+
+    Where the file lands *within* a root is the store's business, but which root
+    the CLI picks is the CLI's — and it has to be the root every reading command
+    resolves, or a spec in a subdirectory files its runs where `report` never
+    looks (docs/adr/0022).
+    """
+    spec_dir = _project(tmp_path)
+    _stub_a_run(
+        monkeypatch, _finished(datetime(2026, 7, 3, 12, 30, tzinfo=timezone.utc))
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["run", "evals/sample.eval.yaml"])
 
     assert result.exit_code == 0, result.output
-    saved = RunStore(spec_dir).resolve("sample")
-    assert saved is not None, "the run was not filed beside its spec"
-    assert RunStore.load(saved).run.timestamp == finished.run.timestamp
+    assert not (spec_dir / ".caliper").exists(), "the run was filed beside its spec"
+    saved = RunStore(tmp_path).resolve("sample")
+    assert saved is not None, "the run was not filed at the project's results root"
+
+
+def test_a_run_is_findable_by_report_from_another_directory(
+    monkeypatch, tmp_path
+) -> None:
+    """The bug this rooting exists to close, end to end through the CLI.
+
+    `run` is invoked from the spec's *own* subdirectory — the case that used to
+    file results into `evals/.caliper/` — and `report` is then invoked from the
+    project root, addressing the run by spec name with no path in hand. Both
+    commands discover the same root, so the second finds what the first wrote.
+    """
+    project = tmp_path / "project"
+    spec_dir = _project(project)
+    _stub_a_run(monkeypatch, _finished(datetime(2026, 7, 4, 9, 0, tzinfo=timezone.utc)))
+
+    monkeypatch.chdir(spec_dir)
+    run_result = runner.invoke(app, ["run", "sample.eval.yaml"])
+    assert run_result.exit_code == 0, run_result.output
+
+    monkeypatch.chdir(project)
+    report_result = runner.invoke(app, ["report", "sample", "--format", "json"])
+    assert report_result.exit_code == 0, report_result.output
+    assert "2026-07-04T09:00:00" in report_result.output
+
+
+def test_report_outside_the_project_does_not_find_its_runs(
+    monkeypatch, tmp_path
+) -> None:
+    """Discovery walks up, never sideways, and stops at the repo boundary.
+
+    The run belongs to `project/`; a sibling directory outside it must not reach
+    in, and the message has to say so rather than reading like a typo.
+    """
+    project = tmp_path / "project"
+    _project(project)
+    _stub_a_run(monkeypatch, _finished(datetime(2026, 7, 5, 9, 0, tzinfo=timezone.utc)))
+
+    monkeypatch.chdir(project)
+    assert runner.invoke(app, ["run", "evals/sample.eval.yaml"]).exit_code == 0
+
+    elsewhere = tmp_path / "elsewhere"
+    (elsewhere / ".git").mkdir(parents=True)
+    monkeypatch.chdir(elsewhere)
+
+    result = runner.invoke(app, ["report", "sample"])
+
+    assert result.exit_code == 1
+    assert "No evaluation results" in result.output
 
 
 def test_baseline_is_retired_and_says_where_the_capability_went(tmp_path) -> None:

--- a/tests/test_runstore.py
+++ b/tests/test_runstore.py
@@ -154,3 +154,77 @@ def test_load_rejects_json_that_is_not_a_run(tmp_path) -> None:
 
     with pytest.raises(UnreadableRun):
         store.load(bad)
+
+
+# --- discovery ---------------------------------------------------------------
+
+
+def test_discover_finds_the_nearest_root(monkeypatch, tmp_path) -> None:
+    """Nearest wins, so a package given its own root keeps its own history."""
+    (tmp_path / ".git").mkdir()
+    package = tmp_path / "packages" / "foo"
+    (package / ".caliper").mkdir(parents=True)
+    (tmp_path / ".caliper").mkdir()
+    monkeypatch.chdir(package)
+
+    assert RunStore.discover().root == package.resolve()
+
+
+def test_discover_walks_up_to_an_existing_root(monkeypatch, tmp_path) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".caliper").mkdir()
+    deep = tmp_path / "evals" / "nested"
+    deep.mkdir(parents=True)
+    monkeypatch.chdir(deep)
+
+    assert RunStore.discover().root == tmp_path.resolve()
+
+
+def test_discover_names_the_repo_root_when_no_root_exists(monkeypatch, tmp_path):
+    """The first run of a project must not plant its root wherever you stood.
+
+    Rooting at the working directory would make the very first `caliper run`
+    decide the layout, and a later run from elsewhere in the same project would
+    silently create a second root (docs/adr/0022).
+    """
+    (tmp_path / ".git").mkdir()
+    spec_dir = tmp_path / "evals"
+    spec_dir.mkdir()
+    monkeypatch.chdir(spec_dir)
+
+    store = RunStore.discover()
+
+    assert store.root == tmp_path.resolve()
+    # Named, not created: `save` is what writes.
+    assert not store.caliper_dir.exists()
+
+
+def test_discover_does_not_reach_past_the_repo_boundary(monkeypatch, tmp_path) -> None:
+    """A stray `.caliper/` above the repo must not become the repo's store."""
+    (tmp_path / ".caliper").mkdir()
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    assert RunStore.discover().root == repo.resolve()
+
+
+def test_discover_falls_back_to_the_working_directory_outside_a_repo(
+    monkeypatch, tmp_path
+) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    # tmp_path itself has no .git and no .caliper, so the walk finds nothing and
+    # the working directory stands in for a project root.
+    assert RunStore.discover(work).root == work.resolve()
+
+
+def test_discover_accepts_an_explicit_start(tmp_path) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".caliper").mkdir()
+    deep = tmp_path / "a" / "b"
+    deep.mkdir(parents=True)
+
+    assert RunStore.discover(deep).root == tmp_path.resolve()

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from caliper.harness.base import ConversationTurn
 from caliper.sandbox import SpecSandbox
 from caliper.schema.spec import EvalSpec, SandboxConfig, TaskSpec
@@ -75,12 +77,60 @@ def test_from_spec_forbids_the_spec_file_itself(tmp_path: Path) -> None:
     assert sandbox.violations([_read(str(spec_file))]) == [str(spec_file)]
 
 
-def test_from_spec_forbids_calipers_own_directory(tmp_path: Path) -> None:
+def test_from_spec_forbids_saved_results(tmp_path: Path) -> None:
     """Last run's saved results are an answer key too."""
     saved = tmp_path / ".caliper" / "results" / "demo" / "2026-01-01T00-00-00.json"
     sandbox = SpecSandbox.from_spec(_spec(), tmp_path / "demo.eval.yaml")
 
     assert sandbox.violations([_read(str(saved))]) == [str(saved)]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/elsewhere/.caliper/results/demo/2026-07-03T10-00-00Z.json",
+        ".caliper/results/demo",
+        "cat ../../.caliper/results/demo/latest.json",
+        "C:\\project\\.caliper\\results\\demo",
+    ],
+)
+def test_saved_results_are_forbidden_wherever_they_are_filed(
+    tmp_path: Path, path: str
+) -> None:
+    """The rule is "no results directory", not "not *this* run's".
+
+    The results root is discovered rather than fixed (docs/adr/0022), so a run
+    can be filed under a root this sandbox never resolved — an older one, a
+    sibling package's, another checkout's. A pattern forbids them all; a
+    resolved path would forbid exactly one and leave the rest readable.
+    """
+    sandbox = SpecSandbox.from_spec(_spec(), tmp_path / "demo.eval.yaml")
+
+    assert sandbox.violations([_read(path)]) == [path]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # A task that writes a caliper spec puts this very text in a tool input.
+        # grill-skill's own eval does exactly that, and a bare `.caliper` marker
+        # flagged those attempts as cheats when it was declared by hand.
+        'forbidden_files:\n    - "./.caliper/.*"',
+        # The MCP config the harness writes into the agent's *own* home.
+        "/home/agent/.caliper-mcp.json",
+        # Listing the directory is not reading the answer key inside it.
+        "ls -la /home/agent/project/.caliper",
+        "/home/agent/caliper/src/main.py",
+        "notes.caliper",
+        "/x/my.caliperish/y",
+    ],
+)
+def test_the_saved_results_rule_does_not_swallow_neighbouring_names(
+    tmp_path: Path, path: str
+) -> None:
+    sandbox = SpecSandbox.from_spec(_spec(), tmp_path / "demo.eval.yaml")
+
+    assert sandbox.violations([_read(path)]) == []
 
 
 def test_from_spec_keeps_the_declared_patterns(tmp_path: Path) -> None:


### PR DESCRIPTION
## The bug

`caliper run` rooted its store at the **spec file's parent**; `report` and `compare` rooted theirs at the **working directory**, and `list` at `--dir`. Those agree only when caliper is invoked from the spec's own directory — so `caliper run evals/my.eval.yaml` wrote `evals/.caliper/results/my/…`, and `caliper report my` from the project root answered "No results found" for a run that existed on disk.

`caliper/runstore.py` named this defect in its docstring and deliberately left it alone, because settling it means deciding where results *belong*.

## The decision

Results belong to a **results root**, discovered the same way by every command:

- the nearest `.caliper/` at or above the working directory — **nearest wins**, so a monorepo package with its own eval suite keeps its own history;
- the walk **stops at the enclosing git repo**, so a stray `.caliper/` in `$HOME` cannot silently become every repo's store;
- when none exists, one is **named at the repo root** (not the cwd) — otherwise the first `caliper run` plants the root wherever the caller happened to be standing, and a later run from elsewhere in the same project quietly creates a second one.

`mkdir .caliper` is the control: it marks a directory as a root, and nearest-wins does the rest.

Recorded in [`docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md`](docs/adr/0022-saved-runs-live-at-a-discovered-results-root.md), with cwd-only, always-repo-root, `--results-dir`, and beside-the-spec as the rejected alternatives. `docs/CONTEXT.md` gains a **results root** entry.

## Breaking

**`list --dir` is removed**, not deprecated. With discovery it pointed the listing at a root `report` and `compare` could not follow — the asymmetry this change exists to remove — and `mkdir .caliper` covers the case it served. This departs from ADR 0015's precedent (`--baseline` was kept parseable for one release); the ADR states the departure as deliberate: `--dir` is a reader's convenience with an obvious substitute, where `--baseline` silently changed what a scripted caller paid for.

**Runs already filed beside a spec are not migrated.** They are still found when caliper is invoked from that spec's directory, so this reads as "runs moved root", not "runs vanished". Moving them is a `mv`; a run file is self-describing. Needs a line in the v0.12 release notes.

## Sandbox

A discovered root cannot be a resolved path, so the runner's auto-forbidden entry became a pattern. It matches `.caliper/results/`, **not** `.caliper` alone: the cheat detector inspects every string in an attempt's tool input, and tasks that legitimately *write caliper specs* contain that text. `grill-skill.eval.yaml` already carried a comment recording the false cheat flag this caused when the pattern was listed by hand — and `evaluate-skill.eval.yaml` was still carrying that very entry while generating specs. Both cleaned up. `.caliper-mcp.json` (the harness's own MCP config in the agent's home) stays out of the pattern.

## Errors

A reader that finds nothing now names the root it searched, and distinguishes "this root has never had a run saved into it" — usually the wrong directory — from "no such spec", which a bare per-spec miss reads like a typo.

## Tests

540 pass. New: six for `discover()` (nearest-wins, walk-up, repo-root naming, repo boundary, non-repo fallback, explicit start); the headline case end to end — `run` from `evals/`, `report` by spec name from the project root; a sibling repo that must not reach in; ten parametrized cases pinning both edges of the cheat pattern.

Four existing tests needed `monkeypatch.chdir` now that the write root follows the cwd. One of them (`test_list_is_unmarked_when_every_run_completed`) was passing vacuously — it asserts only an *absence*, against a listing that had silently found nothing; it now asserts the run actually rendered.