### PR TITLE
refactor(results): a task result owns the facts its readers ask of it

### DIFF
--- a/caliper/commands/list_cmd.py
+++ b/caliper/commands/list_cmd.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from rich.table import Table
 
 from caliper.commands.diagnosis import BadInput, fail
-from caliper.reporter import UNUSABLE_GLYPH
+from caliper.reporter import RULE_GLYPH, UNUSABLE_GLYPH
 from caliper.runstore import RunStore, UnreadableRun
 from caliper.schema.results import RunResults
 
@@ -26,19 +26,30 @@ _INTERRUPTED = UNUSABLE_GLYPH
 
 
 def _score_cell(results: RunResults) -> str:
+    """The run's headline, on the same rule the report renders it by.
+
+    A run whose every task is a trigger probe measured no execution question, so
+    it has no headline — and printing ``avg_score`` regardless is what made the
+    listing disagree with the report about the same file, calling "nothing was
+    asked" a total failure.
+    """
+    if not results.aggregate.measured:
+        return f"[dim]{RULE_GLYPH}[/dim]"
     score = f"{results.aggregate.avg_score * 100:.1f}%"
     if results.run.interrupted:
         return f"{score} [yellow]{_INTERRUPTED}[/yellow]"
     return score
 
 
-def _print_interrupted_legend(marked: bool) -> None:
-    """Explain the marker, only when one is on screen."""
-    if marked:
+def _print_legend(*, interrupted: bool, unmeasured: bool) -> None:
+    """Explain the markers, only the ones on screen."""
+    if interrupted:
         console.print(
             f" [dim][yellow]{_INTERRUPTED}[/yellow] stopped early: scored over "
             "fewer attempts than its k[/dim]"
         )
+    if unmeasured:
+        console.print(f" [dim]{RULE_GLYPH} no execution checks[/dim]")
 
 
 def _read(store: RunStore, path: Path) -> RunResults | None:
@@ -86,9 +97,11 @@ def _list_specs(store: RunStore) -> None:
     table.add_column("Spec")
     table.add_column("Runs", justify="right")
     table.add_column("Latest run")
-    table.add_column("pass@k", justify="right")
+    # The raw success rate, as the report heads it (docs/adr/0007). The cell has
+    # always held ``avg_score``; only the label was left behind by the rename.
+    table.add_column("success", justify="right")
 
-    marked = False
+    marked = unmeasured = False
     for name in specs:
         runs = store.runs(name)
         latest = runs[-1]
@@ -101,11 +114,12 @@ def _list_specs(store: RunStore) -> None:
             ts = results.run.timestamp.strftime("%Y-%m-%d %H:%M")
             score = _score_cell(results)
             marked = marked or results.run.interrupted
+            unmeasured = unmeasured or not results.aggregate.measured
 
         table.add_row(name, str(len(runs)), ts, score)
 
     console.print(table)
-    _print_interrupted_legend(marked)
+    _print_legend(interrupted=marked, unmeasured=unmeasured)
 
 
 def _list_runs(store: RunStore, spec_name: str) -> None:
@@ -123,7 +137,7 @@ def _list_runs(store: RunStore, spec_name: str) -> None:
     # into an ellipsis.
     table.add_column("k", justify="right")
     table.add_column("Tasks", justify="right")
-    table.add_column("pass@k", justify="right")
+    table.add_column("success", justify="right")
     # Which run was a control arm. Without it two runs of one spec are
     # indistinguishable here, and `compare` needs the older side named by path
     # (docs/CONTEXT.md → Run comparison) — so this is where you find out which
@@ -134,7 +148,7 @@ def _list_runs(store: RunStore, spec_name: str) -> None:
     # every character on screen at any terminal width.
     table.add_column("Run", style="dim", overflow="fold")
 
-    marked = False
+    marked = unmeasured = False
     for path in runs:
         results = _read(store, path)
         if results is None:
@@ -146,10 +160,11 @@ def _list_runs(store: RunStore, spec_name: str) -> None:
             n_tasks = str(len(results.task_results))
             ablated = ", ".join(results.run.ablated)
             marked = marked or results.run.interrupted
+            unmeasured = unmeasured or not results.aggregate.measured
 
         # The stem, not the filename: it is what `report --run` takes verbatim,
         # and what a `compare` path is built from.
         table.add_row(k, n_tasks, score, ablated, path.stem)
 
     console.print(table)
-    _print_interrupted_legend(marked)
+    _print_legend(interrupted=marked, unmeasured=unmeasured)

--- a/caliper/commands/list_cmd.py
+++ b/caliper/commands/list_cmd.py
@@ -33,9 +33,13 @@ def _score_cell(results: RunResults) -> str:
     listing disagree with the report about the same file, calling "nothing was
     asked" a total failure.
     """
-    if not results.aggregate.measured:
-        return f"[dim]{RULE_GLYPH}[/dim]"
-    score = f"{results.aggregate.avg_score * 100:.1f}%"
+    if results.aggregate.measured:
+        score = f"{results.aggregate.avg_score * 100:.1f}%"
+    else:
+        score = f"[dim]{RULE_GLYPH}[/dim]"
+    # Marked whichever way the cell reads: a run that stopped early is still one
+    # that stopped early, and dropping the glyph here would leave the legend
+    # below explaining a marker that is nowhere on screen.
     if results.run.interrupted:
         return f"{score} [yellow]{_INTERRUPTED}[/yellow]"
     return score

--- a/caliper/commands/report.py
+++ b/caliper/commands/report.py
@@ -8,7 +8,6 @@ from rich.console import Console
 from caliper.commands.diagnosis import BadInput, fail
 from caliper.reporter import print_results
 from caliper.runstore import RunStore, UnreadableRun
-from caliper.schema.results import UsageTotals
 
 console = Console()
 
@@ -40,9 +39,7 @@ def report_cmd(
         # see docs/CONTEXT.md → Run usage totals); the saved file keeps only the raw
         # per-attempt usage.
         data = results.model_dump(mode="json")
-        data["usage_totals"] = UsageTotals.from_task_results(
-            results.task_results
-        ).model_dump(mode="json")
+        data["usage_totals"] = results.usage.model_dump(mode="json")
         console.print_json(data=data)
     else:
         print_results(results, verbose=verbose)

--- a/caliper/reporter.py
+++ b/caliper/reporter.py
@@ -86,6 +86,9 @@ _UNUSABLE = "⊘" if _UNICODE else "o"
 # Re-exported: `list` marks an interrupted run with the same glyph, and a
 # second literal would be a second thing to forget the ASCII fallback on.
 UNUSABLE_GLYPH = _UNUSABLE
+# Likewise: `list` renders an unmeasured run's score with the same rule the
+# report uses for "nothing to show here".
+RULE_GLYPH = _RULE
 
 # Per-outcome glyph for the per-attempt detail view. Usable failures read as
 # failures; the three noise outcomes get the distinct ⊘ marker.
@@ -226,16 +229,15 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
     table.add_column("", justify="center")
 
     for tr in results.task_results:
-        cheated_count = sum(1 for a in tr.attempts if a.cheated)
-        status_text = _status_cell(tr, k, cheated_count > 0)
-        totals = UsageTotals.from_task_results([tr])
+        status_text = _status_cell(tr, k)
+        totals = tr.usage
         tokens_cell = (
             _fmt_tokens(totals.total_tokens) if totals.tokens_reported else _RULE
         )
         wall_cell = _fmt_duration(totals.wall_seconds)
         # A trigger-only task has no execution numbers to show; "0/3" would read
         # as three failures rather than three questions never asked.
-        k_cell = _RULE if _is_trigger_only(tr) else f"{tr.successes}/{k}"
+        k_cell = _RULE if tr.trigger_only else f"{tr.successes}/{k}"
         row = [tr.task_name, k_cell, _fmt_score(tr.score)]
         if verbose:
             row += [_fmt_score(tr.pass_at_k), _fmt_score(tr.pass_hat_k)]
@@ -252,7 +254,7 @@ def print_results(results: RunResults, verbose: bool = False) -> None:
         _print_observed_activations(results)
     _print_unusable_summary(results)
     console.print()
-    _print_usage_summary(UsageTotals.from_task_results(results.task_results))
+    _print_usage_summary(results.usage)
     console.print()
     _print_task_details(results.task_results, k, verbose)
 
@@ -307,21 +309,9 @@ def _needs_detail(tr: TaskResult) -> bool:
     print a panel for every correct trigger probe.
     """
     activation_short = tr.activation_score is not None and tr.activation_score < 1.0
-    if _is_trigger_only(tr):
+    if tr.trigger_only:
         return activation_short
     return tr.score is None or tr.score < 1.0 or activation_short
-
-
-def _is_trigger_only(tr: TaskResult) -> bool:
-    """True when the task authored no execution check (`activates:` alone).
-
-    Keyed on the *absence of any execution verdict*, not on unanimity: a single
-    timeout among k would otherwise flip a correct trigger probe back to
-    "0/3 UNUSABLE" — the exact reading `not_checked` exists to prevent.
-    """
-    if not any(a.outcome == Outcome.NOT_CHECKED for a in tr.attempts):
-        return False
-    return not any(a.outcome in (Outcome.PASS, Outcome.TASK_FAIL) for a in tr.attempts)
 
 
 def _activation_cell(tr: TaskResult) -> Text:
@@ -345,14 +335,14 @@ def _activation_cell(tr: TaskResult) -> Text:
     return Text(_CROSS, style="red")
 
 
-def _status_cell(tr: TaskResult, k: int, any_cheat: bool) -> Text:
-    if any_cheat:
+def _status_cell(tr: TaskResult, k: int) -> Text:
+    if tr.any_cheat:
         return Text(f"{_WARN} CHEAT", style="bold yellow")
     # An activates:-only task asked no execution question. Its silence is the
     # correct answer, so it reads as a dim skip — never a yellow error.
-    if _is_trigger_only(tr):
+    if tr.trigger_only:
         return Text(f"{_RULE} trigger only", style="dim")
-    if len(tr.attempts) < k and tr.score is None:
+    if tr.aborted(k):
         return Text(f"{_UNUSABLE} ABORTED", style="bold yellow")
     if tr.score is None:
         return Text(f"{_UNUSABLE} UNUSABLE", style="bold yellow")
@@ -380,7 +370,7 @@ def _print_score(results: RunResults) -> None:
     """The execution headline, printed *above* the per-task table it sums up."""
     agg = results.aggregate
 
-    if agg.scored_tasks:
+    if agg.measured:
         plural = "s" if agg.scored_tasks != 1 else ""
         console.print(
             f" [bold]Score[/bold]       [cyan]{agg.avg_score * 100:.1f}%[/cyan]"
@@ -595,7 +585,7 @@ def _format_output(output: str) -> str:
 
 def _print_task_detail(tr: TaskResult, k: int) -> None:
     lines: list[str] = []
-    if len(tr.attempts) < k and tr.score is None and not _is_trigger_only(tr):
+    if tr.aborted(k):
         lines.append(
             f"  [yellow]ABORTED[/yellow] after {len(tr.attempts)}/{k} attempts"
         )
@@ -940,10 +930,6 @@ def _print_comparison_summary(comp: RunComparison) -> None:
             f"only in {b_name}: {only_b}[/dim]"
         )
     console.print()
-
-
-def results_to_json(results: RunResults) -> str:
-    return results.model_dump_json(indent=2)
 
 
 def comparison_to_json(comp: RunComparison) -> str:

--- a/caliper/schema/results.py
+++ b/caliper/schema/results.py
@@ -386,6 +386,50 @@ class TaskResult(BaseModel):
         """
         return success_rate(self.activation_successes, self.activation_usable)
 
+    # --- read-side facts ---------------------------------------------------
+    #
+    # Plain properties, deliberately **not** ``computed_field``: these are how a
+    # task result is *read*, not part of what is stored, so the saved file keeps
+    # the shape it has always had. They live here rather than in the reporter
+    # because four readers need them — the run report, ``list``, ``report`` and
+    # ``compare`` — and a predicate that only one of them can see is how the
+    # listing came to print ``0.0%`` for a run the report renders as "no
+    # execution checks".
+
+    @property
+    def trigger_only(self) -> bool:
+        """True when the task authored no execution check (`activates:` alone).
+
+        Keyed on the *absence of any execution verdict*, not on unanimity: a
+        single timeout among k would otherwise flip a correct trigger probe back
+        to "0/3 UNUSABLE" — the exact reading ``not_checked`` exists to prevent.
+        """
+        if not any(a.outcome == Outcome.NOT_CHECKED for a in self.attempts):
+            return False
+        return not any(
+            a.outcome in (Outcome.PASS, Outcome.TASK_FAIL) for a in self.attempts
+        )
+
+    @property
+    def any_cheat(self) -> bool:
+        """Whether any attempt touched something the sandbox forbade."""
+        return any(a.cheated for a in self.attempts)
+
+    def aborted(self, k: int) -> bool:
+        """Whether the task stopped short of its k attempts with nothing measured.
+
+        Distinct from merely unusable: an aborted task ran *fewer* attempts than
+        asked for (a spending cap, a Ctrl-C), so "0 of 3" would overstate what
+        was tried. A trigger probe is never aborted — its ``score`` is ``None``
+        by construction, not by running short.
+        """
+        return len(self.attempts) < k and self.score is None and not self.trigger_only
+
+    @property
+    def usage(self) -> UsageTotals:
+        """This task's own token/wall roll-up, on the same rules as the run's."""
+        return UsageTotals.from_task_results([self])
+
 
 class UsageTotals(BaseModel):
     """Run-level roll-up of per-attempt token usage + wall-clock time.
@@ -585,6 +629,17 @@ class AggregateScore(BaseModel):
     activation_asserted: int = 0
     activation_per_skill: list[SkillActivationStats] = Field(default_factory=list)
 
+    @property
+    def measured(self) -> bool:
+        """Whether ``avg_score`` describes anything at all.
+
+        False on an all-trigger-probe spec, where no task asked an execution
+        question. Every reader of the headline branches on this rather than on
+        the number, because ``0.0%`` over zero scored tasks is a fabricated
+        failure of a run in which nothing failed.
+        """
+        return self.scored_tasks > 0
+
 
 class RunResults(BaseModel):
     run: RunMeta
@@ -595,6 +650,12 @@ class RunResults(BaseModel):
     skill_snapshots: list[SkillSnapshot] = Field(default_factory=list)
     task_results: list[TaskResult]
     aggregate: AggregateScore
+
+    @property
+    def usage(self) -> UsageTotals:
+        """The run's usage roll-up, derived on read and never persisted here
+        (docs/CONTEXT.md → Run usage totals)."""
+        return UsageTotals.from_task_results(self.task_results)
 
 
 class TaskComparison(BaseModel):

--- a/caliper/schema/results.py
+++ b/caliper/schema/results.py
@@ -4,7 +4,7 @@ import hashlib
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, model_validator
 
 
 class Outcome(str, Enum):
@@ -628,6 +628,35 @@ class AggregateScore(BaseModel):
     activation_tasks: int = 0
     activation_asserted: int = 0
     activation_per_skill: list[SkillActivationStats] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _count_scored_tasks_of_a_legacy_run(cls, data: object) -> object:
+        """Fill in ``scored_tasks`` for a run saved before the field existed.
+
+        The field arrived with install-and-discover (#80), so a file without it
+        is a legacy run (``era: None``) — and taking the ``0`` default at face
+        value would claim that run measured nothing, which is the fabricated
+        reading ``measured`` exists to prevent, pointed the other way. Its
+        per-task rows are still there, so they are what answers the question.
+
+        Only the *absent* key is filled: a stored ``0`` is a real claim by a
+        current run that every task was a trigger probe, and stays one.
+        """
+        if not isinstance(data, dict) or "scored_tasks" in data:
+            return data
+        rows = data.get("per_task") or []
+        scored = sum(
+            1
+            for row in rows
+            if (
+                row.get("score")
+                if isinstance(row, dict)
+                else getattr(row, "score", None)
+            )
+            is not None
+        )
+        return {**data, "scored_tasks": scored}
 
     @property
     def measured(self) -> bool:

--- a/tests/test_not_checked.py
+++ b/tests/test_not_checked.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from caliper.commands.list_cmd import _score_cell
 from caliper.harness.base import AttemptResult, ConversationTurn, HarnessBackend
 from caliper.judge.base import JudgeResult
 from caliper.outcome import classify_outcome
-from caliper.reporter import _is_trigger_only, _status_cell
+from caliper.reporter import _status_cell
+from caliper.main import app
 from caliper.runner import run
-from caliper.schema.results import AttemptRecord, Outcome, TaskResult
+from caliper.schema.results import (
+    AggregateScore,
+    AttemptRecord,
+    Outcome,
+    RunMeta,
+    RunResults,
+    TaskResult,
+)
 from caliper.schema.spec import EvalSpec, TaskSpec
 
 from conftest import task_result
@@ -199,11 +212,11 @@ def _trigger_task() -> TaskResult:
 
 
 def test_trigger_only_task_is_detected():
-    assert _is_trigger_only(_trigger_task()) is True
+    assert _trigger_task().trigger_only is True
 
 
 def test_trigger_only_task_reads_as_a_skip_not_an_error():
-    cell = _status_cell(_trigger_task(), k=2, any_cheat=False)
+    cell = _status_cell(_trigger_task(), k=2)
     assert "UNUSABLE" not in cell.plain
     assert "trigger only" in cell.plain
     assert cell.style == "dim"
@@ -251,8 +264,8 @@ def test_trigger_only_survives_one_timeout_among_k():
         ],
         activation_expected=[],
     )
-    assert _is_trigger_only(tr) is True
-    assert "trigger only" in _status_cell(tr, k=2, any_cheat=False).plain
+    assert tr.trigger_only is True
+    assert "trigger only" in _status_cell(tr, k=2).plain
 
 
 def test_a_task_with_a_real_verdict_is_not_trigger_only():
@@ -268,7 +281,7 @@ def test_a_task_with_a_real_verdict_is_not_trigger_only():
             ),
         ],
     )
-    assert _is_trigger_only(tr) is False
+    assert tr.trigger_only is False
 
 
 class TimingOutHarness(HarnessBackend):
@@ -334,3 +347,61 @@ def test_a_healthy_trigger_probe_resets_the_fail_fast_streak():
     # mid-way and silently truncate the activation sample.
     assert Outcome.NOT_CHECKED.is_execution_noise is False
     assert Outcome.JUDGE_ERROR.is_execution_noise is True
+
+
+# --- every reader tells the same story ------------------------------------
+
+
+def _trigger_only_run() -> RunResults:
+    """A spec whose every task is a trigger probe: nothing execution was asked."""
+    return RunResults(
+        run=RunMeta(
+            spec="probes",
+            timestamp=datetime(2026, 7, 3, tzinfo=timezone.utc),
+            k=2,
+            backend="claude-code",
+            era="install-and-discover",
+        ),
+        skill_snapshots=[],
+        task_results=[_trigger_task()],
+        # What the runner builds for such a run: an average over no scored task.
+        aggregate=AggregateScore(avg_score=0.0, scored_tasks=0, per_task=[]),
+    )
+
+
+def test_an_unmeasured_run_has_no_headline() -> None:
+    assert _trigger_only_run().aggregate.measured is False
+
+
+def test_list_renders_an_unmeasured_run_as_skipped_not_zero(
+    monkeypatch, tmp_path
+) -> None:
+    """The listing and the report must not disagree about the same file.
+
+    `list` printed ``avg_score`` unconditionally, so an all-trigger-probe run —
+    in which nothing failed, because nothing was asked — read as ``0.0%``: the
+    exact fabricated failure ``not_checked`` exists to prevent.
+    """
+    results = _trigger_only_run()
+    out = tmp_path / ".caliper" / "results" / "probes"
+    out.mkdir(parents=True)
+    (out / "2026-07-03T10-00-00Z.json").write_text(results.model_dump_json())
+    monkeypatch.chdir(tmp_path)
+
+    listed = CliRunner().invoke(app, ["list", "probes"])
+
+    assert listed.exit_code == 0, listed.stdout
+    assert "2026-07-03T10-00-00Z" in listed.stdout
+    assert "0.0%" not in listed.stdout
+    assert "no execution checks" in listed.stdout
+
+
+def test_list_still_prints_a_measured_score() -> None:
+    """The skip is keyed on `measured`, not on the number being zero.
+
+    A run that really did score 0% must still say so.
+    """
+    results = _trigger_only_run()
+    results.aggregate = AggregateScore(avg_score=0.0, scored_tasks=1, per_task=[])
+
+    assert _score_cell(results) == "0.0%"

--- a/tests/test_not_checked.py
+++ b/tests/test_not_checked.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typer.testing import CliRunner
 
 from caliper.commands.list_cmd import _score_cell
+from caliper.reporter import RULE_GLYPH, UNUSABLE_GLYPH
 from caliper.harness.base import AttemptResult, ConversationTurn, HarnessBackend
 from caliper.judge.base import JudgeResult
 from caliper.outcome import classify_outcome
@@ -405,3 +406,18 @@ def test_list_still_prints_a_measured_score() -> None:
     results.aggregate = AggregateScore(avg_score=0.0, scored_tasks=1, per_task=[])
 
     assert _score_cell(results) == "0.0%"
+
+
+def test_an_interrupted_unmeasured_run_keeps_its_marker() -> None:
+    """Both facts are provenance, and neither displaces the other.
+
+    A run can stop early *and* have measured nothing; dropping the marker there
+    left the "stopped early" legend explaining a glyph nowhere on screen.
+    """
+    results = _trigger_only_run()
+    results.run.interrupted = True
+
+    cell = _score_cell(results)
+
+    assert RULE_GLYPH in cell
+    assert UNUSABLE_GLYPH in cell

--- a/tests/test_task_metrics.py
+++ b/tests/test_task_metrics.py
@@ -7,7 +7,7 @@ of the six were then thrown away. There is one derivation now, and this is it.
 
 from __future__ import annotations
 
-from caliper.schema.results import Outcome, TaskResult
+from caliper.schema.results import AggregateScore, Outcome, TaskResult
 
 from conftest import task_result as _task
 
@@ -157,3 +157,52 @@ def test_a_task_rolls_up_its_own_usage() -> None:
 
     assert task.usage.attempts == 2
     assert task.usage.unusable_attempts == 1
+
+
+def test_a_legacy_run_counts_its_scored_tasks_from_its_rows() -> None:
+    """``scored_tasks`` arrived with install-and-discover; older files lack it.
+
+    Taking the ``0`` default at face value would report a run that really did
+    measure things as having measured nothing.
+    """
+    legacy = {
+        "avg_score": 0.75,
+        "per_task": [
+            {"task_id": "t1", "task_name": "One", "k": 2, "successes": 2, "score": 1.0},
+            {"task_id": "t2", "task_name": "Two", "k": 2, "successes": 1, "score": 0.5},
+        ],
+    }
+
+    agg = AggregateScore.model_validate(legacy)
+
+    assert agg.scored_tasks == 2
+    assert agg.measured is True
+
+
+def test_a_legacy_runs_unmeasured_rows_do_not_count() -> None:
+    """A row with no rate was never fairly measured, then or now."""
+    legacy = {
+        "avg_score": 0.0,
+        "per_task": [
+            {"task_id": "t1", "task_name": "One", "k": 2, "successes": 0, "score": None}
+        ],
+    }
+
+    assert AggregateScore.model_validate(legacy).measured is False
+
+
+def test_a_stored_zero_stays_a_real_claim() -> None:
+    """A current all-trigger-probe run says zero and means it.
+
+    Only the *absent* key is filled in, so the backfill cannot resurrect a
+    headline for a run that correctly reports having measured nothing.
+    """
+    current = {
+        "avg_score": 0.0,
+        "scored_tasks": 0,
+        "per_task": [
+            {"task_id": "t1", "task_name": "One", "k": 2, "successes": 2, "score": 1.0}
+        ],
+    }
+
+    assert AggregateScore.model_validate(current).measured is False

--- a/tests/test_task_metrics.py
+++ b/tests/test_task_metrics.py
@@ -98,3 +98,62 @@ def test_a_saved_run_cannot_carry_counts_that_contradict_its_attempts() -> None:
 
     assert reloaded.successes == 1
     assert reloaded.score == 0.5
+
+
+# --- read-side facts -------------------------------------------------------
+#
+# These used to be derived in the reporter, where only the run report could see
+# them — which is how `list` came to print 0.0% for a run the report renders as
+# "no execution checks". They are facts about a task result, so they are tested
+# as facts, without a renderer in the way.
+
+
+def test_a_task_with_no_execution_check_is_trigger_only() -> None:
+    assert _task(Outcome.NOT_CHECKED, Outcome.NOT_CHECKED).trigger_only is True
+
+
+def test_trigger_only_survives_one_timeout_among_k() -> None:
+    """Keyed on the absence of a verdict, not on unanimity.
+
+    A single timeout must not flip a correct trigger probe back to "0/2".
+    """
+    assert _task(Outcome.NOT_CHECKED, Outcome.TIMEOUT).trigger_only is True
+
+
+def test_a_task_with_a_real_verdict_is_not_trigger_only() -> None:
+    assert _task(Outcome.PASS, Outcome.NOT_CHECKED).trigger_only is False
+
+
+def test_a_task_with_no_attempts_at_all_is_not_trigger_only() -> None:
+    """It asked nothing because it ran nothing, which is the aborted case."""
+    assert _task().trigger_only is False
+
+
+def test_any_cheat_is_true_when_one_attempt_cheated() -> None:
+    assert _task(Outcome.PASS, Outcome.CHEAT).any_cheat is True
+    assert _task(Outcome.PASS, Outcome.TASK_FAIL).any_cheat is False
+
+
+def test_a_task_that_ran_short_with_nothing_measured_is_aborted() -> None:
+    assert _task(Outcome.INFRA_ERROR).aborted(k=3) is True
+
+
+def test_a_task_that_ran_short_but_measured_something_is_not_aborted() -> None:
+    """It has a rate, so "0 of 3" would be the wrong thing to say about it."""
+    assert _task(Outcome.PASS).aborted(k=3) is False
+
+
+def test_a_complete_task_is_never_aborted() -> None:
+    assert _task(Outcome.INFRA_ERROR, Outcome.INFRA_ERROR).aborted(k=2) is False
+
+
+def test_a_trigger_probe_is_never_aborted() -> None:
+    """Its score is None by construction, not by running short."""
+    assert _task(Outcome.NOT_CHECKED).aborted(k=3) is False
+
+
+def test_a_task_rolls_up_its_own_usage() -> None:
+    task = _task(Outcome.PASS, Outcome.INFRA_ERROR)
+
+    assert task.usage.attempts == 2
+    assert task.usage.unusable_attempts == 1


### PR DESCRIPTION
Facts about a task result were derived inside the reporter, so only the run
report could see them. Four readers need them, and the one that could not see
them printed a different answer for the same file.

## The bug this fixes

An all-trigger-probe run — every task an `activates:`-only probe — asked no
execution question. `caliper report` says so. `caliper list` printed
`avg_score` regardless:

| | before | after |
|---|---|---|
| `caliper report` | `—  no execution checks` | unchanged |
| `caliper list` | `0.0%` | `—`, with a legend |

`0.0%` is the fabricated failure `not_checked` exists to prevent: nothing
failed, because nothing was asked.

## What moved

`trigger_only`, `any_cheat`, `aborted(k)` and the per-task usage roll-up move
onto `TaskResult`, beside the counts and metrics it already derives
(docs/adr/0007). `AggregateScore` gains `measured` — whether `avg_score`
describes anything at all — which both headline renderers now branch on, and
`RunResults` gains `usage`.

They are plain properties, **not** `computed_field`: these are how a result is
*read*, not part of what is stored. The saved JSON keeps the shape it has
always had, verified against a real saved run — so no results-schema doc
updates are due under `CLAUDE.md`.

## Also here, from the same cause

- `caliper list` heads its score column **success**, not `pass@k`. The cell has
  always held `avg_score`; only the label was left behind by the ADR-0007
  rename. No README sample shows this table.
- The aborted rule was written twice in the reporter — once with the
  trigger-only guard (`_status_cell`), once without (`_print_task_detail`).
  One definition now, with the guard.
- `reporter.results_to_json` had no callers and is deleted.
- `report --format json` built its usage totals by hand; it uses
  `RunResults.usage` now.

## Tests

584 pass, 13 new.

- `tests/test_task_metrics.py` gains the predicates as plain assertions, no
  renderer in the way — including the two edge cases the reporter's comments
  described but nothing pinned: a trigger probe surviving one timeout among k,
  and a trigger probe never reading as aborted.
- `tests/test_not_checked.py` gains the cross-reader test: `list` renders an
  unmeasured run as skipped, and still prints a real `0.0%` when a run
  genuinely scored zero. Mutation-checked — it fails without the fix.

No ADR is contradicted. This completes the direction #93 committed to under
ADR-0007, "a task derives its own numbers, once", by extending *numbers* to
*facts*.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edonadei/caliper/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
